### PR TITLE
fix(appsync-modelgen-plugin): add get modeltype method in model provider

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -31,6 +31,22 @@ class ModelProvider implements ModelProviderInterface {
   static final ModelProvider _instance = ModelProvider();
 
   static ModelProvider get instance => _instance;
+
+  ModelType getModelTypeByModelName(String modelName) {
+    switch (modelName) {
+      case \\"SimpleModel\\":
+        {
+          return SimpleModel.classType;
+        }
+        break;
+      default:
+        {
+          throw Exception(
+              \\"Failed to find model in model provider for model name: \\" +
+                  modelName);
+        }
+    }
+  }
 }
 "
 `;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -104,6 +104,30 @@ export class AppSyncModelDartVisitor<
         ' => _instance;',
         { isBlock: false, isGetter: true, static: true }
       );
+      //getModelTypeByModelName
+      if (modelNames.length) {
+        const getModelTypeImplStr = [
+          'switch(modelName) {',
+          ...modelNames.map(modelName => {
+            return [
+              `case "${modelName}": {`,
+              `return ${modelName}.classType;`,
+              '}',
+              'break;'
+            ].join('\n')
+          }),
+          'default: {',
+          'throw Exception("Failed to find model in model provider for model name: " + modelName);',
+          '}',
+          '}'
+        ].join('\n');
+        classDeclarationBlock.addClassMethod(
+          'getModelTypeByModelName',
+          'ModelType',
+          [{type: 'String', name: 'modelName'}],
+          getModelTypeImplStr
+        );
+      }
 
     result.push(packageImports.map(p => `import '${p}.dart';`).join('\n'));
     result.push(packageExports.map(p => `export '${p}.dart';`).join('\n'));


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Add get modeltype method in model provider. The example is as following.
```Dart
ModelType getModelTypeByModelName(String modelName) {
  switch(modelName) {
    case "Blog": {
      return Blog.classType;
    }
    break;
    case "Post": {
      return Post.classType;
    }
    break;
    case "Comment": {
      return Comment.classType;
    }
    break;
    default: {
      throw Exception("Failed to find model in model provider for model name: " + modelName);
    }
  }
}
```
_How are these changes tested:_
`yarn test`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
