### PR TITLE
ModelGen(Swift): Handle nullability of lists properly

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListContainer: Model {
+  public let id: String
+  public var name: String?
+  public var list: [String?]?
+  public var requiredList: [String?]
+  public var requiredListOfRequired: [String]
+  public var listOfRequired: [String]?
+  
+  public init(id: String = UUID().uuidString,
+      name: String? = nil,
+      list: [String?]? = [],
+      requiredList: [String?] = [],
+      requiredListOfRequired: [String] = [],
+      listOfRequired: [String]? = []) {
+      self.id = id
+      self.name = name
+      self.list = list
+      self.requiredList = requiredList
+      self.requiredListOfRequired = requiredListOfRequired
+      self.listOfRequired = listOfRequired
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case list
+    case requiredList
+    case requiredListOfRequired
+    case listOfRequired
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listContainer = ListContainer.keys
+    
+    model.pluralName = \\"ListContainers\\"
+    
+    model.fields(
+      .id(),
+      .field(listContainer.name, is: .optional, ofType: .string),
+      .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.requiredList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.requiredListOfRequired, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.listOfRequired, is: .optional, ofType: .embeddedCollection(of: String.self))
+    )
+    }
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -275,6 +275,29 @@ describe('AppSyncSwiftVisitor', () => {
     `);
   });
 
+  it('Should handle nullability of lists appropriately', () => {
+    const schema = /* GraphQL */ `
+      type ListContainer
+      @model
+      {
+        id: ID!
+        name: String
+        list: [String]
+        requiredList: [String]!
+        requiredListOfRequired: [String!]!
+        listOfRequired: [String!]
+      }
+    `;
+
+    const visitor = getVisitor(schema, 'ListContainer');
+    const generatedCode = visitor.generate();
+    expect(generatedCode).toMatchSnapshot();
+    
+    const metadataVisitor = getVisitor(schema, 'ListContainer', CodeGenGenerateEnum.metadata);
+    const generatedMetadata = metadataVisitor.generate();
+    expect(generatedMetadata).toMatchSnapshot();
+  });
+
   describe('connection', () => {
     describe('One to Many connection', () => {
       const schema = /* GraphQL */ `
@@ -314,7 +337,7 @@ describe('AppSyncSwiftVisitor', () => {
             public var due_date: String?
             public var version: Int
             public var value: Double?
-            public var tasks: List<task>?
+            public var tasks: List<task?>?
             
             public init(id: String = UUID().uuidString,
                 title: String,
@@ -323,7 +346,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task>? = []) {
+                tasks: List<task?>? = []) {
                 self.id = id
                 self.title = title
                 self.done = done
@@ -520,11 +543,11 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor>?
+            public var editors: List<PostEditor?>?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor?>? = []) {
                 self.id = id
                 self.title = title
                 self.editors = editors
@@ -572,11 +595,11 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor>?
+            public var editors: List<PostEditor?>?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor?>? = []) {
                 self.id = id
                 self.title = title
                 self.editors = editors
@@ -642,20 +665,20 @@ describe('AppSyncSwiftVisitor', () => {
 
       public struct ObjectWithNativeTypes: Model {
         public let id: String
-        public var intArr: [Int]?
-        public var strArr: [String]?
-        public var floatArr: [Double]?
-        public var boolArr: [Bool]?
-        public var dateArr: [Temporal.Date]?
-        public var enumArr: [EnumType]?
+        public var intArr: [Int?]?
+        public var strArr: [String?]?
+        public var floatArr: [Double?]?
+        public var boolArr: [Bool?]?
+        public var dateArr: [Temporal.Date?]?
+        public var enumArr: [EnumType?]?
         
         public init(id: String = UUID().uuidString,
-            intArr: [Int]? = [],
-            strArr: [String]? = [],
-            floatArr: [Double]? = [],
-            boolArr: [Bool]? = [],
-            dateArr: [Temporal.Date]? = [],
-            enumArr: [EnumType]? = []) {
+            intArr: [Int?]? = [],
+            strArr: [String?]? = [],
+            floatArr: [Double?]? = [],
+            boolArr: [Bool?]? = [],
+            dateArr: [Temporal.Date?]? = [],
+            enumArr: [EnumType?]? = []) {
             self.id = id
             self.intArr = intArr
             self.strArr = strArr
@@ -740,18 +763,18 @@ describe('AppSyncSwiftVisitor', () => {
         public let id: String
         public var name: String
         public var location: Location
-        public var nearByLocations: [Location]?
+        public var nearByLocations: [Location?]?
         public var status: Status
-        public var statusHistory: [Status]?
-        public var tags: [String]?
+        public var statusHistory: [Status?]?
+        public var tags: [String?]?
         
         public init(id: String = UUID().uuidString,
             name: String,
             location: Location,
-            nearByLocations: [Location]? = [],
+            nearByLocations: [Location?]? = [],
             status: Status,
-            statusHistory: [Status]? = [],
-            tags: [String]? = []) {
+            statusHistory: [Status?]? = [],
+            tags: [String?]? = []) {
             self.id = id
             self.name = name
             self.location = location
@@ -823,7 +846,7 @@ describe('AppSyncSwiftVisitor', () => {
       public struct Location: Embeddable {
         var lat: String
         var lang: String
-        var tags: [String]?
+        var tags: [String?]?
       }"
     `);
 
@@ -959,13 +982,13 @@ describe('AppSyncSwiftVisitor', () => {
           public let id: String
           public var \`Class\`: Class?
           public var nonNullClass: Class
-          public var classes: [\`Class\`]?
+          public var classes: [\`Class\`?]?
           public var nonNullClasses: [\`Class\`]
           
           public init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
-              classes: [\`Class\`]? = [],
+              classes: [\`Class\`?]? = [],
               nonNullClasses: [\`Class\`] = []) {
               self.id = id
               self.\`Class\` = \`Class\`
@@ -1289,7 +1312,7 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self))
+                .field(post.editors, is: .optional, ofType: .embeddedCollection(of: String.self))
               )
               }
           }"

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -122,7 +122,7 @@ export type VariableFlags = {
   variable?: boolean;
   isEnum?: boolean;
 };
-export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean };
+export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean; isListNullable?: boolean };
 export type PropertyFlags = StructFlags;
 export type MethodFlags = { static?: boolean };
 export type DeclarationFlag = { final?: boolean };
@@ -339,7 +339,8 @@ export class SwiftDeclarationBlock {
     const res: string[] = args.reduce((acc: string[], arg) => {
       const val: string | null = arg.value ? arg.value : arg.flags.isList ? '[]' : arg.flags.optional ? 'nil' : null;
       const type = arg.flags.isList ? this.getListType(arg) : escapeKeywords(arg.type);
-      acc.push([escapeKeywords(arg.name), ': ', type, arg.flags.optional ? '?' : '', val ? ` = ${val}` : ''].join(''));
+      const isArgOptional = arg.flags.isList ? arg.flags.isListNullable : arg.flags.optional
+      acc.push([escapeKeywords(arg.name), ': ', type, isArgOptional ? '?' : '', val ? ` = ${val}` : ''].join(''));
       return acc;
     }, []);
 
@@ -347,8 +348,12 @@ export class SwiftDeclarationBlock {
   }
 
   private generatePropertiesStr(prop: StructProperty): string {
-    const propertyTypeName = prop.flags.isList ? this.getListType(prop) : prop.type;
-    const propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.optional ? '?' : ''}` : '';
+    let propertyTypeName = prop.type;
+    let propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.optional ? '?' : ''}` : '';
+    if (prop.flags.isList) {
+      propertyTypeName = this.getListType(prop);
+      propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.isListNullable ? '?' : ''}` : '';
+    }
     let resultArr: string[] = [
       prop.access === 'DEFAULT' ? '' : prop.access,
       prop.flags.static ? 'static' : '',
@@ -388,10 +393,14 @@ export class SwiftDeclarationBlock {
       .trim();
   }
 
-  private getListType(typeDeclaration: VariableDeclaration): string {
+  private getListType(typeDeclaration: MethodArgument): string {
+    const listMemberType = typeDeclaration.flags.optional ?
+     `${escapeKeywords(typeDeclaration.type)}?` : 
+     `${escapeKeywords(typeDeclaration.type)}`
+
     if (typeDeclaration.flags.listType === ListType.LIST) {
-      return `List<${escapeKeywords(typeDeclaration.type)}>`;
+      return `List<${listMemberType}>`;
     }
-    return `[${escapeKeywords(typeDeclaration.type)}]`;
+    return `[${listMemberType}]`;
   }
 }

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -395,7 +395,7 @@ export class SwiftDeclarationBlock {
 
   private getListType(typeDeclaration: MethodArgument): string {
     const listMemberType = typeDeclaration.flags.optional ?
-     `${escapeKeywords(typeDeclaration.type)}?` : 
+     `${escapeKeywords(typeDeclaration.type)}?`:
      `${escapeKeywords(typeDeclaration.type)}`
 
     if (typeDeclaration.flags.listType === ListType.LIST) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -44,6 +44,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
           variable: isVariable,
           isEnum: this.isEnumType(field),
           listType: field.isList ? listType : undefined,
+          isListNullable: field.isListNullable,
         });
       });
       const initImpl: string = this.getInitBody(obj.fields);
@@ -62,6 +63,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
               isList: field.isList,
               isEnum: this.isEnumType(field),
               listType: field.isList ? listType : undefined,
+              isListNullable: field.isListNullable,
             },
           };
         }),
@@ -104,6 +106,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
           variable: true,
           isEnum: this.isEnumType(field),
           listType: field.isList ? ListType.ARRAY : undefined,
+          isListNullable: field.isListNullable,
         });
       });
       result.push(structBlock.string);
@@ -236,7 +239,8 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
     const name = `${modelKeysName}.${this.getFieldName(field)}`;
     const typeName = this.getSwiftModelTypeName(field);
     const { connectionInfo } = field;
-    const isRequired = this.isFieldRequired(field) ? '.required' : '.optional';
+    const isOptionalField = field.isList ? field.isListNullable : field.isNullable
+    const isRequired = !isOptionalField ? '.required' : '.optional';
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {


### PR DESCRIPTION
_Issue #, if available:_    
fix #104

_Description of changes:_
This PR fixes the bug in handling nullable lists and list components. There could be various combinations of optional lists in swift like `[String?]?, [String]?, [String?] and [String]`. These have to be generated correctly based on their graphQL definitions `[String], [String!], [String]! and [String!]!`. 

_How are these changes tested:_
Unit test that covers all combinations of nullability in a list and verifies appropriate swift type is generated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
