### PR TITLE
fix(typegen): enable passing parameters to generated subscription in Angular

### DIFF
--- a/packages/graphql-types-generator/src/angular/index.ts
+++ b/packages/graphql-types-generator/src/angular/index.ts
@@ -150,7 +150,7 @@ function generateSubscriptionOperation(generator: CodeGenerator, op: LegacyOpera
       const params = ['statement'];
       variableAssignmentToInput(generator, vars);
       params.push('gqlAPIServiceArguments');
-      generator.printOnNewline(`return API.graphql(graphqlOperation(${params.join(', ')})) as Observable<SubscriptionResponse<OnCreateRestaurantSubscription>>;`);
+      generator.printOnNewline(`return API.graphql(graphqlOperation(${params.join(', ')})) as Observable<SubscriptionResponse<${returnType}>>;`);
       generator.printOnNewline('}');
     });
   }

--- a/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -1153,6 +1153,70 @@ export class APIService {
 "
 `;
 
+exports[`Angular code generation #generateSource() should generate subscriptions with parameters 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+//  This file was automatically generated and should not be edited.
+import { Injectable } from \\"@angular/core\\";
+import API, { graphqlOperation, GraphQLResult } from \\"@aws-amplify/api-graphql\\";
+import { Observable } from \\"zen-observable-ts\\";
+
+export interface SubscriptionResponse<T> {
+  value: GraphQLResult<T>;
+}
+
+export type Restaurant = {
+  __typename: \\"Restaurant\\";
+  id?: string;
+  name?: string;
+  description?: string;
+  city?: string;
+  owner?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type OnCreateRestaurantSubscription = {
+  __typename: \\"Restaurant\\";
+  id: string;
+  name: string;
+  description: string;
+  city: string;
+  owner?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+@Injectable({
+  providedIn: \\"root\\"
+})
+export class APIService {
+  OnCreateRestaurantListener(
+    owner: string
+  ): Observable<SubscriptionResponse<OnCreateRestaurantSubscription>> {
+    const statement = \`subscription OnCreateRestaurant($owner: String!) {
+        onCreateRestaurant(owner: $owner) {
+          __typename
+          id
+          name
+          description
+          city
+          owner
+          createdAt
+          updatedAt
+        }
+      }\`;
+    const gqlAPIServiceArguments: any = {
+      owner
+    };
+    return API.graphql(
+      graphqlOperation(statement, gqlAPIServiceArguments)
+    ) as Observable<SubscriptionResponse<OnCreateRestaurantSubscription>>;
+  }
+}
+"
+`;
+
 exports[`Angular code generation #generateSource() should handle comments in enums 1`] = `
 "/* tslint:disable */
 /* eslint-disable */

--- a/packages/graphql-types-generator/test/angular/index.js
+++ b/packages/graphql-types-generator/test/angular/index.js
@@ -371,5 +371,25 @@ describe('Angular code generation', function() {
       const source = generateSource(context);
       expect(source).toMatchSnapshot();
     });
+
+    test(`should generate subscriptions with parameters`, function() {
+      const { compileFromSource } = setup(loadSchema(require.resolve('../fixtures/misc/subscriptionSchemaWithParameters.graphql')));
+      const context = compileFromSource(`
+      subscription OnCreateRestaurant($owner: String!) {
+        onCreateRestaurant(owner: $owner) {
+          id
+          name
+          description
+          city
+          owner
+          createdAt
+          updatedAt
+        }
+      }
+      `);
+
+      const source = generateSource(context);
+      expect(source).toMatchSnapshot();
+    });
   });
 });

--- a/packages/graphql-types-generator/test/fixtures/misc/subscriptionSchemaWithParameters.graphql
+++ b/packages/graphql-types-generator/test/fixtures/misc/subscriptionSchemaWithParameters.graphql
@@ -1,0 +1,162 @@
+type Restaurant {
+  id: ID!
+  name: String!
+  description: String!
+  city: String!
+  owner: String
+  createdAt: AWSDateTime!
+  updatedAt: AWSDateTime!
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelRestaurantConnection {
+  items: [Restaurant]
+  nextToken: String
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelRestaurantFilterInput {
+  id: ModelIDInput
+  name: ModelStringInput
+  description: ModelStringInput
+  city: ModelStringInput
+  owner: ModelStringInput
+  and: [ModelRestaurantFilterInput]
+  or: [ModelRestaurantFilterInput]
+  not: ModelRestaurantFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getRestaurant(id: ID!): Restaurant
+  listRestaurants(filter: ModelRestaurantFilterInput, limit: Int, nextToken: String): ModelRestaurantConnection
+}
+
+input CreateRestaurantInput {
+  id: ID
+  name: String!
+  description: String!
+  city: String!
+  owner: String
+}
+
+input UpdateRestaurantInput {
+  id: ID!
+  name: String
+  description: String
+  city: String
+  owner: String
+}
+
+input DeleteRestaurantInput {
+  id: ID
+}
+
+type Mutation {
+  createRestaurant(input: CreateRestaurantInput!, condition: ModelRestaurantConditionInput): Restaurant
+  updateRestaurant(input: UpdateRestaurantInput!, condition: ModelRestaurantConditionInput): Restaurant
+  deleteRestaurant(input: DeleteRestaurantInput!, condition: ModelRestaurantConditionInput): Restaurant
+}
+
+input ModelRestaurantConditionInput {
+  name: ModelStringInput
+  description: ModelStringInput
+  city: ModelStringInput
+  and: [ModelRestaurantConditionInput]
+  or: [ModelRestaurantConditionInput]
+  not: ModelRestaurantConditionInput
+}
+
+type Subscription {
+  onCreateRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["createRestaurant"])
+  onUpdateRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["updateRestaurant"])
+  onDeleteRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["deleteRestaurant"])
+}


### PR DESCRIPTION
_Issue #, if available:_
fix #31
_Description of changes:_
The generated subscription code in angular service enable passing the parameters.
*In case of breaking customers' app, we remain the same output if no parameters are passed in schema definition.
Given a schema and sub operation as followings
**schema.graphql**
```GraphQL
type Restaurant {
  id: ID!
  name: String!
  description: String!
  city: String!
  owner: String
  createdAt: AWSDateTime!
  updatedAt: AWSDateTime!
}

# ...other definitions

type Subscription {
  onCreateRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["createRestaurant"])
  onUpdateRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["updateRestaurant"])
  onDeleteRestaurant(owner: String!): Restaurant @aws_subscribe(mutations: ["deleteRestaurant"])
}
```
**subscriptions.graphql**
```GraphQL
subscription OnCreateRestaurant($owner: String!) {
  onCreateRestaurant(owner: $owner) {
    id
    name
    description
    city
    owner
    createdAt
    updatedAt
  }
}
```
The new `OnCreateRestaurantListener` will be generated in `API.service.ts`
```JavaScript
OnCreateRestaurantListener(
  owner: string
): Observable<SubscriptionResponse<OnCreateRestaurantSubscription>> {
  const statement = `subscription OnCreateRestaurant($owner: String!) {
      onUpdateRestaurant(owner: $owner) {
        id
        name
        description
        city
        owner
        createdAt
        updatedAt
      }
    }`;
  const gqlAPIServiceArguments: any = {
    owner
  };
  return API.graphql(
    graphqlOperation(statement, gqlAPIServiceArguments)
  ) as Observable<SubscriptionResponse<OnCreateRestaurantSubscription>>;
}
```
_How are these changes tested:_
`jest angular`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
