### PR TITLE
TypeGen(swift): Generate S3ObjectInput related extensions only if all required fields are present

### DIFF
--- a/packages/graphql-types-generator/src/utilities/complextypes.ts
+++ b/packages/graphql-types-generator/src/utilities/complextypes.ts
@@ -1,6 +1,8 @@
-import { GraphQLType, isInputObjectType, getNamedType, isObjectType } from 'graphql';
+import { GraphQLType, isInputObjectType, getNamedType, isObjectType, isNonNullType } from 'graphql';
 
-const S3_FIELD_NAMES = ['bucket', 'key', 'region'];
+// These fields are required for AWSAppsync iOS SDK to create/update 
+// S3 objects referenced in the API.
+const S3_FIELD_NAMES = ['bucket', 'key', 'region', 'localUri', 'mimeType'];
 
 export function hasS3Fields(input: GraphQLType): boolean {
   if (isObjectType(input) || isInputObjectType(input)) {
@@ -17,8 +19,9 @@ export function isS3Field(field: GraphQLType): boolean {
   if (isObjectType(field) || isInputObjectType(field)) {
     const fields = field.getFields();
     const stringFields = Object.keys(fields).filter(f => {
-      const typeName = getNamedType(fields[f].type);
-      return typeName.name === 'String';
+      const fieldType = fields[f].type;
+      const typeName = getNamedType(fieldType);
+      return (typeName.name === 'String' && isNonNullType(fieldType));
     });
     const isS3FileField = S3_FIELD_NAMES.every(fieldName => stringFields.includes(fieldName));
     if (isS3FileField) {

--- a/packages/graphql-types-generator/src/utilities/complextypes.ts
+++ b/packages/graphql-types-generator/src/utilities/complextypes.ts
@@ -1,6 +1,6 @@
 import { GraphQLType, isInputObjectType, getNamedType, isObjectType, isNonNullType } from 'graphql';
 
-// These fields are required for AWSAppsync iOS SDK to create/update 
+// These fields are required for AWSAppsync iOS SDK to create/update
 // S3 objects referenced in the API.
 const S3_FIELD_NAMES = ['bucket', 'key', 'region', 'localUri', 'mimeType'];
 

--- a/packages/graphql-types-generator/test/complexTypes.ts
+++ b/packages/graphql-types-generator/test/complexTypes.ts
@@ -1,0 +1,41 @@
+import { buildSchema } from 'graphql';
+import { isS3Field } from '../src/utilities/complextypes';
+
+describe('Should detect S3 complex objects in schema', () => {
+    it('Should return false for S3Object type without localUri and mimeType', () => {
+        const schema = buildSchema(`
+            type S3Object {
+                bucket: String!
+                region: String!
+                key: String!
+            }          
+        `);
+        expect(isS3Field(schema.getTypeMap()['S3Object'])).toBe(false);
+    })
+
+    it('Should return false for S3Object type with optional localUri and mimeType', () => {
+        const schema = buildSchema(`
+            type S3Object {
+                bucket: String!
+                region: String!
+                key: String!
+                localUri: String
+                mimeType: String
+            }          
+        `);
+        expect(isS3Field(schema.getTypeMap()['S3Object'])).toBe(false);
+    })
+
+    it('Should return true for valid S3Object type', () => {
+        const schema = buildSchema(`
+            type S3Object {
+                bucket: String!
+                region: String!
+                key: String!
+                localUri: String!
+                mimeType: String!
+            }          
+        `);
+        expect(isS3Field(schema.getTypeMap()['S3Object'])).toBe(true);
+    })
+})


### PR DESCRIPTION
_Issue #, if available:_
#52 

_Description of changes:_
These changes fix the issue with swift types generation where conformance to `AWSS3InputObjectProtocol` extension was generated even when the `localUri` and `mimeType` fields are either optional or not present in the schema S3Object. This caused build errors for iOS projects. 

_How are these changes tested:_
unit test included for changes, run using `jest`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
