### PR TITLE
Migrate amplify-codegen package

### DIFF
--- a/packages/amplify-codegen/.npmignore
+++ b/packages/amplify-codegen/.npmignore
@@ -1,0 +1,6 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tests
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/amplify-codegen/CHANGELOG.md
+++ b/packages/amplify-codegen/CHANGELOG.md
@@ -1,0 +1,996 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [2.21.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.21.1...amplify-codegen@2.21.2) (2021-02-17)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.21.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.21.0...amplify-codegen@2.21.1) (2021-02-11)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** set sourceDir path to correct graphql schema location ([#6512](https://github.com/aws-amplify/amplify-cli/issues/6512)) ([6edf229](https://github.com/aws-amplify/amplify-cli/commit/6edf2298ebbabda57230f9e0b9c6c4f504f8a275)), closes [aws-amplify/amplify-cli#5483](https://github.com/aws-amplify/amplify-cli/issues/5483) [aws-amplify/amplify-cli#5483](https://github.com/aws-amplify/amplify-cli/issues/5483)
+
+
+
+
+
+# [2.21.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.5...amplify-codegen@2.21.0) (2021-02-10)
+
+
+### Features
+
+* add Flutter  support for Admin UI ([#6516](https://github.com/aws-amplify/amplify-cli/issues/6516)) ([d9ee44b](https://github.com/aws-amplify/amplify-cli/commit/d9ee44be73f43b11da2a07d21fd60108f49b1608))
+
+
+
+
+
+## [2.20.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.4...amplify-codegen@2.20.5) (2021-01-08)
+
+
+### Bug Fixes
+
+* remove process on next and await ([#6239](https://github.com/aws-amplify/amplify-cli/issues/6239)) ([59d4a0e](https://github.com/aws-amplify/amplify-cli/commit/59d4a0eb318d2b3ad97be34bda9dee756cf82d74))
+
+
+
+
+
+## [2.20.4](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.3...amplify-codegen@2.20.4) (2020-12-31)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** excludes flutter projects from gql gen ([#6199](https://github.com/aws-amplify/amplify-cli/issues/6199)) ([450616e](https://github.com/aws-amplify/amplify-cli/commit/450616e42d28e862919c54b29454a29dbd715eaf))
+
+
+
+
+
+## [2.20.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.2...amplify-codegen@2.20.3) (2020-12-21)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.20.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.1...amplify-codegen@2.20.2) (2020-12-16)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.20.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.20.0...amplify-codegen@2.20.1) (2020-12-11)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+# [2.20.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.19.1...amplify-codegen@2.20.0) (2020-12-07)
+
+
+### Features
+
+* add support for multiple [@key](https://github.com/key) changes in same [@model](https://github.com/model) ([#6044](https://github.com/aws-amplify/amplify-cli/issues/6044)) ([e574637](https://github.com/aws-amplify/amplify-cli/commit/e5746379ea1330c53dacb55e8f6a9de7b17b55ae))
+
+
+
+
+
+## [2.19.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.19.0...amplify-codegen@2.19.1) (2020-12-03)
+
+
+
+## 4.37.1 (2020-12-02)
+
+
+### Bug Fixes
+
+* **amplify-codegen-appsync-model-plugin:** address feedback from flutter team(Nov 28) ([#6004](https://github.com/aws-amplify/amplify-cli/issues/6004)) ([b624e0f](https://github.com/aws-amplify/amplify-cli/commit/b624e0fff58659d0aeb13bc3e79b437071295aa3))
+
+
+
+
+
+# [2.19.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.18.1...amplify-codegen@2.19.0) (2020-11-30)
+
+
+### Features
+
+* pre-deploy pull, new login mechanism and pkg cli updates ([#5941](https://github.com/aws-amplify/amplify-cli/issues/5941)) ([7274251](https://github.com/aws-amplify/amplify-cli/commit/7274251faadc1035acce5f44699b172e10e2e67d))
+
+
+
+
+
+## [2.18.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.18.0...amplify-codegen@2.18.1) (2020-11-27)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+# [2.18.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.17.1...amplify-codegen@2.18.0) (2020-11-26)
+
+
+
+# 4.36.0 (2020-11-24)
+
+
+### Features
+
+* **amplify-codegen-appsync-model-plugin:** add appsync dart visitor … ([#5937](https://github.com/aws-amplify/amplify-cli/issues/5937)) ([28168ad](https://github.com/aws-amplify/amplify-cli/commit/28168ad25c341c038bfd13d7ca54b1b7bd74adc7))
+
+
+
+
+
+## [2.17.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.16.2...amplify-codegen@2.17.1) (2020-11-22)
+
+
+
+# 4.33.0 (2020-11-19)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** generate eslintignore in js ([#5865](https://github.com/aws-amplify/amplify-cli/issues/5865)) ([baa8a6f](https://github.com/aws-amplify/amplify-cli/commit/baa8a6f76dc6cdbd69685f77300a02073c270ac9))
+* eslintignore creation with uninitialized project ([#5913](https://github.com/aws-amplify/amplify-cli/issues/5913)) ([a7b7a8c](https://github.com/aws-amplify/amplify-cli/commit/a7b7a8c1a193dc4fc5eaf120307d9494e6e2c8ca))
+
+
+
+
+
+# [2.17.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@2.17.0) (2020-11-22)
+
+
+### Bug Fixes
+
+* eslintignore creation with uninitialized project ([#5913](https://github.com/aws-amplify/amplify-cli/issues/5913)) ([a7b7a8c](https://github.com/aws-amplify/amplify-cli/commit/a7b7a8c1a193dc4fc5eaf120307d9494e6e2c8ca))
+* **amplify-codegen:** add proper response type for subs ([#5317](https://github.com/aws-amplify/amplify-cli/issues/5317)) ([48d2e11](https://github.com/aws-amplify/amplify-cli/commit/48d2e11b2a9dbb9616cc989aa76c207eb7b5f13b)), closes [#5284](https://github.com/aws-amplify/amplify-cli/issues/5284)
+* **amplify-codegen:** generate eslintignore in js ([#5865](https://github.com/aws-amplify/amplify-cli/issues/5865)) ([baa8a6f](https://github.com/aws-amplify/amplify-cli/commit/baa8a6f76dc6cdbd69685f77300a02073c270ac9))
+* [#2360](https://github.com/aws-amplify/amplify-cli/issues/2360) - meta json was written as object ([#2381](https://github.com/aws-amplify/amplify-cli/issues/2381)) ([7dd3c37](https://github.com/aws-amplify/amplify-cli/commit/7dd3c370552af31d63a4c2352c7b7453d6ab1fc0))
+* [#4549](https://github.com/aws-amplify/amplify-cli/issues/4549) [#4550](https://github.com/aws-amplify/amplify-cli/issues/4550) init and folder exist checks ([#4553](https://github.com/aws-amplify/amplify-cli/issues/4553)) ([30a33f9](https://github.com/aws-amplify/amplify-cli/commit/30a33f9e8ca9ff23d6e7343ef8e869461133f709))
+* added exit code on remove ([#5427](https://github.com/aws-amplify/amplify-cli/issues/5427)) ([33132f7](https://github.com/aws-amplify/amplify-cli/commit/33132f764b290cafd345720409a5db8ea6088069))
+* changed default config to user defined config ([#5334](https://github.com/aws-amplify/amplify-cli/issues/5334)) ([c630145](https://github.com/aws-amplify/amplify-cli/commit/c63014558547f75a0afa7e506116d8bb124c44d2))
+* codegen spelling mistake ([#4757](https://github.com/aws-amplify/amplify-cli/issues/4757)) ([7896ebd](https://github.com/aws-amplify/amplify-cli/commit/7896ebdfe538478d1c6d8e5e7e2318c7baf1bb69))
+* data inconsitency ([#5344](https://github.com/aws-amplify/amplify-cli/issues/5344)) ([bfe1903](https://github.com/aws-amplify/amplify-cli/commit/bfe19038b5b676056f45d7ffcc4c2460057936d8))
+* **amplify-category-api:** use standard json read ([#2581](https://github.com/aws-amplify/amplify-cli/issues/2581)) ([3adc395](https://github.com/aws-amplify/amplify-cli/commit/3adc395a5e4ccf3673735f8091db63923a46c501))
+* **amplify-codegen:** add framework only if javascript ([5709742](https://github.com/aws-amplify/amplify-cli/commit/5709742f33a20916c93869243f2bc699d40ddcce))
+* **amplify-codegen:** add framework only if javascript ([#2342](https://github.com/aws-amplify/amplify-cli/issues/2342)) ([57c29c4](https://github.com/aws-amplify/amplify-cli/commit/57c29c450082c35dc6925be3d005422a2f5732bf))
+* **amplify-codegen:** await statement generation before generating types ([#2168](https://github.com/aws-amplify/amplify-cli/issues/2168)) ([4c3aad0](https://github.com/aws-amplify/amplify-cli/commit/4c3aad032924a821497eaef7cc303dfcaa09dee2)), closes [#2129](https://github.com/aws-amplify/amplify-cli/issues/2129)
+* **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+* **amplify-codegen:** replace upath with slash ([#3133](https://github.com/aws-amplify/amplify-cli/issues/3133)) ([a565053](https://github.com/aws-amplify/amplify-cli/commit/a565053463e563ed3d44f1405ab551520e0cd818)), closes [#3131](https://github.com/aws-amplify/amplify-cli/issues/3131)
+* **amplify-codegen:** support appsync scalars in modelgen ([#3424](https://github.com/aws-amplify/amplify-cli/issues/3424)) ([a6eba85](https://github.com/aws-amplify/amplify-cli/commit/a6eba858f2ed31192a1214a22a3180dd243c80c7)), closes [#3296](https://github.com/aws-amplify/amplify-cli/issues/3296)
+* **amplify-codegen:** use ResDir directory to compute modelgen output ([#4145](https://github.com/aws-amplify/amplify-cli/issues/4145)) ([06a7ec5](https://github.com/aws-amplify/amplify-cli/commit/06a7ec5ede3b311e2ac0d2f86ee393bc04ef3eb5)), closes [#3993](https://github.com/aws-amplify/amplify-cli/issues/3993)
+* [#1056](https://github.com/aws-amplify/amplify-cli/issues/1056), dedup environment file reading ([#2088](https://github.com/aws-amplify/amplify-cli/issues/2088)) ([940deaa](https://github.com/aws-amplify/amplify-cli/commit/940deaa6bbe7370e40e61946d0f1073623ba6e90))
+* e2e tests, tsconfigs, [@deprecated](https://github.com/deprecated) directive for codegen: ([#3338](https://github.com/aws-amplify/amplify-cli/issues/3338)) ([2ed7715](https://github.com/aws-amplify/amplify-cli/commit/2ed77151dd6367ac9547f78fe600e7913a3d37b2))
+* **amplify-codegen:** support headless push for newly added api ([#2442](https://github.com/aws-amplify/amplify-cli/issues/2442)) ([84c08e7](https://github.com/aws-amplify/amplify-cli/commit/84c08e79623fdb68ba8d0f24acf33f342fc83bb5)), closes [#2365](https://github.com/aws-amplify/amplify-cli/issues/2365)
+* fix load config withoutinit ([389e739](https://github.com/aws-amplify/amplify-cli/commit/389e73916946d16b46805ebd00f0672064539966))
+* **amplify-codegen:** support multi os team workflow in codegen ([#2212](https://github.com/aws-amplify/amplify-cli/issues/2212)) ([e4a0454](https://github.com/aws-amplify/amplify-cli/commit/e4a045468d761c9333a799d3b3dae6c6399dc179)), closes [#2147](https://github.com/aws-amplify/amplify-cli/issues/2147) [#2002](https://github.com/aws-amplify/amplify-cli/issues/2002)
+* **amplify-codegen:** support nonarray includes/excludes in codegen conf ([#2271](https://github.com/aws-amplify/amplify-cli/issues/2271)) ([30904a0](https://github.com/aws-amplify/amplify-cli/commit/30904a0ac01b2ae6064d57109c998c9243b36d68)), closes [#2262](https://github.com/aws-amplify/amplify-cli/issues/2262)
+* **cli:** fix new plugin platform codegen related issue ([#2266](https://github.com/aws-amplify/amplify-cli/issues/2266)) ([c557182](https://github.com/aws-amplify/amplify-cli/commit/c557182b2d423bb1c2f8832ecd49076c806b05bb))
+* local mock fix ([#1982](https://github.com/aws-amplify/amplify-cli/issues/1982)) ([8ee9029](https://github.com/aws-amplify/amplify-cli/commit/8ee90298189f4d3140ab84fe2d40d16bcb95485f))
+* move test package dependencies to devDependencies ([#2034](https://github.com/aws-amplify/amplify-cli/issues/2034)) ([f5623d0](https://github.com/aws-amplify/amplify-cli/commit/f5623d04a43e685901f4f1cd96e2a227164c71ee))
+
+
+### Features
+
+* **amplify-codegen:** add schema compile process in codegen commands ([#5164](https://github.com/aws-amplify/amplify-cli/issues/5164)) ([85f739a](https://github.com/aws-amplify/amplify-cli/commit/85f739a46112ff29b3b04e882ecd8db020452308))
+* **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+* **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+* **cli:** new plugin platform ([#2254](https://github.com/aws-amplify/amplify-cli/issues/2254)) ([7ec29dd](https://github.com/aws-amplify/amplify-cli/commit/7ec29dd4f2da8c90727b36469eca646d289877b6))
+* add support for multiauth in mock server ([#2109](https://github.com/aws-amplify/amplify-cli/issues/2109)) ([fe8ee8c](https://github.com/aws-amplify/amplify-cli/commit/fe8ee8cff355a826fa9ccddcf0fad8a200a081af))
+* adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c1927da10f8c54f38a523021187361131c))
+* implement multi-auth functionality ([#1916](https://github.com/aws-amplify/amplify-cli/issues/1916)) ([b99f58e](https://github.com/aws-amplify/amplify-cli/commit/b99f58e4a2b85cbe9f430838554ae3c277440132))
+* mock support for API, function and storage ([#1893](https://github.com/aws-amplify/amplify-cli/issues/1893)) ([372e534](https://github.com/aws-amplify/amplify-cli/commit/372e5346ee1f27a2e9bee25fbbdcb19417f5230f))
+
+
+### Reverts
+
+* Revert "feat(amplify-codegen): add schema compile process in codegen commands (#5164)" (#5707) ([d83f496](https://github.com/aws-amplify/amplify-cli/commit/d83f496f9ab51ded2eef6b0dd796627009eaf556)), closes [#5164](https://github.com/aws-amplify/amplify-cli/issues/5164) [#5707](https://github.com/aws-amplify/amplify-cli/issues/5707)
+
+
+
+
+
+## [2.16.4](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.16.2...amplify-codegen@2.16.4) (2020-11-20)
+
+
+### Bug Fixes
+
+* eslintignore creation with uninitialized project ([#5913](https://github.com/aws-amplify/amplify-cli/issues/5913)) ([a7b7a8c](https://github.com/aws-amplify/amplify-cli/commit/a7b7a8c1a193dc4fc5eaf120307d9494e6e2c8ca))
+* **amplify-codegen:** generate eslintignore in js ([#5865](https://github.com/aws-amplify/amplify-cli/issues/5865)) ([baa8a6f](https://github.com/aws-amplify/amplify-cli/commit/baa8a6f76dc6cdbd69685f77300a02073c270ac9))
+
+
+
+
+
+## [2.16.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.16.2...amplify-codegen@2.16.3) (2020-11-20)
+
+
+### Bug Fixes
+
+* eslintignore creation with uninitialized project ([#5913](https://github.com/aws-amplify/amplify-cli/issues/5913)) ([a7b7a8c](https://github.com/aws-amplify/amplify-cli/commit/a7b7a8c1a193dc4fc5eaf120307d9494e6e2c8ca))
+* **amplify-codegen:** generate eslintignore in js ([#5865](https://github.com/aws-amplify/amplify-cli/issues/5865)) ([baa8a6f](https://github.com/aws-amplify/amplify-cli/commit/baa8a6f76dc6cdbd69685f77300a02073c270ac9))
+
+
+
+
+
+## [2.16.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.16.1...amplify-codegen@2.16.2) (2020-10-30)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.16.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.16.0...amplify-codegen@2.16.1) (2020-10-27)
+
+
+### Reverts
+
+* Revert "feat(amplify-codegen): add schema compile process in codegen commands (#5164)" (#5707) ([d83f496](https://github.com/aws-amplify/amplify-cli/commit/d83f496f9ab51ded2eef6b0dd796627009eaf556)), closes [#5164](https://github.com/aws-amplify/amplify-cli/issues/5164) [#5707](https://github.com/aws-amplify/amplify-cli/issues/5707)
+
+
+
+
+
+# [2.16.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.21...amplify-codegen@2.16.0) (2020-10-22)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** add proper response type for subs ([#5317](https://github.com/aws-amplify/amplify-cli/issues/5317)) ([48d2e11](https://github.com/aws-amplify/amplify-cli/commit/48d2e11b2a9dbb9616cc989aa76c207eb7b5f13b)), closes [#5284](https://github.com/aws-amplify/amplify-cli/issues/5284)
+
+
+### Features
+
+* **amplify-codegen:** add schema compile process in codegen commands ([#5164](https://github.com/aws-amplify/amplify-cli/issues/5164)) ([85f739a](https://github.com/aws-amplify/amplify-cli/commit/85f739a46112ff29b3b04e882ecd8db020452308))
+
+
+
+
+
+## [2.15.21](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.20...amplify-codegen@2.15.21) (2020-10-07)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.20](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.19...amplify-codegen@2.15.20) (2020-10-01)
+
+
+### Bug Fixes
+
+* added exit code on remove ([#5427](https://github.com/aws-amplify/amplify-cli/issues/5427)) ([33132f7](https://github.com/aws-amplify/amplify-cli/commit/33132f764b290cafd345720409a5db8ea6088069))
+* changed default config to user defined config ([#5334](https://github.com/aws-amplify/amplify-cli/issues/5334)) ([c630145](https://github.com/aws-amplify/amplify-cli/commit/c63014558547f75a0afa7e506116d8bb124c44d2))
+
+
+
+
+
+## [2.15.19](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.18...amplify-codegen@2.15.19) (2020-09-25)
+
+
+### Bug Fixes
+
+* data inconsitency ([#5344](https://github.com/aws-amplify/amplify-cli/issues/5344)) ([bfe1903](https://github.com/aws-amplify/amplify-cli/commit/bfe19038b5b676056f45d7ffcc4c2460057936d8))
+
+
+
+
+
+## [2.15.18](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.17...amplify-codegen@2.15.18) (2020-08-31)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.17](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.16...amplify-codegen@2.15.17) (2020-08-20)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.16](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.15...amplify-codegen@2.15.16) (2020-08-06)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.15](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.13...amplify-codegen@2.15.15) (2020-07-29)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.14](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.13...amplify-codegen@2.15.14) (2020-07-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.13](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.12...amplify-codegen@2.15.13) (2020-07-15)
+
+
+### Bug Fixes
+
+* codegen spelling mistake ([#4757](https://github.com/aws-amplify/amplify-cli/issues/4757)) ([454fdc0](https://github.com/aws-amplify/amplify-cli/commit/454fdc01f97f74fce337a25efa12950257597174))
+
+
+
+
+
+## [2.15.12](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.11...amplify-codegen@2.15.12) (2020-07-07)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.11](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.10...amplify-codegen@2.15.11) (2020-06-18)
+
+
+### Bug Fixes
+
+* [#4549](https://github.com/aws-amplify/amplify-cli/issues/4549) [#4550](https://github.com/aws-amplify/amplify-cli/issues/4550) init and folder exist checks ([#4553](https://github.com/aws-amplify/amplify-cli/issues/4553)) ([543d531](https://github.com/aws-amplify/amplify-cli/commit/543d5312823783db7794ad574d03d0ca3991c8b5))
+
+
+
+
+
+## [2.15.10](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.9...amplify-codegen@2.15.10) (2020-06-10)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.9](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.8...amplify-codegen@2.15.9) (2020-05-26)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.8](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.7...amplify-codegen@2.15.8) (2020-05-15)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.7](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.6...amplify-codegen@2.15.7) (2020-05-08)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** use ResDir directory to compute modelgen output ([#4145](https://github.com/aws-amplify/amplify-cli/issues/4145)) ([06a7ec5](https://github.com/aws-amplify/amplify-cli/commit/06a7ec5ede3b311e2ac0d2f86ee393bc04ef3eb5)), closes [#3993](https://github.com/aws-amplify/amplify-cli/issues/3993)
+
+
+
+
+
+## [2.15.6](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.5...amplify-codegen@2.15.6) (2020-04-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.4...amplify-codegen@2.15.5) (2020-04-06)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.4](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.3...amplify-codegen@2.15.4) (2020-03-26)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.2...amplify-codegen@2.15.3) (2020-03-22)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.15.1...amplify-codegen@2.15.2) (2020-03-10)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.15.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.13.3...amplify-codegen@2.15.1) (2020-03-07)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.14.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.13.5-beta.0...amplify-codegen@2.14.1) (2020-03-05)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+## [2.13.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.13.2...amplify-codegen@2.13.3) (2020-02-13)
+
+
+### Bug Fixes
+
+* **amplify-codegen:** support appsync scalars in modelgen ([#3424](https://github.com/aws-amplify/amplify-cli/issues/3424)) ([a6eba85](https://github.com/aws-amplify/amplify-cli/commit/a6eba858f2ed31192a1214a22a3180dd243c80c7)), closes [#3296](https://github.com/aws-amplify/amplify-cli/issues/3296)
+
+
+
+
+
+## [2.13.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.13.1...amplify-codegen@2.13.2) (2020-02-07)
+
+
+### Bug Fixes
+
+* e2e tests, tsconfigs, [@deprecated](https://github.com/deprecated) directive for codegen: ([#3338](https://github.com/aws-amplify/amplify-cli/issues/3338)) ([2ed7715](https://github.com/aws-amplify/amplify-cli/commit/2ed77151dd6367ac9547f78fe600e7913a3d37b2))
+
+
+
+
+
+## [2.13.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@2.13.0...amplify-codegen@2.13.1) (2020-01-24)
+
+**Note:** Version bump only for package amplify-codegen
+
+
+
+
+
+# [2.13.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.13.0) (2020-01-23)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+- **amplify-codegen:** replace upath with slash ([#3133](https://github.com/aws-amplify/amplify-cli/issues/3133)) ([a565053](https://github.com/aws-amplify/amplify-cli/commit/a565053463e563ed3d44f1405ab551520e0cd818)), closes [#3131](https://github.com/aws-amplify/amplify-cli/issues/3131)
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.12.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.12.0) (2020-01-09)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+- **amplify-codegen:** replace upath with slash ([#3133](https://github.com/aws-amplify/amplify-cli/issues/3133)) ([a565053](https://github.com/aws-amplify/amplify-cli/commit/a565053463e563ed3d44f1405ab551520e0cd818)), closes [#3131](https://github.com/aws-amplify/amplify-cli/issues/3131)
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.11.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.11.0) (2019-12-31)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.10.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.10.0) (2019-12-28)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.9.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.9.0) (2019-12-26)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.8.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.8.0) (2019-12-25)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.7.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.7.0) (2019-12-20)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.6.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.6.0) (2019-12-10)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.4.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.4.0) (2019-12-03)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.3.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.3.0) (2019-12-01)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.2.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.2.0) (2019-11-27)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [2.1.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.29.0...amplify-codegen@2.1.0) (2019-11-27)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix headless push with codegen ([#2743](https://github.com/aws-amplify/amplify-cli/issues/2743)) ([da248a4](https://github.com/aws-amplify/amplify-cli/commit/da248a456d96ed37533f964c066651ae22459166))
+
+### Features
+
+- **amplify-codegen-appsync-model-plugin:** modelgen connection support ([#2836](https://github.com/aws-amplify/amplify-cli/issues/2836)) ([353749c](https://github.com/aws-amplify/amplify-cli/commit/353749ce6643a07206a1f4c30d00beb775db169e))
+- **cli:** cLI updates and new features for Amplify Console ([#2742](https://github.com/aws-amplify/amplify-cli/issues/2742)) ([0fd0dd5](https://github.com/aws-amplify/amplify-cli/commit/0fd0dd5102177766c454c8715fa5acac32385048))
+
+# [1.11.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.11.0) (2019-08-30)
+
+### Bug Fixes
+
+- [#1056](https://github.com/aws-amplify/amplify-cli/issues/1056), dedup environment file reading ([#2088](https://github.com/aws-amplify/amplify-cli/issues/2088)) ([940deaa](https://github.com/aws-amplify/amplify-cli/commit/940deaa))
+- local mock fix ([#1982](https://github.com/aws-amplify/amplify-cli/issues/1982)) ([8ee9029](https://github.com/aws-amplify/amplify-cli/commit/8ee9029))
+- move test package dependencies to devDependencies ([#2034](https://github.com/aws-amplify/amplify-cli/issues/2034)) ([f5623d0](https://github.com/aws-amplify/amplify-cli/commit/f5623d0))
+- **amplify-codegen:** await statement generation before generating types ([#2168](https://github.com/aws-amplify/amplify-cli/issues/2168)) ([4c3aad0](https://github.com/aws-amplify/amplify-cli/commit/4c3aad0)), closes [#2129](https://github.com/aws-amplify/amplify-cli/issues/2129)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+- mock support for API, function and storage ([#1893](https://github.com/aws-amplify/amplify-cli/issues/1893)) ([372e534](https://github.com/aws-amplify/amplify-cli/commit/372e534))
+
+# [1.10.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.10.0) (2019-08-28)
+
+### Bug Fixes
+
+- [#1056](https://github.com/aws-amplify/amplify-cli/issues/1056), dedup environment file reading ([#2088](https://github.com/aws-amplify/amplify-cli/issues/2088)) ([940deaa](https://github.com/aws-amplify/amplify-cli/commit/940deaa))
+- local mock fix ([#1982](https://github.com/aws-amplify/amplify-cli/issues/1982)) ([8ee9029](https://github.com/aws-amplify/amplify-cli/commit/8ee9029))
+- move test package dependencies to devDependencies ([#2034](https://github.com/aws-amplify/amplify-cli/issues/2034)) ([f5623d0](https://github.com/aws-amplify/amplify-cli/commit/f5623d0))
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+- mock support for API, function and storage ([#1893](https://github.com/aws-amplify/amplify-cli/issues/1893)) ([372e534](https://github.com/aws-amplify/amplify-cli/commit/372e534))
+
+# [1.9.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.9.0) (2019-08-13)
+
+### Bug Fixes
+
+- local mock fix ([#1982](https://github.com/aws-amplify/amplify-cli/issues/1982)) ([8ee9029](https://github.com/aws-amplify/amplify-cli/commit/8ee9029))
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+- mock support for API, function and storage ([#1893](https://github.com/aws-amplify/amplify-cli/issues/1893)) ([372e534](https://github.com/aws-amplify/amplify-cli/commit/372e534))
+
+# [1.8.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.8.0) (2019-08-07)
+
+### Bug Fixes
+
+- local mock fix ([#1982](https://github.com/aws-amplify/amplify-cli/issues/1982)) ([8ee9029](https://github.com/aws-amplify/amplify-cli/commit/8ee9029))
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+- mock support for API, function and storage ([#1893](https://github.com/aws-amplify/amplify-cli/issues/1893)) ([372e534](https://github.com/aws-amplify/amplify-cli/commit/372e534))
+
+# [1.7.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.7.0) (2019-08-02)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+# [1.6.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.7...amplify-codegen@1.6.0) (2019-07-31)
+
+### Features
+
+- adding amplify cli predictions category ([#1936](https://github.com/aws-amplify/amplify-cli/issues/1936)) ([b7b7c2c](https://github.com/aws-amplify/amplify-cli/commit/b7b7c2c))
+
+## [1.5.7](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.6...amplify-codegen@1.5.7) (2019-07-23)
+
+### Bug Fixes
+
+- **amplify-codegen:** fix cross os issue ([#1741](https://github.com/aws-amplify/amplify-cli/issues/1741)) ([ae20d0d](https://github.com/aws-amplify/amplify-cli/commit/ae20d0d)), closes [#1522](https://github.com/aws-amplify/amplify-cli/issues/1522)
+
+## [1.5.6](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.5...amplify-codegen@1.5.6) (2019-06-20)
+
+### Bug Fixes
+
+- **cli:** fix inquirer version ([#1690](https://github.com/aws-amplify/amplify-cli/issues/1690)) ([9246032](https://github.com/aws-amplify/amplify-cli/commit/9246032)), closes [#1688](https://github.com/aws-amplify/amplify-cli/issues/1688)
+
+## [1.5.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.4...amplify-codegen@1.5.5) (2019-06-12)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.5.4](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.3...amplify-codegen@1.5.4) (2019-06-11)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.5.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.2...amplify-codegen@1.5.3) (2019-06-06)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.5.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.1...amplify-codegen@1.5.2) (2019-05-21)
+
+### Bug Fixes
+
+- **amplify-codegen:** auto detect S3Object in swift codegen ([#1482](https://github.com/aws-amplify/amplify-cli/issues/1482)) ([ea2de2d](https://github.com/aws-amplify/amplify-cli/commit/ea2de2d)), closes [#1468](https://github.com/aws-amplify/amplify-cli/issues/1468)
+
+## [1.5.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.5.0...amplify-codegen@1.5.1) (2019-05-17)
+
+**Note:** Version bump only for package amplify-codegen
+
+# [1.5.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.4.2...amplify-codegen@1.5.0) (2019-04-30)
+
+### Bug Fixes
+
+- **amplify-codegen:** make codegen multienv aware ([b146c77](https://github.com/aws-amplify/amplify-cli/commit/b146c77)), closes [#1243](https://github.com/aws-amplify/amplify-cli/issues/1243)
+
+### Features
+
+- Multiauth external api add ([#1329](https://github.com/aws-amplify/amplify-cli/issues/1329)) ([13d9fc3](https://github.com/aws-amplify/amplify-cli/commit/13d9fc3))
+
+## [1.4.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.4.1...amplify-codegen@1.4.2) (2019-04-16)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.4.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.3.1...amplify-codegen@1.4.1) (2019-04-09)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.3.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.10...amplify-codegen@1.3.1) (2019-04-03)
+
+### Bug Fixes
+
+- **amplify-cli:** promise not resolving in lts/dubnium ([#1028](https://github.com/aws-amplify/amplify-cli/issues/1028)) ([8a966be](https://github.com/aws-amplify/amplify-cli/commit/8a966be))
+
+## [1.0.10](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.9...amplify-codegen@1.0.10) (2019-03-05)
+
+### Bug Fixes
+
+- **amplify-codegen:** use path relative to project root for codegen ([#951](https://github.com/aws-amplify/amplify-cli/issues/951)) ([7b52efb](https://github.com/aws-amplify/amplify-cli/commit/7b52efb)), closes [#886](https://github.com/aws-amplify/amplify-cli/issues/886)
+
+## [1.0.9](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.8...amplify-codegen@1.0.9) (2019-02-20)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.8](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.6...amplify-codegen@1.0.8) (2019-02-15)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.7](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.6...amplify-codegen@1.0.7) (2019-02-14)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.6](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.5...amplify-codegen@1.0.6) (2019-02-12)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.3-beta.0...amplify-codegen@1.0.5) (2019-02-11)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.3-beta.0...amplify-codegen@1.0.3) (2019-02-11)
+
+**Note:** Version bump only for package amplify-codegen
+
+## [1.0.3-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@1.0.2...amplify-codegen@1.0.3-beta.0) (2019-02-11)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.7"></a>
+
+## [0.2.1-multienv.7](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.6...amplify-codegen@0.2.1-multienv.7) (2019-01-24)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.6"></a>
+
+## [0.2.1-multienv.6](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.5...amplify-codegen@0.2.1-multienv.6) (2019-01-22)
+
+### Bug Fixes
+
+- **amplify-codegen:** hide types gen message for JS ([bd39555](https://github.com/aws-amplify/amplify-cli/commit/bd39555))
+
+<a name="0.2.1-multienv.5"></a>
+
+## [0.2.1-multienv.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.4...amplify-codegen@0.2.1-multienv.5) (2019-01-16)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.4"></a>
+
+## [0.2.1-multienv.4](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.3...amplify-codegen@0.2.1-multienv.4) (2018-12-27)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.3"></a>
+
+## [0.2.1-multienv.3](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.2...amplify-codegen@0.2.1-multienv.3) (2018-12-10)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.2"></a>
+
+## [0.2.1-multienv.2](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.1...amplify-codegen@0.2.1-multienv.2) (2018-12-04)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.2.1-multienv.1"></a>
+
+## [0.2.1-multienv.1](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.2.1-multienv.0...amplify-codegen@0.2.1-multienv.1) (2018-11-30)
+
+### Features
+
+- **amplify-codegen:** add remove support ([#510](https://github.com/aws-amplify/amplify-cli/issues/510)) ([#521](https://github.com/aws-amplify/amplify-cli/issues/521)) ([21e6b7e](https://github.com/aws-amplify/amplify-cli/commit/21e6b7e))
+
+<a name="0.2.1-multienv.0"></a>
+
+## [0.2.1-multienv.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.35-multienv.0...amplify-codegen@0.2.1-multienv.0) (2018-11-21)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.35-multienv.0"></a>
+
+## [0.1.35-multienv.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.34...amplify-codegen@0.1.35-multienv.0) (2018-11-16)
+
+### Bug Fixes
+
+- fix projectPath references in ios and codegen packages & fix for correct AWS profile pickup in the cloudformation provider ([a73656e](https://github.com/aws-amplify/amplify-cli/commit/a73656e))
+- **amplify-codgen:** codegen headless support ([#452](https://github.com/aws-amplify/amplify-cli/issues/452)) ([bbb27c3](https://github.com/aws-amplify/amplify-cli/commit/bbb27c3))
+
+### Features
+
+- headless Init and configure ([#371](https://github.com/aws-amplify/amplify-cli/issues/371)) ([acd14a8](https://github.com/aws-amplify/amplify-cli/commit/acd14a8))
+
+<a name="0.1.34"></a>
+
+## [0.1.34](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.34-beta.0...amplify-codegen@0.1.34) (2018-11-13)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.34-beta.0"></a>
+
+## [0.1.34-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.33...amplify-codegen@0.1.34-beta.0) (2018-11-13)
+
+### Bug Fixes
+
+- **amplify-codegen:** update the params passed to types generator ([#442](https://github.com/aws-amplify/amplify-cli/issues/442)) ([9b87c74](https://github.com/aws-amplify/amplify-cli/commit/9b87c74)), closes [in#434](https://github.com/in/issues/434) [#434](https://github.com/aws-amplify/amplify-cli/issues/434)
+
+<a name="0.1.33"></a>
+
+## [0.1.33](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.33-beta.0...amplify-codegen@0.1.33) (2018-11-09)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.33-beta.0"></a>
+
+## [0.1.33-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.33-beta.0) (2018-11-09)
+
+### Features
+
+- **amplify-codegen:** add angular codegen support ([7dd7259](https://github.com/aws-amplify/amplify-cli/commit/7dd7259))
+
+<a name="0.1.32"></a>
+
+## [0.1.32](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.32-beta.0...amplify-codegen@0.1.32) (2018-11-05)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.32-beta.0"></a>
+
+## [0.1.32-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.32-beta.0) (2018-11-05)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.31"></a>
+
+## [0.1.31](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.31) (2018-11-02)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.30"></a>
+
+## [0.1.30](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.30-beta.0...amplify-codegen@0.1.30) (2018-11-02)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.30-beta.0"></a>
+
+## [0.1.30-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.30-beta.0) (2018-11-02)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.29"></a>
+
+## [0.1.29](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.29-beta.0...amplify-codegen@0.1.29) (2018-10-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.29-beta.0"></a>
+
+## [0.1.29-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.29-beta.0) (2018-10-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.28"></a>
+
+## [0.1.28](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.28-beta.0...amplify-codegen@0.1.28) (2018-10-18)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.28-beta.0"></a>
+
+## [0.1.28-beta.0](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.13...amplify-codegen@0.1.28-beta.0) (2018-10-12)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.13"></a>
+
+## [0.1.13](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.12...amplify-codegen@0.1.13) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.12"></a>
+
+## [0.1.12](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.11...amplify-codegen@0.1.12) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.11"></a>
+
+## [0.1.11](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.9...amplify-codegen@0.1.11) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.9"></a>
+
+## [0.1.9](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.8...amplify-codegen@0.1.9) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.8"></a>
+
+## [0.1.8](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.7...amplify-codegen@0.1.8) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.7"></a>
+
+## [0.1.7](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.6...amplify-codegen@0.1.7) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.6"></a>
+
+## [0.1.6](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.5...amplify-codegen@0.1.6) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.5"></a>
+
+## [0.1.5](https://github.com/aws-amplify/amplify-cli/compare/amplify-codegen@0.1.4...amplify-codegen@0.1.5) (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.4"></a>
+
+## 0.1.4 (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.3"></a>
+
+## 0.1.3 (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.2"></a>
+
+## 0.1.2 (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen
+
+<a name="0.1.1"></a>
+
+## 0.1.1 (2018-08-23)
+
+**Note:** Version bump only for package amplify-codegen

--- a/packages/amplify-codegen/amplify-plugin.json
+++ b/packages/amplify-codegen/amplify-plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "codegen",
+  "type": "util",
+  "commands": ["add", "codegen", "configure", "remove", "statements", "types", "models"],
+  "commandAliases": {
+    "update": "configure",
+    "statement": "statements",
+    "model": "models"
+  },
+  "eventHandlers": []
+}

--- a/packages/amplify-codegen/awsAppSyncDirectives.graphql
+++ b/packages/amplify-codegen/awsAppSyncDirectives.graphql
@@ -1,0 +1,22 @@
+scalar AWSDate
+scalar AWSTime
+scalar AWSDateTime
+scalar AWSTimestamp
+scalar AWSEmail
+scalar AWSJSON
+scalar AWSURL
+scalar AWSPhone
+scalar AWSIPAddress
+scalar BigInt
+scalar Double
+
+directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
+
+# Allows transformer libraries to deprecate directive arguments.
+directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+
+directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
+directive @aws_api_key on FIELD_DEFINITION | OBJECT
+directive @aws_iam on FIELD_DEFINITION | OBJECT
+directive @aws_oidc on FIELD_DEFINITION | OBJECT
+directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT

--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -1,0 +1,24 @@
+const codeGen = require('../../src/index');
+const constants = require('../../src/constants');
+
+const featureName = 'add';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      const { options = {} } = context.parameters;
+      const keys = Object.keys(options);
+      if (keys.length && !keys.includes('apiId')) {
+        const paramMsg = keys.length > 1 ? 'Invalid parameters ' : 'Invalid parameter ';
+        context.print.info(`${paramMsg} ${keys.join(', ')}`);
+        context.print.info(constants.INFO_MESSAGE_ADD_ERROR);
+        return;
+      }
+      const apiId = context.parameters.options.apiId || null;
+      await codeGen.add(context, apiId);
+    } catch (ex) {
+      context.print.error(ex.message);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -1,0 +1,50 @@
+const constants = require('../../src/constants');
+const codeGen = require('../../src');
+const { InvalidSubCommandError, exitOnNextTick } = require('amplify-cli-core');
+const featureName = 'codegen';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    if (context.parameters.options.help) {
+      const header = `amplify ${featureName} [subcommand] [[--nodownload] [--max-depth <number>]]\nDescriptions:
+      Generates GraphQL statements (queries, mutations and subscriptions) and type annotations. \nSub Commands:`;
+
+      const commands = [
+        {
+          name: 'types [--nodownload]',
+          description: constants.CMD_DESCRIPTION_GENERATE_TYPES,
+        },
+        {
+          name: 'statements [--nodownload] [--max-depth]',
+          description: constants.CMD_DESCRIPTION_GENERATE_STATEMENTS,
+        },
+        {
+          name: 'add',
+          description: constants.CMD_DESCRIPTION_ADD,
+        },
+        {
+          name: 'configure',
+          description: constants.CMD_DESCRIPTION_CONFIGURE,
+        },
+      ];
+      context.amplify.showHelp(header, commands);
+      return;
+    }
+    if (context.parameters.first) {
+      context.print.info(constants.CMD_DESCRIPTION_NOT_SUPPORTED);
+      await context.usageData.emitError(new InvalidSubCommandError(constants.CMD_DESCRIPTION_NOT_SUPPORTED));
+      exitOnNextTick(1);
+    }
+
+    try {
+      let forceDownloadSchema = !context.parameters.options.nodownload;
+      let { maxDepth } = context.parameters.options;
+      await codeGen.generate(context, forceDownloadSchema, maxDepth);
+    } catch (e) {
+      context.print.info(e.message);
+      await context.usageData.emitError(e);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/configure.js
+++ b/packages/amplify-codegen/commands/codegen/configure.js
@@ -1,0 +1,15 @@
+const codeGen = require('../../src/index');
+
+const featureName = 'configure';
+
+module.exports = {
+  name: featureName,
+  alias: 'update',
+  run: async context => {
+    try {
+      await codeGen.configure(context);
+    } catch (ex) {
+      context.print.error(ex.message);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/models.js
+++ b/packages/amplify-codegen/commands/codegen/models.js
@@ -1,0 +1,17 @@
+const codeGen = require('../../src');
+const { exitOnNextTick } = require('amplify-cli-core');
+const featureName = 'models';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      await codeGen.generateModels(context);
+    } catch (ex) {
+      context.print.info(ex.message);
+      console.log(ex.stack);
+      await context.usageData.emitError(ex);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/remove.js
+++ b/packages/amplify-codegen/commands/codegen/remove.js
@@ -1,0 +1,14 @@
+const codeGen = require('../../src/index');
+
+const featureName = 'remove';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      await codeGen.remove(context);
+    } catch (ex) {
+      context.print.error(ex.message);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/statements.js
+++ b/packages/amplify-codegen/commands/codegen/statements.js
@@ -1,0 +1,18 @@
+const codeGen = require('../../src');
+const { exitOnNextTick } = require('amplify-cli-core');
+const featureName = 'statements';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      const forceDownloadSchema = !context.parameters.options.nodownload;
+      const { maxDepth } = context.parameters.options;
+      await codeGen.generateStatements(context, forceDownloadSchema, maxDepth);
+    } catch (ex) {
+      context.print.info(ex.message);
+      await context.usageData.emitError(ex);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/commands/codegen/types.js
+++ b/packages/amplify-codegen/commands/codegen/types.js
@@ -1,0 +1,17 @@
+const codeGen = require('../../src');
+const { exitOnNextTick } = require('amplify-cli-core');
+const featureName = 'types';
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      const forceDownloadSchema = !context.parameters.options.nodownload;
+      await codeGen.generateTypes(context, forceDownloadSchema);
+    } catch (ex) {
+      context.print.info(ex.message);
+      await context.usageData.emitError(ex);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "amplify-codegen",
+  "version": "2.21.2",
+  "description": "amplify code generator",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "directory": "packages/amplify-codegen"
+  },
+  "author": "Amazon Web Services",
+  "license": "Apache-2.0",
+  "main": "src/index.js",
+  "keywords": [
+    "graphql",
+    "appsync",
+    "aws"
+  ],
+  "scripts": {
+    "test": "jest",
+    "test-watch": "jest --watch"
+  },
+  "dependencies": {
+    "@aws-amplify/appsync-modelgen-plugin": "^1.22.6",
+    "@graphql-codegen/core": "1.8.3",
+    "amplify-cli-core": "1.17.0",
+    "amplify-codegen-appsync-model-plugin": "1.22.3",
+    "@aws-amplify/graphql-docs-generator": "^2.3.0",
+    "amplify-graphql-docs-generator": "2.2.1",
+    "@aws-amplify/graphql-types-generator": "^2.7.0",
+    "amplify-graphql-types-generator": "2.7.0",
+    "chalk": "^3.0.0",
+    "fs-extra": "^8.1.0",
+    "glob-all": "^3.1.0",
+    "glob-parent": "5.1.1",
+    "graphql": "^14.5.8",
+    "graphql-config": "^2.2.1",
+    "graphql-transformer-core": "6.26.2",
+    "inquirer": "^7.3.3",
+    "ora": "^4.0.3",
+    "slash": "^3.0.0"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "testURL": "http://localhost",
+    "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "js",
+      "jsx",
+      "node"
+    ]
+  }
+}

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -20,13 +20,13 @@
     "test-watch": "jest --watch"
   },
   "dependencies": {
-    "@aws-amplify/appsync-modelgen-plugin": "^1.22.6",
+    "@aws-amplify/appsync-modelgen-plugin": "1.22.8",
     "@graphql-codegen/core": "1.8.3",
     "amplify-cli-core": "1.17.0",
     "amplify-codegen-appsync-model-plugin": "1.22.3",
-    "@aws-amplify/graphql-docs-generator": "^2.3.0",
+    "@aws-amplify/graphql-docs-generator": "2.3.2",
     "amplify-graphql-docs-generator": "2.2.1",
-    "@aws-amplify/graphql-types-generator": "^2.7.0",
+    "@aws-amplify/graphql-types-generator": "2.7.2",
     "amplify-graphql-types-generator": "2.7.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-codegen",
-  "version": "2.21.2",
+  "version": "2.22.0",
   "description": "amplify code generator",
   "repository": {
     "type": "git",

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -4,7 +4,7 @@
   "description": "amplify code generator",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aws-amplify/amplify-cli.git",
+    "url": "https://github.com/aws-amplify/amplify-codegen.git",
     "directory": "packages/amplify-codegen"
   },
   "author": "Amazon Web Services",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-amplify/appsync-modelgen-plugin": "1.22.8",
     "@graphql-codegen/core": "1.8.3",
-    "amplify-cli-core": "1.17.0",
+    "amplify-cli-core": "^1.17.0",
     "amplify-codegen-appsync-model-plugin": "1.22.3",
     "@aws-amplify/graphql-docs-generator": "2.3.2",
     "amplify-graphql-docs-generator": "2.2.1",
@@ -34,7 +34,7 @@
     "glob-parent": "5.1.1",
     "graphql": "^14.5.8",
     "graphql-config": "^2.2.1",
-    "graphql-transformer-core": "6.26.2",
+    "graphql-transformer-core": "^6.26.2",
     "inquirer": "^7.3.3",
     "ora": "^4.0.3",
     "slash": "^3.0.0"

--- a/packages/amplify-codegen/src/amplify-plugin-index.js
+++ b/packages/amplify-codegen/src/amplify-plugin-index.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+const pluginName = 'codegen';
+
+async function executeAmplifyCommand(context) {
+  let commandPath = path.normalize(path.join(__dirname, '../commands'));
+  commandPath = path.join(commandPath, pluginName, context.input.command);
+  const commandModule = require(commandPath);
+  await commandModule.run(context);
+}
+
+async function handleAmplifyEvent(context, args) {
+  context.print.info(`${pluginName} handleAmplifyEvent to be implemented`);
+  context.print.info(`Received event args ${args}`);
+}
+
+module.exports = {
+  executeAmplifyCommand,
+  handleAmplifyEvent,
+};

--- a/packages/amplify-codegen/src/callbacks/postPushCallback.js
+++ b/packages/amplify-codegen/src/callbacks/postPushCallback.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const { pathManager } = require('amplify-cli-core');
+
+const loadConfig = require('../codegen-config');
+const generateStatements = require('../commands/statements');
+const generateTypes = require('../commands/types');
+const generateModels = require('../commands/models');
+
+const { downloadIntrospectionSchema, getAppSyncAPIDetails, getSchemaDownloadLocation } = require('../utils');
+
+async function postPushCallback(context, graphQLConfig) {
+  if (!graphQLConfig) {
+    return;
+  }
+
+  try {
+    if (!graphQLConfig.gqlConfig.schema) {
+      const config = loadConfig(context);
+
+      const projectPath = pathManager.findProjectRoot() || process.cwd();
+      const schemaLocation = path.join(projectPath, getSchemaDownloadLocation(context));
+
+      const newProject = graphQLConfig.gqlConfig;
+      newProject.schema = schemaLocation;
+      config.addProject(newProject);
+      config.save();
+    }
+    const apis = getAppSyncAPIDetails(context);
+
+    await downloadIntrospectionSchema(context, apis[0].id, graphQLConfig.gqlConfig.schema);
+    if (graphQLConfig.shouldGenerateDocs) {
+      await generateStatements(context);
+    }
+    if (graphQLConfig.shouldGenerateModels) {
+      await generateModels(context);
+    }
+    await generateTypes(context);
+  } catch (error) {
+    // Code Generation failure should not result in actual push failure
+    context.print.warning(`Code generation failed with the following error \n${error.message}.`);
+  }
+}
+
+module.exports = postPushCallback;

--- a/packages/amplify-codegen/src/callbacks/prePushAddCallback.js
+++ b/packages/amplify-codegen/src/callbacks/prePushAddCallback.js
@@ -1,0 +1,64 @@
+const { normalizeInputParams } = require('../utils/input-params-manager');
+const constants = require('../constants');
+const askShouldGenerateCode = require('../walkthrough/questions/generateCode');
+const addWalkThrough = require('../walkthrough/add');
+const { getFrontEndHandler, isCodegenConfigured } = require('../utils');
+const prePushUpdateCallback = require('./prePushUpdateCallback');
+const path = require('path');
+const { isDataStoreEnabled } = require('graphql-transformer-core');
+const { pathManager } = require('amplify-cli-core');
+
+async function prePushAddCallback(context, resourceName) {
+  // when codegen is already configured
+  if (isCodegenConfigured(context, resourceName)) {
+    return prePushUpdateCallback(context, resourceName);
+  }
+
+  let shouldGenerateCode = false;
+  if (context.exeInfo.inputParams) {
+    const frontend = getFrontEndHandler(context);
+
+    if (frontend !== 'flutter') {
+      normalizeInputParams(context);
+      const inputParams = context.exeInfo.inputParams[constants.Label];
+      const yesFlag = context.exeInfo.inputParams.yes;
+
+      shouldGenerateCode = await determineValue(inputParams, yesFlag, 'generateCode', true, () => askShouldGenerateCode());
+    }
+  } else {
+    shouldGenerateCode = await askShouldGenerateCode();
+  }
+
+  if (shouldGenerateCode) {
+    const answers = await addWalkThrough(context, ['shouldGenerateCode']);
+    const newProject = {
+      projectName: resourceName,
+      includes: answers.includePattern,
+      excludes: answers.excludePattern,
+      amplifyExtension: {
+        codeGenTarget: answers.target || '',
+        generatedFileName: answers.generatedFileName || '',
+        docsFilePath: answers.docsFilePath,
+      },
+    };
+    return {
+      shouldGenerateModels: await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName)),
+      gqlConfig: newProject,
+      shouldGenerateDocs: answers.shouldGenerateDocs,
+    };
+  }
+}
+
+async function determineValue(inputParams, yesFlag, propertyName, defaultValue, askFunction) {
+  let result;
+  if (inputParams && inputParams.hasOwnProperty(propertyName)) {
+    result = inputParams[propertyName];
+  } else if (yesFlag && defaultValue !== undefined) {
+    result = defaultValue;
+  } else {
+    result = await askFunction();
+  }
+  return result;
+}
+
+module.exports = prePushAddCallback;

--- a/packages/amplify-codegen/src/callbacks/prePushUpdateCallback.js
+++ b/packages/amplify-codegen/src/callbacks/prePushUpdateCallback.js
@@ -1,0 +1,55 @@
+const { normalizeInputParams } = require('../utils/input-params-manager');
+const constants = require('../constants');
+const loadConfig = require('../codegen-config');
+const askShouldUpdateCode = require('../walkthrough/questions/updateCode');
+const askShouldUpdateDocs = require('../walkthrough/questions/updateDocs');
+const path = require('path');
+const { isDataStoreEnabled } = require('graphql-transformer-core');
+const { pathManager } = require('amplify-cli-core');
+
+async function prePushUpdateCallback(context, resourceName) {
+  const config = loadConfig(context);
+  const project = config.getProjects().find(projectItem => projectItem.projectName === resourceName);
+  if (project) {
+    let shouldGenerateCode = false;
+    let shouldGenerateDocs = false;
+    if (context.exeInfo.inputParams) {
+      normalizeInputParams(context);
+      const inputParams = context.exeInfo.inputParams[constants.Label];
+      const yesFlag = context.exeInfo.inputParams.yes;
+
+      shouldGenerateCode = await determineValue(inputParams, yesFlag, 'generateCode', true, () => askShouldUpdateCode());
+
+      if (shouldGenerateCode) {
+        shouldGenerateDocs = await determineValue(inputParams, yesFlag, 'generateDocs', true, () => askShouldUpdateDocs());
+      }
+    } else {
+      shouldGenerateCode = await askShouldUpdateCode();
+      if (shouldGenerateCode) {
+        shouldGenerateDocs = await askShouldUpdateDocs();
+      }
+    }
+
+    if (shouldGenerateCode) {
+      return {
+        shouldGenerateModels: await isDataStoreEnabled(path.join(pathManager.getBackendDirPath(), 'api', resourceName)),
+        gqlConfig: project,
+        shouldGenerateDocs,
+      };
+    }
+  }
+}
+
+async function determineValue(inputParams, yesFlag, propertyName, defaultValue, askFunction) {
+  let result;
+  if (inputParams && inputParams.hasOwnProperty(propertyName)) {
+    result = inputParams[propertyName];
+  } else if (yesFlag && defaultValue !== undefined) {
+    result = defaultValue;
+  } else {
+    result = await askFunction();
+  }
+  return result;
+}
+
+module.exports = prePushUpdateCallback;

--- a/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
@@ -1,0 +1,130 @@
+const graphQLConfig = require('graphql-config');
+const { join, isAbsolute, relative } = require('path');
+const slash = require('slash');
+const { graphQlToAmplifyConfig } = require('./utils');
+
+class AmplifyCodeGenConfig {
+  constructor(context, withoutInit = false) {
+    try {
+      this.gqlConfig = graphQLConfig.getGraphQLConfig();
+      this.fixOldConfig();
+    } catch (e) {
+      if (e instanceof graphQLConfig.ConfigNotFoundError) {
+        const { amplify } = context;
+        let projectRoot;
+        if (!withoutInit) {
+          projectRoot = amplify.getEnvInfo().projectPath || process.cwd();
+        } else {
+          projectRoot = process.cwd();
+        }
+        const configPath = join(projectRoot, '.graphqlconfig.yml');
+        this.gqlConfig = new graphQLConfig.GraphQLConfig(null, configPath);
+        this.gqlConfig.config = {};
+      } else {
+        throw e;
+      }
+    }
+  }
+  static isValidAmplifyProject(project) {
+    if (project.schema && Object.keys(project.amplifyExtension).length) {
+      return true;
+    }
+    return false;
+  }
+  save() {
+    if (this.gqlConfig) {
+      this.gqlConfig.saveConfig(this.gqlConfig.config);
+    }
+  }
+  getProjects() {
+    return this.gqlConfig.config ? graphQlToAmplifyConfig(this.gqlConfig) : [];
+  }
+  addProject(project) {
+    if (!this.constructor.isValidAmplifyProject(project)) {
+      return false;
+    }
+    const schemaPath = isAbsolute(project.schema) ? relative(this.gqlConfig.configDir, project.schema) : project.schema;
+    const newProject = {
+      schemaPath,
+      includes: project.includes,
+      excludes: project.excludes,
+    };
+    const extensions = {};
+    if (project.amplifyExtension && Object.keys(project.amplifyExtension).length) {
+      extensions.amplify = project.amplifyExtension;
+    }
+
+    if (Object.keys(extensions).length) {
+      newProject.extensions = extensions;
+    }
+
+    const projects = this.gqlConfig.config.projects || {};
+    projects[project.projectName] = this.constructor.normalizePath(newProject);
+    this.gqlConfig.config.projects = projects;
+  }
+  removeProject(projectName) {
+    if (Object.keys(this.gqlConfig.getProjects()).includes(projectName)) {
+      delete this.gqlConfig.config.projects[projectName];
+      return true;
+    }
+    return false;
+  }
+
+  static normalizePath(proj) {
+    if (!proj.schemaPath || !proj.extensions || !proj.extensions.amplify) {
+      return proj;
+    }
+    const updatedProj = {};
+    updatedProj.schemaPath = slash(proj.schemaPath);
+    updatedProj.includes = (proj.includes || []).map(p => slash(p));
+    updatedProj.excludes = (proj.excludes || []).map(p => slash(p));
+    const amplifyExtension = {
+      ...proj.extensions.amplify,
+    };
+    amplifyExtension.generatedFileName = amplifyExtension.generatedFileName
+      ? slash(amplifyExtension.generatedFileName)
+      : amplifyExtension.generatedFileName;
+    amplifyExtension.docsFilePath = amplifyExtension.docsFilePath ? slash(amplifyExtension.docsFilePath) : amplifyExtension.docsFilePath;
+
+    updatedProj.extensions = {
+      amplify: amplifyExtension,
+    };
+
+    return updatedProj;
+  }
+
+  fixOldConfig() {
+    // Older version of config is not a valid graphqlconfig, fix it when loading
+    const { config: cfg } = this.gqlConfig;
+    if (cfg.extensions && cfg.extensions.amplify && cfg.extensions.amplify.version >= 3) {
+      return;
+    }
+    cfg.projects = cfg.projects || {};
+    Object.keys(cfg).forEach(key => {
+      const proj = cfg[key];
+      if (proj.extensions && proj.extensions.amplify) {
+        delete cfg[key];
+        if (proj.extensions.endPoints) {
+          proj.extensions.endpoints = {
+            prod: proj.extensions.endPoints,
+          };
+          delete proj.extensions.endPoints;
+        }
+        cfg.projects[key] = proj;
+      }
+    });
+
+    Object.keys(cfg.projects || {}).forEach(projName => {
+      cfg.projects[projName] = this.constructor.normalizePath(cfg.projects[projName]);
+    });
+    cfg.extensions = {
+      ...cfg.extensions,
+      amplify: {
+        ...((cfg.extensions && cfg.extensions.amplify) || {}),
+        version: 3,
+      },
+    };
+    this.save();
+  }
+}
+module.exports = AmplifyCodeGenConfig;

--- a/packages/amplify-codegen/src/codegen-config/index.js
+++ b/packages/amplify-codegen/src/codegen-config/index.js
@@ -1,0 +1,12 @@
+const AmplifyCodeGenConfig = require('./AmplifyCodeGenConfig');
+
+let config = null;
+
+function loadConfig(context, withoutInit = false) {
+  if (!config) {
+    config = new AmplifyCodeGenConfig(context, withoutInit);
+  }
+  return config;
+}
+
+module.exports = loadConfig;

--- a/packages/amplify-codegen/src/codegen-config/utils/graphQlToAmplifyConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/utils/graphQlToAmplifyConfig.js
@@ -1,0 +1,35 @@
+function graphQlToAmplifyConfig(gqlConfig) {
+  const amplifyConfig = [];
+  let cfg = getAmplifyConfig(gqlConfig.config);
+  if (cfg) {
+    amplifyConfig.push({ ...cfg, __root__: true });
+  }
+  const projects = gqlConfig.getProjects() || {};
+
+  Object.keys(projects).forEach(projectName => {
+    const project = projects[projectName];
+    cfg = getAmplifyConfig(project.config);
+
+    if (cfg) amplifyConfig.push({ ...cfg, __root__: false, projectName });
+  });
+
+  return amplifyConfig;
+}
+
+function getAmplifyConfig(config = {}) {
+  if (config && config.extensions && config.extensions.amplify && config.includes) {
+    if (typeof config.includes === 'string') {
+      config.includes = [config.includes];
+    }
+    return {
+      schema: config.schemaPath,
+      includes: Array.isArray(config.includes) ? config.includes : [config.includes],
+      excludes: Array.isArray(config.excludes) ? config.excludes : [config.excludes],
+      amplifyExtension: {
+        ...config.extensions.amplify,
+      },
+    };
+  }
+}
+
+module.exports = graphQlToAmplifyConfig;

--- a/packages/amplify-codegen/src/codegen-config/utils/index.js
+++ b/packages/amplify-codegen/src/codegen-config/utils/index.js
@@ -1,0 +1,3 @@
+const graphQlToAmplifyConfig = require('./graphQlToAmplifyConfig');
+
+module.exports = { graphQlToAmplifyConfig };

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -1,0 +1,159 @@
+const Ora = require('ora');
+const loadConfig = require('../codegen-config');
+const constants = require('../constants');
+const generateStatements = require('./statements');
+const generateTypes = require('./types');
+const { AmplifyCodeGenNoAppSyncAPIAvailableError: NoAppSyncAPIAvailableError, AmplifyCodeGenAPINotFoundError } = require('../errors');
+const {
+  downloadIntrospectionSchemaWithProgress,
+  getAppSyncAPIDetails,
+  getAppSyncAPIInfo,
+  getProjectAwsRegion,
+  updateAmplifyMeta,
+  getSDLSchemaLocation,
+  getFrontEndHandler,
+} = require('../utils');
+const addWalkThrough = require('../walkthrough/add');
+const changeAppSyncRegion = require('../walkthrough/changeAppSyncRegions');
+const path = require('path');
+const fs = require('fs-extra');
+const askForFrontend = require('../walkthrough/questions/selectFrontend');
+const askForFramework = require('../walkthrough/questions/selectFramework');
+
+const frontends = ['android', 'ios', 'javascript'];
+const frameworks = ['angular', 'ember', 'ionic', 'react', 'react-native', 'vue', 'none'];
+
+async function add(context, apiId = null) {
+  let withoutInit = false;
+  // Determine if working in an amplify project
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+    const config = loadConfig(context, withoutInit);
+    if (config.getProjects().length) {
+      throw new Error(constants.ERROR_CODEGEN_SUPPORT_MAX_ONE_API);
+    }
+  }
+
+  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
+  if (withoutInit && !schemaPath) {
+    throw Error(
+      `Please download schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
+    );
+  }
+  // Grab the frontend
+  let frontend;
+  if (withoutInit) {
+    ({ frontend } = context.parameters.options);
+    if (frontend) {
+      // Make sure provided frontend prarameter is valid
+      if (!frontends.includes(frontend)) {
+        throw Error('Invalid frontend provided');
+      }
+    } else {
+      frontend = await askForFrontend(frontends);
+    }
+  }
+
+  // Grab the framework
+  let framework;
+  if (withoutInit) {
+    ({ framework } = context.parameters.options);
+    if (framework) {
+      if (frontend !== 'javascript' || !frameworks.includes(framework)) {
+        throw Error('Invalid framework provided');
+      }
+    } else if (frontend === 'javascript') {
+      framework = await askForFramework(frameworks);
+    }
+  }
+
+  let region = 'us-east-1';
+  if (!withoutInit) {
+    region = getProjectAwsRegion(context);
+  }
+  const config = loadConfig(context, withoutInit);
+  if (config.getProjects().length) {
+    throw new Error(constants.ERROR_CODEGEN_SUPPORT_MAX_ONE_API);
+  }
+  let apiDetails;
+  if (!withoutInit) {
+    if (!apiId) {
+      const availableAppSyncApis = getAppSyncAPIDetails(context); // published and un-published
+      if (availableAppSyncApis.length === 0) {
+        throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
+      }
+      [apiDetails] = availableAppSyncApis;
+      apiDetails.isLocal = true;
+    } else {
+      let shouldRetry = true;
+      while (shouldRetry) {
+        const apiDetailSpinner = new Ora();
+        try {
+          apiDetailSpinner.start('Getting API details');
+          apiDetails = await getAppSyncAPIInfo(context, apiId, region);
+          apiDetailSpinner.succeed();
+          await updateAmplifyMeta(context, apiDetails);
+          break;
+        } catch (e) {
+          apiDetailSpinner.fail();
+          if (e instanceof AmplifyCodeGenAPINotFoundError) {
+            context.print.info(`AppSync API was not found in region ${region}`);
+            ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+  }
+
+  if (!withoutInit && !apiDetails) {
+    return;
+  }
+  const answer = await addWalkThrough(context, undefined, withoutInit, frontend, framework);
+
+  let schema;
+  if (!withoutInit) {
+    if (!apiDetails.isLocal) {
+      schema = await downloadIntrospectionSchemaWithProgress(context, apiDetails.id, answer.schemaLocation, region);
+    } else if (getFrontEndHandler(context) === 'android') {
+      schema = answer.schemaLocation;
+    } else {
+      schema = getSDLSchemaLocation(apiDetails.name);
+    }
+  } else {
+    schema = schemaPath;
+  }
+
+  const newProject = {
+    projectName: withoutInit ? 'Codegen Project' : apiDetails.name,
+    includes: answer.includePattern,
+    excludes: answer.excludePattern,
+    schema,
+    amplifyExtension: {
+      codeGenTarget: answer.target || '',
+      generatedFileName: answer.generatedFileName || '',
+      docsFilePath: answer.docsFilePath,
+      region,
+      apiId,
+      ...(withoutInit ? { frontend } : {}),
+      ...(withoutInit && frontend === 'javascript' ? { framework } : {}),
+    },
+  };
+
+  if (answer.maxDepth) {
+    newProject.amplifyExtension.maxDepth = answer.maxDepth;
+  }
+  config.addProject(newProject);
+  if (answer.shouldGenerateDocs) {
+    await generateStatements(context, false, undefined, withoutInit, frontend);
+  }
+  if (answer.shouldGenerateCode) {
+    await generateTypes(context, false, withoutInit, frontend);
+  }
+  config.save();
+}
+
+module.exports = add;

--- a/packages/amplify-codegen/src/commands/configure.js
+++ b/packages/amplify-codegen/src/commands/configure.js
@@ -1,0 +1,23 @@
+const loadConfig = require('../codegen-config');
+const configureProjectWalkThrough = require('../walkthrough/configure');
+const add = require('./add');
+
+async function configure(context) {
+  let withoutInit = false;
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
+  const config = loadConfig(context, withoutInit);
+  if (!config.getProjects().length) {
+    await add(context);
+    return;
+  }
+  const project = await configureProjectWalkThrough(context, config.getProjects(), withoutInit);
+  config.addProject(project);
+  config.save();
+  console.log('Codegen configured. Remember to run "amplify codegen" to generate your types and statements.')
+}
+
+module.exports = configure;

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -1,0 +1,62 @@
+const { join } = require('path');
+const { AmplifyCodeGenNoAppSyncAPIAvailableError: NoAppSyncAPIAvailableError } = require('../errors');
+const generateTypes = require('./types');
+const generateStatements = require('./statements');
+const loadConfig = require('../codegen-config');
+const constants = require('../constants');
+const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../utils');
+const path = require('path');
+const fs = require('fs-extra');
+
+async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth) {
+  let withoutInit = false;
+  // Determine if working in an amplify project
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
+
+  // Check if introspection schema exists
+  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
+  if (withoutInit && !schemaPath) {
+    throw Error(
+      `Please download the schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`
+    );
+  }
+
+  if (withoutInit) {
+    forceDownloadSchema = false;
+  }
+  const config = loadConfig(context, withoutInit);
+  const projects = config.getProjects();
+  if (!projects.length) {
+    throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  }
+  let apis = [];
+  if (!withoutInit) {
+    apis = getAppSyncAPIDetails(context);
+  }
+  if (!apis.length && !withoutInit) {
+    throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  }
+  const project = projects[0];
+  const { frontend } = project.amplifyExtension;
+  let projectPath = process.cwd();
+  if (!withoutInit) {
+    ({ projectPath } = context.amplify.getEnvInfo());
+  }
+
+  let downloadPromises;
+  if (!withoutInit) {
+    downloadPromises = projects.map(
+      async cfg =>
+        await ensureIntrospectionSchema(context, join(projectPath, cfg.schema), apis[0], cfg.amplifyExtension.region, forceDownloadSchema)
+    );
+    await Promise.all(downloadPromises);
+  }
+  await generateStatements(context, false, maxDepth, withoutInit, frontend);
+  await generateTypes(context, false, withoutInit, frontend);
+}
+
+module.exports = generateStatementsAndTypes;

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -1,0 +1,166 @@
+const path = require('path');
+const fs = require('fs-extra');
+const { parse } = require('graphql');
+const { FeatureFlags, pathManager } = require('amplify-cli-core');
+const gqlCodeGen = require('@graphql-codegen/core');
+const { getModelgenPackage } = require('../utils/getModelgenPackage');
+
+const platformToLanguageMap = {
+  android: 'java',
+  ios: 'swift',
+  flutter: 'dart',
+  javascript: 'javascript',
+};
+
+async function generateModels(context) {
+  // steps:
+  // 1. Load the schema and validate using transformer
+  // 2. get all the directives supported by transformer
+  // 3. Generate code
+  let projectRoot;
+  try {
+    context.amplify.getProjectMeta();
+    projectRoot = context.amplify.getEnvInfo().projectPath;
+  } catch (e) {
+    projectRoot = process.cwd();
+  }
+
+  const allApiResources = await context.amplify.getResourceStatus('api');
+  const apiResource = allApiResources.allResources.find(
+    resource => resource.service === 'AppSync' && resource.providerPlugin === 'awscloudformation',
+  );
+
+  if (!apiResource) {
+    context.print.info('No AppSync API configured. Please add an API');
+    return;
+  }
+
+  await validateSchema(context);
+  const backendPath = await context.amplify.pathManager.getBackendDirPath();
+  const apiResourcePath = path.join(backendPath, 'api', apiResource.resourceName);
+
+  const directiveDefinitions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getTransformerDirectives', {
+    resourceDir: apiResourcePath,
+  });
+
+  const schemaContent = loadSchema(apiResourcePath);
+  const outputPath = path.join(projectRoot, getModelOutputPath(context));
+  const schema = parse(schemaContent);
+  const projectConfig = context.amplify.getProjectConfig();
+
+  const modelgenPackageMigrationflag = 'codegen.useAppSyncModelgenPlugin';
+
+  const appSyncDataStoreCodeGen = getModelgenPackage(FeatureFlags.getBoolean(modelgenPackageMigrationflag));
+
+  const appsyncLocalConfig = await appSyncDataStoreCodeGen.preset.buildGeneratesSection({
+    baseOutputDir: outputPath,
+    schema,
+    config: {
+      target: platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend,
+      directives: directiveDefinitions,
+    },
+  });
+
+  const codeGenPromises = appsyncLocalConfig.map(cfg => {
+    return gqlCodeGen.codegen({
+      ...cfg,
+      plugins: [
+        {
+          appSyncLocalCodeGen: {},
+        },
+      ],
+      pluginMap: {
+        appSyncLocalCodeGen: appSyncDataStoreCodeGen,
+      },
+    });
+  });
+
+  const generatedCode = await Promise.all(codeGenPromises);
+
+  appsyncLocalConfig.forEach((cfg, idx) => {
+    const outPutPath = cfg.filename;
+    fs.ensureFileSync(outPutPath);
+    fs.writeFileSync(outPutPath, generatedCode[idx]);
+  });
+
+  generateEslintIgnore(context);
+
+  context.print.info(`Successfully generated models. Generated models can be found in ${outputPath}`);
+}
+
+async function validateSchema(context) {
+  await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+    noConfig: true,
+    forceCompile: true,
+    dryRun: true,
+    disableResolverOverrides: true,
+  });
+}
+
+function loadSchema(apiResourcePath) {
+  const schemaFilePath = path.join(apiResourcePath, 'schema.graphql');
+  const schemaDirectory = path.join(apiResourcePath, 'schema');
+  if (fs.pathExistsSync(schemaFilePath)) {
+    return fs.readFileSync(schemaFilePath, 'utf8');
+  }
+  if (fs.pathExistsSync(schemaDirectory) && fs.lstatSync(schemaDirectory).isDirectory()) {
+    return fs
+      .readdirSync(schemaDirectory)
+      .map(file => path.join(schemaDirectory, file))
+      .filter(file => file.endsWith('.graphql') && fs.lstatSync(file).isFile())
+      .map(file => fs.readFileSync(file, 'utf8'))
+      .join('\n');
+  }
+
+  throw new Error('Could not load the schema');
+}
+
+function getModelOutputPath(context) {
+  const projectConfig = context.amplify.getProjectConfig();
+  switch (projectConfig.frontend) {
+    case 'javascript':
+      return projectConfig.javascript && projectConfig.javascript.config && projectConfig.javascript.config.SourceDir
+        ? path.normalize(projectConfig.javascript.config.SourceDir)
+        : 'src';
+    case 'android':
+      return projectConfig.android && projectConfig.android.config && projectConfig.android.config.ResDir
+        ? path.normalize(path.join(projectConfig.android.config.ResDir, '..', 'java'))
+        : path.join('app', 'src', 'main', 'java');
+    case 'ios':
+      return 'amplify/generated/models';
+    case 'flutter':
+      return 'lib/models';
+    default:
+      return '.';
+  }
+}
+
+function generateEslintIgnore(context) {
+  const projectConfig = context.amplify.getProjectConfig();
+
+  if (projectConfig.frontend !== 'javascript') {
+    return;
+  }
+
+  const projectPath = pathManager.findProjectRoot();
+
+  if (!projectPath) {
+    return;
+  }
+
+  const eslintIgnorePath = path.join(projectPath, '.eslintignore');
+  const modelFolder = path.join(getModelOutputPath(context), 'models');
+
+  if (!fs.existsSync(eslintIgnorePath)) {
+    fs.writeFileSync(eslintIgnorePath, modelFolder);
+    return;
+  }
+
+  const eslintContents = fs.readFileSync(eslintIgnorePath);
+
+  if (!eslintContents.includes(modelFolder)) {
+    fs.appendFileSync(eslintIgnorePath, `\n${modelFolder}\n`);
+  }
+}
+
+module.exports = generateModels;

--- a/packages/amplify-codegen/src/commands/remove.js
+++ b/packages/amplify-codegen/src/commands/remove.js
@@ -1,0 +1,38 @@
+const inquirer = require('inquirer');
+
+const loadConfig = require('../codegen-config');
+const constants = require('../constants');
+
+async function remove(context) {
+  let withoutInit = false;
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
+  const config = loadConfig(context, withoutInit);
+  const projects = config.getProjects();
+  let projectName;
+  if (projects.length === 0) {
+    throw new Error('Codegen is not configured');
+  }
+
+  if (projects.length === 1) {
+    const [proj] = config.getProjects();
+    ({ projectName } = proj);
+  } else {
+    const choices = projects.map(proj => proj.projectName);
+    ({ projectName } = await inquirer.prompt([
+      {
+        name: 'projectName',
+        message: constants.PROMPT_MSG_API_REMOVE,
+        type: 'list',
+        choices,
+      },
+    ]));
+  }
+  config.removeProject(projectName);
+  config.save();
+}
+
+module.exports = remove;

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const fs = require('fs-extra');
+const Ora = require('ora');
+
+const loadConfig = require('../codegen-config');
+const constants = require('../constants');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
+const { FeatureFlags } = require('amplify-cli-core');
+const { getDocsgenPackage } = require('../utils/getDocsgenPackage');
+
+const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
+const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
+
+async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
+  const config = loadConfig(context, withoutInit);
+  const projects = config.getProjects();
+  let apis = [];
+  if (!withoutInit) {
+    apis = getAppSyncAPIDetails(context);
+  }
+  let projectPath = process.cwd();
+  if (!withoutInit) {
+    ({ projectPath } = context.amplify.getEnvInfo());
+  }
+  if (!projects.length || !apis.length) {
+    if (!withoutInit) {
+      context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+      return;
+    }
+  }
+  if (!projects.length && withoutInit) {
+    context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+    return;
+  }
+  for (const cfg of projects) {
+    const includeFiles = path.join(projectPath, cfg.includes[0]);
+    const opsGenDirectory = cfg.amplifyExtension.docsFilePath
+      ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
+      : path.dirname(path.dirname(includeFiles));
+    const schemaPath = path.join(projectPath, cfg.schema);
+    let region;
+    let frontend;
+    if (!withoutInit) {
+      ({ region } = cfg.amplifyExtension);
+      await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
+      frontend = getFrontEndHandler(context);
+    } else {
+      frontend = decoupleFrontend;
+    }
+    const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
+    const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
+    opsGenSpinner.start();
+    try {
+      fs.ensureDirSync(opsGenDirectory);
+      generate(schemaPath, opsGenDirectory, {
+        separateFiles: true,
+        language,
+        maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
+      });
+      opsGenSpinner.succeed(constants.INFO_MESSAGE_OPS_GEN_SUCCESS + path.relative(path.resolve('.'), opsGenDirectory));
+    } finally {
+      opsGenSpinner.stop();
+    }
+  }
+}
+module.exports = generateStatements;

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -1,0 +1,83 @@
+const glob = require('glob-all');
+const path = require('path');
+const Ora = require('ora');
+
+const constants = require('../constants');
+const loadConfig = require('../codegen-config');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
+const { FeatureFlags } = require('amplify-cli-core');
+const { getTypesgenPackage } = require('../utils/getTypesgenPackage');
+
+const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
+const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
+
+async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
+  let frontend = decoupleFrontend;
+  try {
+    context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
+  if (!withoutInit) {
+    frontend = getFrontEndHandler(context);
+  }
+  if (frontend !== 'android') {
+    const config = loadConfig(context, withoutInit);
+    const projects = config.getProjects();
+    let apis = [];
+    if (!withoutInit) {
+      apis = getAppSyncAPIDetails(context);
+    }
+    if (!projects.length || !apis.length) {
+      if (!withoutInit) {
+        context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+        return;
+      }
+    }
+
+    let projectPath = process.cwd();
+    if (!withoutInit) {
+      ({ projectPath } = context.amplify.getEnvInfo());
+    }
+
+    try {
+      projects.forEach(async cfg => {
+        const { generatedFileName } = cfg.amplifyExtension || {};
+        const includeFiles = cfg.includes;
+        if (!generatedFileName || generatedFileName === '' || includeFiles.length === 0) {
+          return;
+        }
+
+        const excludes = cfg.excludes.map(pattern => `!${pattern}`);
+        const queries = glob.sync([...includeFiles, ...excludes], {
+          cwd: projectPath,
+          absolute: true,
+        });
+        const schemaPath = path.join(projectPath, cfg.schema);
+        const target = cfg.amplifyExtension.codeGenTarget;
+
+        const outputPath = path.join(projectPath, generatedFileName);
+        let region;
+        if (!withoutInit) {
+          ({ region } = cfg.amplifyExtension);
+          await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
+        }
+        const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
+        codeGenSpinner.start();
+        try {
+          generate(queries, schemaPath, path.join(projectPath, generatedFileName), '', target, '', {
+            addTypename: true,
+            complexObjectSupport: 'auto',
+          });
+          codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);
+        } catch (err) {
+          codeGenSpinner.fail(err.message);
+        }
+      });
+    } catch (err) {
+      throw Error(err.message);
+    }
+  }
+}
+
+module.exports = generateTypes;

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -1,0 +1,57 @@
+const chalk = require('chalk');
+
+module.exports = {
+  Label: 'codegen',
+  Aliases: ['codeGen'],
+  PROMPT_MSG_API_LIST: 'Choose the AppSync API that you want to use in this project',
+  PROMPT_MSG_API_REMOVE: 'Choose the AppSync API that you want to remove from codegen',
+  PROMPT_MSG_FILE_NAME: 'Enter the file name for the generated code',
+  PROMPT_MSG_CODEGEN_TARGET: 'Choose the code generation language target',
+  PROMPT_MSG_API_KEY: 'Choose the API Key to use',
+  PROMPT_MSG_GQL_FILE_PATTERN: 'Enter the file name pattern of graphql queries, mutations and subscriptions',
+  PROMPT_MSG_GENERATE_CODE: 'Do you want to generate code for your newly created GraphQL API',
+  PROMPT_MSG_UPDATE_STATEMENTS:
+    'Do you want to generate GraphQL statements (queries, mutations and subscription) based on your schema types?\nThis will overwrite your current graphql queries, mutations and subscriptions',
+  PROMPT_MSG_CHANGE_REGION: 'Do you want to choose a different region',
+  PROMPT_MSG_UPDATE_CODE: 'Do you want to update code for your updated GraphQL API',
+  PROMPT_MSG_MAX_DEPTH: 'Enter maximum statement depth [increase from default if your schema is deeply nested]',
+  PROMPT_MSG_GENERATE_OPS: 'Do you want to generate/update all possible GraphQL operations - queries, mutations and subscriptions',
+  PROMPT_MSG_SELECT_PROJECT: 'Choose the AppSync API',
+  PROMPT_MSG_SELECT_REGION: 'Choose AWS Region',
+  ERROR_CODEGEN_TARGET_NOT_SUPPORTED: 'is not supported by codegen plugin',
+  ERROR_CODEGEN_FRONTEND_NOT_SUPPORTED: 'The project frontend is not supported by codegen',
+  ERROR_MSG_MAX_DEPTH: 'Depth should be a integer greater than 0',
+  ERROR_CODEGEN_NO_API_AVAILABLE: 'There are no GraphQL APIs available.\nAdd by running $amplify api add',
+  ERROR_CODEGEN_NO_API_KEY_AVAILABLE:
+    "Security mode is set to API Key but coudn't find any API Keys. Please add an API Key to your AppSync API using the AWS AppSync console",
+  ERROR_CODEGEN_ALL_APIS_ALREADY_ADDED: 'All enabled AppSync APIs are already added',
+  ERROR_CODEGEN_SUPPORT_MAX_ONE_API: 'Codegen support only one GraphQL API per project',
+  CMD_DESCRIPTION_ADD: 'Generate API code or type annotations based on a GraphQL schema and query documents',
+  CMD_DESCRIPTION_GENERATE_TYPES:
+    "Generate API code or type annotations based on a GraphQL schema and statements.\nIf don't want to download schema before generating code pass --nodownload flag.",
+  CMD_DESCRIPTION_GENERATE_STATEMENTS:
+    "Generate GraphQL statements(query, mutations and subscriptions) from schema.\nIf don't want to download schema before generating code pass --nodownload flag",
+  ERROR_NOT_CONFIGURED: '',
+  CMD_DESCRIPTION_NOT_SUPPORTED: 'invalid subcommand',
+  CMD_DESCRIPTION_CONFIGURE: 'Change/Update codegen configuration',
+  ERROR_CODEGEN_NO_API_CONFIGURED: 'code generation is not configured. Configure it by running \n$amplify codegen add',
+  ERROR_CODEGEN_PENDING_API_PUSH: 'AppSync API is not pushed to the cloud. Did you forget to do \n$amplify api push',
+  WARNING_CODEGEN_PENDING_API_PUSH: 'The APIs listed below are not pushed to the cloud. Run amplify api push',
+  ERROR_APPSYNC_API_NOT_FOUND:
+    'Could not find the AppSync API. If you have removed the AppSync API in the console run amplify codegen remove',
+  MSG_CODEGEN_PENDING_API_PUSH: `${chalk.bold(
+    'WARNING:',
+  )} You have modified your schema locally and not pushed to the cloud, which may result in incomplete type generation.\nWe recommend you first run ${chalk.underline(
+    '$amplify push',
+  )}`,
+  INFO_AUTO_SELECTED_API: 'Using AppSync API:',
+  INFO_MSG_REMOVE_API_SUCCESS: 'removed project',
+  INFO_MESSAGE_CODEGEN_GENERATE_STARTED: 'Generating',
+  INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS: 'Code generated successfully and saved in file',
+  INFO_MESSAGE_DOWNLOADING_SCHEMA: 'Downloading the introspection schema',
+  INFO_MESSAGE_DOWNLOAD_SUCCESS: 'Downloaded the schema',
+  INFO_MESSAGE_DOWNLOAD_ERROR: 'Downloading schema failed',
+  INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
+  INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
+  INFO_MESSAGE_ADD_ERROR: 'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
+};

--- a/packages/amplify-codegen/src/errors/index.js
+++ b/packages/amplify-codegen/src/errors/index.js
@@ -1,0 +1,14 @@
+class AmplifyCodeGenNotSupportedError extends Error {}
+
+class AmplifyCodeGenNoAppSyncAPIAvailableError extends Error {}
+class AmplifyCodeGenNoProjectAvailableError extends Error {}
+
+class AmplifyCodeGenAPINotFoundError extends Error {}
+class AmplifyCodeGenAPIPendingPush extends Error {}
+module.exports = {
+  AmplifyCodeGenNotSupportedError,
+  AmplifyCodeGenNoAppSyncAPIAvailableError,
+  AmplifyCodeGenNoProjectAvailableError,
+  AmplifyCodeGenAPINotFoundError,
+  AmplifyCodeGenAPIPendingPush,
+};

--- a/packages/amplify-codegen/src/index.js
+++ b/packages/amplify-codegen/src/index.js
@@ -1,0 +1,29 @@
+const generateTypes = require('./commands/types');
+const generateStatements = require('./commands/statements');
+const generate = require('./commands/generateStatementsAndType');
+const add = require('./commands/add');
+const remove = require('./commands/remove');
+const configure = require('./commands/configure');
+const generateModels = require('./commands/models');
+const { isCodegenConfigured, switchToSDLSchema } = require('./utils');
+const prePushAddGraphQLCodegenHook = require('./callbacks/prePushAddCallback');
+const prePushUpdateGraphQLCodegenHook = require('./callbacks/prePushUpdateCallback');
+const postPushGraphQLCodegenHook = require('./callbacks/postPushCallback');
+const { executeAmplifyCommand, handleAmplifyEvent } = require('./amplify-plugin-index');
+
+module.exports = {
+  configure,
+  generate,
+  generateTypes,
+  generateStatements,
+  add,
+  remove,
+  prePushAddGraphQLCodegenHook,
+  prePushUpdateGraphQLCodegenHook,
+  postPushGraphQLCodegenHook,
+  isCodegenConfigured,
+  switchToSDLSchema,
+  executeAmplifyCommand,
+  handleAmplifyEvent,
+  generateModels,
+};

--- a/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
@@ -1,0 +1,30 @@
+const fs = require('fs-extra');
+const { dirname, relative } = require('path');
+
+const { AmplifyCodeGenAPINotFoundError } = require('../errors');
+const constants = require('../constants');
+
+async function downloadIntrospectionSchema(context, apiId, downloadLocation, region) {
+  const { amplify } = context;
+
+  if (!downloadLocation.endsWith('.graphql')) {
+    try {
+      const schema = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getIntrospectionSchema', {
+        apiId,
+        region,
+      });
+      const introspectionDir = dirname(downloadLocation);
+      fs.ensureDirSync(introspectionDir);
+      fs.writeFileSync(downloadLocation, schema, 'utf8');
+      return relative(amplify.getEnvInfo().projectPath, downloadLocation);
+    } catch (ex) {
+      if (ex.code === 'NotFoundException') {
+        throw new AmplifyCodeGenAPINotFoundError(constants.ERROR_APPSYNC_API_NOT_FOUND);
+      }
+      throw ex;
+    }
+  }
+  return downloadLocation;
+}
+
+module.exports = downloadIntrospectionSchema;

--- a/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
@@ -1,0 +1,19 @@
+const fs = require('fs-extra');
+const getFrontendHandler = require('./getFrontEndHandler');
+const generateIntrospectionSchema = require('./generateIntrospectionSchema');
+const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
+
+async function ensureIntrospectionSchema(context, schemaPath, apiConfig, region, forceDownloadSchema) {
+  const meta = context.amplify.getProjectMeta();
+  const { id, name } = apiConfig;
+  const isTransformedAPI = Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
+  if (isTransformedAPI && getFrontendHandler(context) === 'android') {
+    generateIntrospectionSchema(context, name);
+  } else if (schemaPath.endsWith('.json')) {
+    if (forceDownloadSchema || !fs.existsSync(schemaPath)) {
+      await downloadIntrospectionSchemaWithProgress(context, id, schemaPath, region);
+    }
+  }
+}
+
+module.exports = ensureIntrospectionSchema;

--- a/packages/amplify-codegen/src/utils/generateIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/generateIntrospectionSchema.js
@@ -1,0 +1,19 @@
+const gqlUtils = require('graphql/utilities');
+const path = require('path');
+const fs = require('fs-extra');
+const getSchemaDownloadLocation = require('./getSchemaDownloadLocation');
+const getSDLSchemaPath = require('./getSDLSchemaLocation');
+
+async function generateIntrospectionSchema(context, apiName) {
+  const appSyncDirectives = fs.readFileSync(path.normalize(path.join(__dirname, '..', '..', 'awsAppSyncDirectives.graphql')));
+  const { projectPath } = context.amplify.getEnvInfo();
+  const introspectionSchemaPath = path.join(projectPath, getSchemaDownloadLocation(context));
+  const sdlSchemaPath = path.join(projectPath, getSDLSchemaPath(apiName));
+  const schemaContent = fs.readFileSync(sdlSchemaPath, 'utf8');
+  const schema = gqlUtils.buildSchema(`${appSyncDirectives}\n${schemaContent}`);
+  const introspectionSchemaContent = gqlUtils.introspectionFromSchema(schema);
+  fs.ensureFileSync(introspectionSchemaPath);
+  fs.writeFileSync(introspectionSchemaPath, JSON.stringify(introspectionSchemaContent, null, 4));
+}
+
+module.exports = generateIntrospectionSchema;

--- a/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
+++ b/packages/amplify-codegen/src/utils/generateIntrospectionSchemaWithProgress.js
@@ -1,0 +1,22 @@
+const Ora = require('ora');
+
+const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
+const constants = require('../constants');
+
+async function downloadSchemaWithProgressSpinner(context, apiId, downloadLocation, region) {
+  if (!downloadLocation.endsWith('.graphql')) {
+    const downloadSpinner = new Ora(constants.INFO_MESSAGE_DOWNLOADING_SCHEMA);
+    downloadSpinner.start();
+    try {
+      const schemaLocation = await downloadIntrospectionSchema(context, apiId, downloadLocation, region);
+      downloadSpinner.succeed(constants.INFO_MESSAGE_DOWNLOAD_SUCCESS);
+      return schemaLocation;
+    } catch (e) {
+      downloadSpinner.fail(constants.INFO_MESSAGE_DOWNLOAD_ERROR);
+      throw e;
+    }
+  }
+  return downloadLocation;
+}
+
+module.exports = downloadSchemaWithProgressSpinner;

--- a/packages/amplify-codegen/src/utils/getAndroidResDir.js
+++ b/packages/amplify-codegen/src/utils/getAndroidResDir.js
@@ -1,0 +1,16 @@
+const getFrontendHandler = require('./getFrontEndHandler');
+
+const AMPLIFY_FRONTEND_ANDROID_CONFIG_KEY = 'android';
+function getAndroidResDir(context) {
+  // XXX: create a util function in CLI core and use it
+  const { amplify } = context;
+  const frontEndHandler = getFrontendHandler(context);
+  if (frontEndHandler !== 'android') {
+    throw new Error('Not an android project');
+  }
+  const config = amplify.getProjectConfig();
+  const frontendConfig = config[AMPLIFY_FRONTEND_ANDROID_CONFIG_KEY];
+  return frontendConfig.config.ResDir;
+}
+
+module.exports = getAndroidResDir;

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIDetails.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIDetails.js
@@ -1,0 +1,17 @@
+const getAppSyncAPIs = require('./getAppSyncAPIs');
+
+function getAppSyncAPIDetails(context) {
+  const meta = context.amplify.getProjectMeta();
+  const appSyncAPIs = getAppSyncAPIs(meta.api);
+  if (!appSyncAPIs.length) {
+    return [];
+  }
+  return appSyncAPIs.map(api => ({
+    name: api.name,
+    endpoint: api.output.GraphQLAPIEndpointOutput,
+    id: api.output.GraphQLAPIIdOutput,
+    authConfig: api.output.authConfig,
+  }));
+}
+
+module.exports = getAppSyncAPIDetails;

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfo.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfo.js
@@ -1,0 +1,57 @@
+const { AmplifyCodeGenAPINotFoundError } = require('../errors');
+const constants = require('../constants');
+
+async function getAppSyncAPIInfo(context, apiId, region) {
+  const { amplify } = context;
+  try {
+    const { graphqlApi } = await amplify.executeProviderUtils(context, 'awscloudformation', 'getGraphQLApiDetails', {
+      apiId,
+      region,
+    });
+
+    let apiKeys;
+
+    const additionalAuthenticationProviders = (graphqlApi.additionalAuthenticationProviders || [])
+      .map(provider => provider.authenticationType)
+      .filter(t => !!t);
+
+    if ([...additionalAuthenticationProviders, graphqlApi.authenticationType].includes('API_KEY')) {
+      apiKeys = await getAPIKeys(context, apiId, region);
+    }
+
+    // Transform the authentication options to Amplify meta format
+
+    return {
+      id: graphqlApi.apiId,
+      endpoint: graphqlApi.uris.GRAPHQL,
+      name: graphqlApi.name,
+      authConfig: {
+        defaultAuthentication: {
+          authenticationType: graphqlApi.authenticationType,
+        },
+        additionalAuthenticationProviders: graphqlApi.additionalAuthenticationProviders || null,
+        userPoolConfig: graphqlApi.userPoolConfig,
+        openIDConnectConfig: graphqlApi.openIDConnectConfig,
+      },
+      apiKeys,
+      region, // region override for externally added API
+    };
+  } catch (e) {
+    if (e.code === 'NotFoundException') {
+      throw new AmplifyCodeGenAPINotFoundError(constants.ERROR_APPSYNC_API_NOT_FOUND);
+    }
+    throw e;
+  }
+}
+
+async function getAPIKeys(context, apiId, region) {
+  const { amplify } = context;
+  const result = await amplify.executeProviderUtils(context, 'awscloudformation', 'getAppSyncApiKeys', {
+    apiId,
+    region,
+  });
+  const { apiKeys = [] } = result;
+  return apiKeys;
+}
+
+module.exports = getAppSyncAPIInfo;

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIs.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIs.js
@@ -1,0 +1,12 @@
+function getAppSyncAPIs(allAPIs = {}) {
+  const appSyncAPIs = Object.keys(allAPIs).reduce((acc, apiName) => {
+    const api = allAPIs[apiName];
+    if (api.service === 'AppSync') {
+      acc.push({ ...api, name: apiName });
+    }
+    return acc;
+  }, []);
+  return appSyncAPIs;
+}
+
+module.exports = getAppSyncAPIs;

--- a/packages/amplify-codegen/src/utils/getDocsgenPackage.js
+++ b/packages/amplify-codegen/src/utils/getDocsgenPackage.js
@@ -1,0 +1,10 @@
+const oldDocsgen = require('amplify-graphql-docs-generator'); // old graphql statements generator package
+const newDocsgen = require('@aws-amplify/graphql-docs-generator'); // migrated graphql statements generator package
+
+function getDocsgenPackage(isNewDocsgenPackage) {
+  return isNewDocsgenPackage ? newDocsgen : oldDocsgen;
+}
+
+module.exports = {
+    getDocsgenPackage,
+};

--- a/packages/amplify-codegen/src/utils/getFrontEndFramework.js
+++ b/packages/amplify-codegen/src/utils/getFrontEndFramework.js
@@ -1,0 +1,19 @@
+const getFrontendHandler = require('./getFrontEndHandler');
+
+function getFrontEndFramework(context, withoutInit = false, decoupleFrontend = '', decoupleFramework = '') {
+  const { amplify } = context;
+  let frontendHandler = decoupleFrontend;
+  if (!withoutInit) {
+    frontendHandler = getFrontendHandler(context);
+  }
+  if (frontendHandler === 'javascript') {
+    if (!withoutInit) {
+      const projectConfig = amplify.getProjectConfig();
+      return projectConfig.javascript.framework;
+    }
+    return decoupleFramework;
+  }
+  return '';
+}
+
+module.exports = getFrontEndFramework;

--- a/packages/amplify-codegen/src/utils/getFrontEndHandler.js
+++ b/packages/amplify-codegen/src/utils/getFrontEndHandler.js
@@ -1,0 +1,7 @@
+function getFrontendHandler(context) {
+  const { amplify } = context;
+  const projectConfig = amplify.getProjectConfig();
+  return projectConfig.frontend;
+}
+
+module.exports = getFrontendHandler;

--- a/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
+++ b/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
@@ -1,0 +1,11 @@
+const { join } = require('path');
+const globParent = require('glob-parent');
+
+function getGraphQLDocPath(frontend, graphQLDirectory, includePathGlob) {
+  if (frontend === 'android') {
+    return join(graphQLDirectory, 'com/amazonaws/amplify/generated/graphql');
+  }
+  return includePathGlob ? globParent(includePathGlob) : graphQLDirectory;
+}
+
+module.exports = getGraphQLDocPath;

--- a/packages/amplify-codegen/src/utils/getIncludePattern.js
+++ b/packages/amplify-codegen/src/utils/getIncludePattern.js
@@ -1,0 +1,35 @@
+const { join, dirname } = require('path');
+
+function getIncludePatterns(language, schemaLocation) {
+  let graphQLDirectory;
+  let graphQLExtension;
+  switch (language) {
+    case 'android':
+      graphQLDirectory = dirname(schemaLocation);
+      graphQLExtension = '*.graphql';
+      break;
+    case 'typescript':
+      graphQLDirectory = join('src', 'graphql');
+      graphQLExtension = '*.ts';
+      break;
+    case 'javascript':
+    case 'flow':
+      graphQLDirectory = join('src', 'graphql');
+      graphQLExtension = '*.js';
+      break;
+    case 'angular':
+      graphQLDirectory = join('src', 'graphql');
+      graphQLExtension = '*.graphql';
+      break;
+    default:
+      graphQLDirectory = 'graphql';
+      graphQLExtension = '*.graphql';
+  }
+
+  return {
+    graphQLDirectory,
+    graphQLExtension,
+  };
+}
+
+module.exports = getIncludePatterns;

--- a/packages/amplify-codegen/src/utils/getModelgenPackage.js
+++ b/packages/amplify-codegen/src/utils/getModelgenPackage.js
@@ -1,0 +1,10 @@
+const oldModelgen = require('amplify-codegen-appsync-model-plugin'); // old modelgen package
+const newModelgen = require('@aws-amplify/appsync-modelgen-plugin'); // migrated modelgen package
+
+function getModelgenPackage(isNewModelgenPackage) {
+  return isNewModelgenPackage ? newModelgen : oldModelgen;
+}
+
+module.exports = {
+  getModelgenPackage,
+};

--- a/packages/amplify-codegen/src/utils/getOutputFileName.js
+++ b/packages/amplify-codegen/src/utils/getOutputFileName.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+function getOutputFileName(inputFileName, target) {
+  const extensionMap = {
+    swift: 'swift',
+    typescript: 'ts',
+    flow: 'js',
+    angular: 'service.ts',
+  };
+  const folderMap = {
+    javascript: 'src',
+    typescript: 'src',
+    flow: 'src',
+    angular: 'src/app',
+  };
+
+  inputFileName = inputFileName || (target === 'angular' ? 'api' : 'API');
+  if (Object.keys(extensionMap).includes(target)) {
+    const fileExtension = extensionMap[target];
+    const ext = path.extname(inputFileName);
+    const baseName = inputFileName.substr(0, inputFileName.length - ext.length);
+    const filename = inputFileName.includes(fileExtension) ? inputFileName : `${baseName}.${fileExtension}`;
+    const defaultPath = Object.keys(folderMap).includes(target) ? folderMap[target] : '';
+    return ['API', 'api'].includes(inputFileName) ? path.join(defaultPath, filename) : filename;
+  }
+  return inputFileName;
+}
+
+module.exports = getOutputFileName;

--- a/packages/amplify-codegen/src/utils/getProjectAWSRegion.js
+++ b/packages/amplify-codegen/src/utils/getProjectAWSRegion.js
@@ -1,0 +1,7 @@
+function getProjectAWSRegion(context) {
+  const projectMeta = context.amplify.getProjectMeta();
+  const { awscloudformation } = projectMeta.providers;
+  return awscloudformation.Region;
+}
+
+module.exports = getProjectAWSRegion;

--- a/packages/amplify-codegen/src/utils/getSDLSchemaLocation.js
+++ b/packages/amplify-codegen/src/utils/getSDLSchemaLocation.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+function getSDLSchemaLocation(apiName) {
+  return path.join('amplify', 'backend', 'api', apiName, 'build', 'schema.graphql');
+}
+
+module.exports = getSDLSchemaLocation;

--- a/packages/amplify-codegen/src/utils/getSchemaDownloadLocation.js
+++ b/packages/amplify-codegen/src/utils/getSchemaDownloadLocation.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const { pathManager } = require('amplify-cli-core');
+
+const getAndroidResDir = require('./getAndroidResDir');
+const getFrontEndHandler = require('./getFrontEndHandler');
+
+function isSubDirectory(parent, pathToCheck) {
+  const relative = path.relative(parent, pathToCheck);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+function getSchemaDownloadLocation(context) {
+  let downloadDir;
+  try {
+    const androidResDir = getAndroidResDir(context);
+    downloadDir = path.join(path.dirname(androidResDir), 'graphql');
+  } catch (e) {
+    const projectConfig = context.amplify.getProjectConfig();
+    const sourceDir =
+      projectConfig.javascript && projectConfig.javascript.config && projectConfig.javascript.config.SourceDir
+        ? path.normalize(projectConfig.javascript.config.SourceDir)
+        : 'src';
+    const frontEnd = getFrontEndHandler(context);
+    const outputPath = frontEnd === 'javascript' ? sourceDir : '';
+    downloadDir = path.join(outputPath, 'graphql');
+  }
+
+  const projectRoot = pathManager.findProjectRoot();
+  // Downloaded schema should always be inside the project dir so the project is self contained
+  downloadDir = isSubDirectory(projectRoot, path.resolve(downloadDir)) ? downloadDir : path.join(projectRoot, downloadDir);
+  return path.join(downloadDir, 'schema.json');
+}
+
+module.exports = getSchemaDownloadLocation;

--- a/packages/amplify-codegen/src/utils/getTypesgenPackage.js
+++ b/packages/amplify-codegen/src/utils/getTypesgenPackage.js
@@ -1,0 +1,10 @@
+const oldTypesgen = require('amplify-graphql-types-generator'); // old types generator package for GraphQL
+const newTypesgen = require('@aws-amplify/graphql-types-generator'); // migrated types generator package for GraphQL
+
+function getTypesgenPackage(isNewTypesgenPackage) {
+  return isNewTypesgenPackage ? newTypesgen : oldTypesgen;
+}
+
+module.exports = {
+    getTypesgenPackage,
+};

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -1,0 +1,43 @@
+const getFrontEndHandler = require('./getFrontEndHandler');
+const getFrontEndFramework = require('./getFrontEndFramework');
+const getAppSyncAPIDetails = require('./getAppSyncAPIDetails');
+const getOutputFileName = require('./getOutputFileName');
+const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
+const getSchemaDownloadLocation = require('./getSchemaDownloadLocation');
+const getIncludePattern = require('./getIncludePattern');
+const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+const getProjectAwsRegion = require('./getProjectAWSRegion');
+const getGraphQLDocPath = require('./getGraphQLDocPath');
+const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
+const isAppSyncApiPendingPush = require('./isAppSyncApiPendingPush');
+const updateAmplifyMeta = require('./updateAmplifyMeta');
+const isCodegenConfigured = require('./isCodegenConfigured');
+const getSDLSchemaLocation = require('./getSDLSchemaLocation');
+const switchToSDLSchema = require('./switchToSDLSchema');
+const ensureIntrospectionSchema = require('./ensureIntrospectionSchema');
+const getModelgenPackage = require('./getModelgenPackage');
+const getDocsgenPackage = require('./getDocsgenPackage');
+const getTypesgenPackage = require('./getTypesgenPackage');
+
+module.exports = {
+  getAppSyncAPIDetails,
+  getFrontEndHandler,
+  getFrontEndFramework,
+  getSchemaDownloadLocation,
+  getOutputFileName,
+  downloadIntrospectionSchema,
+  downloadIntrospectionSchemaWithProgress,
+  getIncludePattern,
+  getAppSyncAPIInfo,
+  getProjectAwsRegion,
+  getGraphQLDocPath,
+  isAppSyncApiPendingPush,
+  updateAmplifyMeta,
+  isCodegenConfigured,
+  getSDLSchemaLocation,
+  switchToSDLSchema,
+  ensureIntrospectionSchema,
+  getModelgenPackage,
+  getDocsgenPackage,
+  getTypesgenPackage
+};

--- a/packages/amplify-codegen/src/utils/input-params-manager.js
+++ b/packages/amplify-codegen/src/utils/input-params-manager.js
@@ -1,0 +1,71 @@
+const constants = require('../constants');
+
+function normalizeInputParams(context) {
+  let inputParams;
+  if (context.exeInfo && context.exeInfo.inputParams) {
+    if (context.exeInfo.inputParams[constants.Label]) {
+      inputParams = context.exeInfo.inputParams[constants.Label];
+    } else {
+      for (let i = 0; i < constants.Aliases.length; i++) {
+        const alias = constants.Aliases[i];
+        if (context.exeInfo.inputParams[alias]) {
+          inputParams = context.exeInfo.inputParams[alias];
+          break;
+        }
+      }
+    }
+  } else {
+    context.exeInfo = { inputParams: {} };
+  }
+  if (inputParams) {
+    const normalizedInputParams = {};
+    Object.keys(inputParams).forEach(key => {
+      const normalizedKey = normalizeKey(key);
+      const normalizedValue = normalizeValue(normalizedKey, inputParams[key]);
+      normalizedInputParams[normalizedKey] = normalizedValue;
+    });
+    context.exeInfo.inputParams[constants.Label] = normalizedInputParams;
+  }
+}
+
+function normalizeKey(key) {
+  if (['generateCode', 'generate-code', 'shouldGenerateCode', 'should-generate-code'].includes(key)) {
+    key = 'generateCode';
+  }
+  if (
+    [
+      'generateDocs',
+      'generate-docs',
+      'shouldGenerateDocs',
+      'should-generate-docs',
+      'generateStatements',
+      'generate-statements',
+      'shouldGenerateStatements',
+      'should-generate-statements',
+    ].includes(key)
+  ) {
+    key = 'generateDocs';
+  }
+  if (['targetLanguage', 'target-language', 'codeLanguage', 'code-language'].includes(key)) {
+    key = 'targetLanguage';
+  }
+  if (['includePattern', 'include-pattern', 'fileNamePattern', 'file-name-pattern'].includes(key)) {
+    key = 'includePattern';
+  }
+  if (['generatedFileName', 'generated-file-name'].includes(key)) {
+    key = 'generatedFileName';
+  }
+
+  return key;
+}
+
+function normalizeValue(key, value) {
+  if (key === 'targetLanguage') {
+    value = value.toLowerCase();
+  }
+  return value;
+}
+
+module.exports = {
+  normalizeInputParams,
+};

--- a/packages/amplify-codegen/src/utils/isAppSyncApiPendingPush.js
+++ b/packages/amplify-codegen/src/utils/isAppSyncApiPendingPush.js
@@ -1,0 +1,16 @@
+async function isAppSyncApiPendingPush(context) {
+  const resourceStatus = await context.amplify.getResourceStatus('api');
+  const appSyncResources = [];
+  ['resourcesToBeCreated', 'resourcesToBeUpdated'].forEach(opName => {
+    const status = resourceStatus[opName];
+    status.forEach(resource => {
+      if (resource.service === 'AppSync') {
+        appSyncResources.push(resource);
+      }
+    });
+  });
+
+  return appSyncResources.length > 0;
+}
+
+module.exports = isAppSyncApiPendingPush;

--- a/packages/amplify-codegen/src/utils/isCodegenConfigured.js
+++ b/packages/amplify-codegen/src/utils/isCodegenConfigured.js
@@ -1,0 +1,14 @@
+const loadConfig = require('../codegen-config');
+
+function isCodegenConfigured(context, apiName) {
+  const config = loadConfig(context);
+  const projects = config.getProjects();
+  if (apiName) {
+    const isConfigured = projects.find(p => p.projectName === apiName);
+    return isConfigured !== undefined;
+  }
+
+  return projects.length > 0;
+}
+
+module.exports = isCodegenConfigured;

--- a/packages/amplify-codegen/src/utils/switchToSDLSchema.js
+++ b/packages/amplify-codegen/src/utils/switchToSDLSchema.js
@@ -1,0 +1,24 @@
+const loadConfig = require('../codegen-config');
+const getSDLSchemaPath = require('./getSDLSchemaLocation');
+const getFrontendHandler = require('./getFrontEndHandler');
+
+function switchToSDLSchema(context, apiName) {
+  if (getFrontendHandler(context) === 'android') {
+    return false;
+  }
+  const config = loadConfig(context);
+  const projects = config.getProjects();
+  const project = projects.find(p => p.projectName === apiName);
+  if (project) {
+    if (project.schema.endsWith('.json')) {
+      project.schema = getSDLSchemaPath(apiName);
+      config.addProject(project);
+      config.save();
+      return true;
+    }
+    return false;
+  }
+  throw new Error(`Codegen is not configured with API ${apiName}`);
+}
+
+module.exports = switchToSDLSchema;

--- a/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
+++ b/packages/amplify-codegen/src/utils/updateAmplifyMeta.js
@@ -1,0 +1,43 @@
+module.exports = async (context, apiDetails) => {
+  const fs = context.filesystem;
+
+  const appsyncMetadata = {
+    service: 'AppSync',
+    output: {
+      authConfig: apiDetails.authConfig,
+      GraphQLAPIIdOutput: apiDetails.id,
+      GraphQLAPIEndpointOutput: apiDetails.endpoint,
+      name: apiDetails.name,
+    },
+    lastPushTimeStamp: new Date(),
+  };
+  if (apiDetails.region) {
+    appsyncMetadata.output.region = apiDetails.region;
+  }
+  if (apiDetails.apiKeys && apiDetails.apiKeys.length) {
+    // eslint-disable-next-line prefer-destructuring
+    appsyncMetadata.output.GraphQLAPIKeyOutput = apiDetails.apiKeys[0].id;
+  }
+
+  const { amplifyMeta } = context.amplify.getProjectDetails();
+
+  if (!amplifyMeta.api) {
+    amplifyMeta.api = {};
+  }
+
+  amplifyMeta.api[apiDetails.name] = appsyncMetadata;
+
+  const amplifyMetaFilePath = context.amplify.pathManager.getAmplifyMetaFilePath();
+  fs.write(amplifyMetaFilePath, JSON.stringify(amplifyMeta, null, 4));
+
+  const currentAmplifyMetaFilePath = context.amplify.pathManager.getCurrentAmplifyMetaFilePath();
+  const currentAmplifyMeta = context.amplify.readJsonFile(currentAmplifyMetaFilePath);
+  if (!currentAmplifyMeta.api) {
+    currentAmplifyMeta.api = {};
+  }
+  currentAmplifyMeta.api[apiDetails.name] = appsyncMetadata;
+  fs.write(currentAmplifyMetaFilePath, JSON.stringify(currentAmplifyMeta, null, 4));
+
+  await context.amplify.onCategoryOutputsChange(context);
+  context.print.success(`Successfully added API ${apiDetails.name} to your Amplify project`);
+};

--- a/packages/amplify-codegen/src/walkthrough/add.js
+++ b/packages/amplify-codegen/src/walkthrough/add.js
@@ -1,0 +1,103 @@
+const { join } = require('path');
+const askCodeGenTargetLanguage = require('./questions/languageTarget');
+const askCodeGenQueryFilePattern = require('./questions/queryFilePattern');
+const askTargetFileName = require('./questions/generatedFileName');
+const askShouldGenerateCode = require('./questions/generateCode');
+const askShouldGenerateDocs = require('./questions/generateDocs');
+const askMaxDepth = require('./questions/maxDepth');
+const { normalizeInputParams } = require('../utils/input-params-manager');
+const constants = require('../constants');
+const { getOutputFileName } = require('../utils');
+
+const { getFrontEndHandler, getSchemaDownloadLocation, getIncludePattern, getGraphQLDocPath } = require('../utils');
+
+const DEFAULT_EXCLUDE_PATTERNS = ['./amplify/**'];
+
+async function addWalkThrough(context, skip = [], withoutInit, decoupleFrontend, decoupleFramework) {
+  let inputParams;
+  let yesFlag = false;
+  if (context.exeInfo && context.exeInfo.inputParams) {
+    normalizeInputParams(context);
+    inputParams = context.exeInfo.inputParams[constants.Label];
+    yesFlag = context.exeInfo.inputParams.yes;
+  }
+
+  let frontend = decoupleFrontend;
+  let schemaLocation = '';
+
+  if (frontend === 'android') {
+    schemaLocation = './app/src/main/graphql/schema.json';
+  } else if (frontend === 'ios') {
+    schemaLocation = './graphql/schema.json';
+  } else if (frontend === 'javascript') {
+    schemaLocation = './src/graphql/schema.json';
+  } else {
+    schemaLocation = './src/graphql/schema.json';
+  }
+
+  if (!withoutInit) {
+    frontend = getFrontEndHandler(context);
+    schemaLocation = getSchemaDownloadLocation(context);
+  }
+  const answers = {
+    excludePattern: DEFAULT_EXCLUDE_PATTERNS,
+    schemaLocation,
+  };
+
+  let targetLanguage = 'android';
+
+  if (frontend !== 'android') {
+    if (!skip.includes('targetLanguage')) {
+      answers.target = await determineValue(inputParams, yesFlag, 'targetLanguage', 'javascript', () =>
+        askCodeGenTargetLanguage(context, undefined, withoutInit, decoupleFrontend, decoupleFramework)
+      );
+      targetLanguage = answers.target;
+    }
+  }
+
+  const includePatternDefault = getIncludePattern(targetLanguage, schemaLocation);
+  const includePathGlob = join(includePatternDefault.graphQLDirectory, '**', includePatternDefault.graphQLExtension);
+  const docsFilePathDefault = includePatternDefault.graphQLDirectory;
+
+  if (!skip.includes('includePattern')) {
+    answers.includePattern = await determineValue(inputParams, yesFlag, 'includePattern', [includePathGlob], () =>
+      askCodeGenQueryFilePattern([includePathGlob])
+    );
+  }
+  if (!skip.includes('shouldGenerateDocs')) {
+    answers.shouldGenerateDocs = await determineValue(inputParams, yesFlag, 'generateDocs', true, () => askShouldGenerateDocs());
+    answers.docsFilePath = getGraphQLDocPath(frontend, docsFilePathDefault, answers.includePattern);
+  }
+
+  if (answers.shouldGenerateDocs && !skip.includes('maxDepth')) {
+    answers.maxDepth = await determineValue(inputParams, yesFlag, 'maxDepth', true, askMaxDepth);
+  }
+
+  if (!(frontend === 'android' || answers.target === 'javascript')) {
+    if (!skip.includes('generatedFileName')) {
+      const defaultValue = getOutputFileName('API', answers.target || '');
+      answers.generatedFileName = await determineValue(inputParams, yesFlag, 'generatedFileName', defaultValue, () =>
+        askTargetFileName('API', answers.target || '')
+      );
+    }
+    if (!skip.includes('shouldGenerateCode')) {
+      answers.shouldGenerateCode = await determineValue(inputParams, yesFlag, 'generateCode', true, () => askShouldGenerateCode());
+    }
+  }
+
+  return answers;
+}
+
+async function determineValue(inputParams, yesFlag, propertyName, defaultValue, askFunction) {
+  let result;
+  if (inputParams && inputParams.hasOwnProperty(propertyName)) {
+    result = inputParams[propertyName];
+  } else if (yesFlag && defaultValue !== undefined) {
+    result = defaultValue;
+  } else {
+    result = await askFunction();
+  }
+  return result;
+}
+
+module.exports = addWalkThrough;

--- a/packages/amplify-codegen/src/walkthrough/changeAppSyncRegions.js
+++ b/packages/amplify-codegen/src/walkthrough/changeAppSyncRegions.js
@@ -1,0 +1,15 @@
+const askShouldTryWithDifferentRegion = require('./questions/changeRegion');
+const changeRegion = require('./questions/selectRegions');
+
+async function changeAppSyncRegion(context, currentRegion) {
+  const regions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getRegionMappings');
+
+  const shouldRetry = await askShouldTryWithDifferentRegion();
+  const region = shouldRetry && (await changeRegion(regions, currentRegion));
+  return {
+    shouldRetry,
+    region,
+  };
+}
+
+module.exports = changeAppSyncRegion;

--- a/packages/amplify-codegen/src/walkthrough/configure.js
+++ b/packages/amplify-codegen/src/walkthrough/configure.js
@@ -1,0 +1,63 @@
+const { join } = require('path');
+
+const askForGraphQLAPIResource = require('./questions/selectProject');
+const askCodeGenTargetLanguage = require('./questions/languageTarget');
+const askCodeGeneQueryFilePattern = require('./questions/queryFilePattern');
+const askTargetFileName = require('./questions/generatedFileName');
+const askMaxDepth = require('./questions/maxDepth');
+const { getFrontEndHandler, getIncludePattern, getGraphQLDocPath } = require('../utils/');
+
+function deepCopy(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+async function configureProjectWalkThrough(context, amplifyConfig, withoutInit = false) {
+  const projects = amplifyConfig.map(cfg => ({
+    name: cfg.projectName,
+    value: cfg.amplifyExtension.graphQLApiId,
+  }));
+  let apiId;
+  if (!withoutInit) {
+    apiId = await askForGraphQLAPIResource(context, projects);
+  }
+
+  let selectedProjectConfig;
+  if (!withoutInit) {
+    selectedProjectConfig = deepCopy(amplifyConfig.find(project => project.amplifyExtension.graphQLApiId === apiId));
+  } else {
+    selectedProjectConfig = deepCopy(amplifyConfig.find(project => project.projectName === 'Codegen Project'));
+  }
+
+  let frontend;
+  let framework;
+  if (!withoutInit) {
+    frontend = getFrontEndHandler(context);
+  } else {
+    ({ frontend } = selectedProjectConfig.amplifyExtension);
+    ({ framework } = selectedProjectConfig.amplifyExtension);
+  }
+
+  const { amplifyExtension } = selectedProjectConfig;
+  let targetLanguage = 'android';
+
+  if (frontend !== 'android') {
+    targetLanguage = await askCodeGenTargetLanguage(context, amplifyExtension.codeGenTarget, withoutInit, frontend, framework);
+  }
+
+  const includePatternDefault = getIncludePattern(targetLanguage, selectedProjectConfig.schema);
+  const includePathGlob = join(includePatternDefault.graphQLDirectory, '**', includePatternDefault.graphQLExtension);
+  const includePattern = targetLanguage === amplifyExtension.codeGenTarget ? selectedProjectConfig.includes : [includePathGlob];
+
+  selectedProjectConfig.includes = await askCodeGeneQueryFilePattern(includePattern);
+
+  if (!(frontend === 'android' || targetLanguage === 'javascript')) {
+    amplifyExtension.generatedFileName = await askTargetFileName(amplifyExtension.generatedFileName || 'API', targetLanguage);
+  } else {
+    amplifyExtension.generatedFileName = '';
+  }
+  amplifyExtension.codeGenTarget = targetLanguage;
+  amplifyExtension.docsFilePath = getGraphQLDocPath(frontend, includePatternDefault.graphQLDirectory, selectedProjectConfig.includes)
+  amplifyExtension.maxDepth = await askMaxDepth(amplifyExtension.maxDepth);
+
+  return selectedProjectConfig;
+}
+module.exports = configureProjectWalkThrough;

--- a/packages/amplify-codegen/src/walkthrough/questions/apiTarget.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/apiTarget.js
@@ -1,0 +1,24 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askAppSyncAPITarget(context, apis, selectedApi = null) {
+  const choices = apis.map(api => ({ name: api.name, value: api.id }));
+  if (apis.length === 1) {
+    return apis[0].id;
+  }
+
+  const answer = await inquirer.prompt([
+    {
+      name: 'apiId',
+      message: constants.PROMPT_MSG_API_LIST,
+      type: 'list',
+      choices,
+      default: selectedApi || null,
+    },
+  ]);
+
+  return answer.apiId;
+}
+
+module.exports = askAppSyncAPITarget;

--- a/packages/amplify-codegen/src/walkthrough/questions/changeRegion.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/changeRegion.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askShouldChangeRegion() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'changeRegion',
+      message: constants.PROMPT_MSG_CHANGE_REGION,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.changeRegion;
+}
+
+module.exports = askShouldChangeRegion;

--- a/packages/amplify-codegen/src/walkthrough/questions/generateCode.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/generateCode.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askGenerateCode() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'confirmGenerateCode',
+      message: constants.PROMPT_MSG_GENERATE_CODE,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.confirmGenerateCode;
+}
+
+module.exports = askGenerateCode;

--- a/packages/amplify-codegen/src/walkthrough/questions/generateDocs.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/generateDocs.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askGenerateDocs() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'confirmGenerateOperations',
+      message: constants.PROMPT_MSG_GENERATE_OPS,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.confirmGenerateOperations;
+}
+
+module.exports = askGenerateDocs;

--- a/packages/amplify-codegen/src/walkthrough/questions/generatedFileName.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/generatedFileName.js
@@ -1,0 +1,19 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+const { getOutputFileName } = require('../../utils');
+
+async function askGeneratedFileName(name, target) {
+  const answers = await inquirer.prompt([
+    {
+      name: 'generatedFileName',
+      type: 'input',
+      message: constants.PROMPT_MSG_FILE_NAME,
+      default: getOutputFileName(name, target),
+    },
+  ]);
+  return answers.generatedFileName;
+}
+
+module.exports = askGeneratedFileName;

--- a/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
@@ -1,0 +1,43 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+const { AmplifyCodeGenNotSupportedError } = require('../../errors');
+const { getFrontEndHandler, getFrontEndFramework } = require('../../utils');
+
+const frontEndToTargetMappings = {
+  ios: ['swift'],
+  javascript: ['javascript', 'typescript', 'flow'],
+  angular: ['angular', 'typescript'],
+};
+
+async function askCodeGenTargetLanguage(context, target, withoutInit = false, decoupleFrontend = '', decoupleFramework = '') {
+  let frontend = decoupleFrontend;
+  if (!withoutInit) {
+    frontend = getFrontEndHandler(context);
+  }
+  const isAngular =
+    frontend === 'javascript' && getFrontEndFramework(context, withoutInit, decoupleFrontend, decoupleFramework) === 'angular';
+  const isIonic = frontend === 'javascript' && getFrontEndFramework(context, withoutInit, decoupleFrontend, decoupleFramework) === 'ionic';
+  const targetLanguage = isAngular || isIonic ? 'angular' : frontend;
+  const targetMapping = frontEndToTargetMappings[targetLanguage];
+  if (!targetMapping || !targetMapping.length) {
+    throw new AmplifyCodeGenNotSupportedError(`${frontend} ${constants.ERROR_CODEGEN_TARGET_NOT_SUPPORTED}`);
+  }
+
+  if (targetMapping.length === 1) {
+    return targetMapping[0];
+  }
+
+  const answer = await inquirer.prompt([
+    {
+      name: 'target',
+      type: 'list',
+      message: constants.PROMPT_MSG_CODEGEN_TARGET,
+      choices: targetMapping,
+      default: target || null,
+    },
+  ]);
+  return answer.target;
+}
+
+module.exports = askCodeGenTargetLanguage;

--- a/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
@@ -1,0 +1,22 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askMaxDepth(defaultDepth = 2) {
+  const answer = await inquirer.prompt([
+    {
+      name: 'maxDepth',
+      message: constants.PROMPT_MSG_MAX_DEPTH,
+      type: 'input',
+      validate: val => {
+        const num = Number.parseInt(val, 10);
+        return Number.isInteger(num) && Number.isFinite(num) && num > 0 ? true : constants.ERROR_MSG_MAX_DEPTH;
+      },
+      default: defaultDepth,
+    },
+  ]);
+
+  return Number.parseInt(answer.maxDepth, 10);
+}
+
+module.exports = askMaxDepth;

--- a/packages/amplify-codegen/src/walkthrough/questions/queryFilePattern.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/queryFilePattern.js
@@ -1,0 +1,17 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askCodeGenQueryFilePattern(includePattern = ['**/*.graphql']) {
+  const answers = await inquirer.prompt([
+    {
+      name: 'includePattern',
+      type: 'input',
+      message: constants.PROMPT_MSG_GQL_FILE_PATTERN,
+      default: includePattern.join(','),
+    },
+  ]);
+  return answers.includePattern.split(',').map(pattern => pattern.trim());
+}
+
+module.exports = askCodeGenQueryFilePattern;

--- a/packages/amplify-codegen/src/walkthrough/questions/selectFramework.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/selectFramework.js
@@ -1,0 +1,15 @@
+const inquirer = require('inquirer');
+
+async function askForFramework(frameworks) {
+  const selectFramework = {
+    type: 'list',
+    name: 'selectedFramework',
+    message: 'What javascript framework are you using',
+    choices: frameworks,
+    default: 'react',
+  };
+  const answer = await inquirer.prompt(selectFramework);
+  return answer.selectedFramework;
+}
+
+module.exports = askForFramework;

--- a/packages/amplify-codegen/src/walkthrough/questions/selectFrontend.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/selectFrontend.js
@@ -1,0 +1,15 @@
+const inquirer = require('inquirer');
+
+async function askForFrontend(frontends) {
+  const selectFrontend = {
+    type: 'list',
+    name: 'selectedFrontend',
+    message: "Choose the type of app that you're building",
+    choices: frontends,
+    default: 'javascript',
+  };
+  const answer = await inquirer.prompt(selectFrontend);
+  return answer.selectedFrontend;
+}
+
+module.exports = askForFrontend;

--- a/packages/amplify-codegen/src/walkthrough/questions/selectProject.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/selectProject.js
@@ -1,0 +1,24 @@
+const inquirer = require('inquirer');
+
+const { AmplifyCodeGenNoAppSyncAPIAvailableError } = require('../../errors');
+const constants = require('../../constants');
+
+async function askForProject(context, projects) {
+  if (projects.length === 0) {
+    throw new AmplifyCodeGenNoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
+  }
+  if (projects.length === 1) {
+    return projects[0].value;
+  }
+  const answer = await inquirer.prompt([
+    {
+      name: 'projectName',
+      message: constants.PROMPT_MSG_SELECT_PROJECT,
+      type: 'list',
+      choices: projects,
+    },
+  ]);
+  return answer.projectName;
+}
+
+module.exports = askForProject;

--- a/packages/amplify-codegen/src/walkthrough/questions/selectRegions.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/selectRegions.js
@@ -1,0 +1,22 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function selectRegions(regions, currentRegion) {
+  const regionMap = Object.keys(regions).map(r => ({
+    value: r,
+    name: regions[r],
+  }));
+  const answer = await inquirer.prompt([
+    {
+      name: 'region',
+      type: 'list',
+      message: constants.PROMPT_MSG_SELECT_REGION,
+      choices: regionMap,
+      default: currentRegion || null,
+    },
+  ]);
+  return answer.region;
+}
+
+module.exports = selectRegions;

--- a/packages/amplify-codegen/src/walkthrough/questions/updateCode.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/updateCode.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askUpdateCode() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'confirmUpdateCode',
+      message: constants.PROMPT_MSG_UPDATE_CODE,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.confirmUpdateCode;
+}
+
+module.exports = askUpdateCode;

--- a/packages/amplify-codegen/src/walkthrough/questions/updateDocs.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/updateDocs.js
@@ -1,0 +1,18 @@
+const inquirer = require('inquirer');
+
+const constants = require('../../constants');
+
+async function askUpdateDocs() {
+  const answer = await inquirer.prompt([
+    {
+      name: 'confirmUpdateDocs',
+      message: constants.PROMPT_MSG_UPDATE_STATEMENTS,
+      type: 'confirm',
+      default: true,
+    },
+  ]);
+
+  return answer.confirmUpdateDocs;
+}
+
+module.exports = askUpdateDocs;

--- a/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/postPushCallback.test.js
@@ -1,0 +1,120 @@
+const path = require('path');
+const { pathManager } = require('amplify-cli-core');
+const loadConfig = require('../../src/codegen-config');
+const { downloadIntrospectionSchema, getAppSyncAPIDetails, getSchemaDownloadLocation } = require('../../src/utils');
+const generateStatements = require('../../src/commands/statements');
+const generateTypes = require('../../src/commands/types');
+const postPushCallback = require('../../src/callbacks/postPushCallback');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+};
+const MOCK_PATH_MANAGER_PROJECT_ROOT = '/project';
+
+jest.mock('amplify-cli-core');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/utils');
+jest.mock('../../src/commands/statements');
+jest.mock('../../src/commands/types');
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      }),
+    },
+    pathManager: {
+      findProjectRoot: () => MOCK_PATH_MANAGER_PROJECT_ROOT,
+    },
+  };
+});
+
+const MOCK_PROJECT_NAME = 'MOCK_PROJECT';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_API_ENDPOINT = 'MOCK_API_ENDPOINT';
+
+const MOCK_SELECTED_PROJECT = {
+  projectName: MOCK_PROJECT_NAME,
+  id: MOCK_API_ID,
+  endpoint: MOCK_API_ENDPOINT,
+};
+const MOCK_PROJECTS = [MOCK_SELECTED_PROJECT];
+const MOCK_SCHEMA_DOWNLOAD_LOCATION = 'MOCK_SCHEMA_DOWNLOAD_MOCK_SCHEMA_DOWNLOAD_LOCATION';
+const MOCK_GRAPHQL_CONFIG = {
+  gqlConfig: {
+    amplifyExtension: {},
+    projectName: MOCK_PROJECT_NAME,
+  },
+  shouldGenerateDocs: true,
+};
+
+const LOAD_CONFIG_METHODS = {
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+describe('Callback - Post Push update AppSync API', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    loadConfig.mockReturnValue(LOAD_CONFIG_METHODS);
+    getAppSyncAPIDetails.mockReturnValue(MOCK_PROJECTS);
+    getSchemaDownloadLocation.mockReturnValue(MOCK_SCHEMA_DOWNLOAD_LOCATION);
+  });
+
+  it('should update project configuration and generate code', async () => {
+    await postPushCallback(MOCK_CONTEXT, { ...MOCK_GRAPHQL_CONFIG });
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(getAppSyncAPIDetails).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(getSchemaDownloadLocation).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(downloadIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      MOCK_API_ID,
+      path.join(MOCK_PATH_MANAGER_PROJECT_ROOT, MOCK_SCHEMA_DOWNLOAD_LOCATION),
+    );
+    expect(LOAD_CONFIG_METHODS.addProject).toHaveBeenCalled();
+    const newProject = LOAD_CONFIG_METHODS.addProject.mock.calls[0][0];
+    expect(newProject).toEqual({
+      ...MOCK_GRAPHQL_CONFIG.gqlConfig,
+      amplifyExtension: {
+        ...MOCK_GRAPHQL_CONFIG.gqlConfig.amplifyExtension,
+      },
+      schema: path.join(MOCK_PATH_MANAGER_PROJECT_ROOT, MOCK_SCHEMA_DOWNLOAD_LOCATION),
+    });
+    expect(generateTypes).toHaveBeenCalledTimes(1);
+    expect(generateStatements).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not update schema location when updating existing API', async () => {
+    const PREV_DOWNLOAD_LOCATION = 'src/graphql/schema.json';
+    await postPushCallback(MOCK_CONTEXT, {
+      gqlConfig: {
+        ...MOCK_GRAPHQL_CONFIG.gqlConfig,
+        schema: PREV_DOWNLOAD_LOCATION,
+      },
+    });
+    expect(loadConfig).not.toHaveBeenCalledWith();
+    expect(getAppSyncAPIDetails).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(getSchemaDownloadLocation).not.toHaveBeenCalled();
+    expect(downloadIntrospectionSchema).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, PREV_DOWNLOAD_LOCATION);
+    expect(LOAD_CONFIG_METHODS.addProject).not.toHaveBeenCalled();
+  });
+
+  it('should not save codegen config when graphQLConfig is missing', async () => {
+    await postPushCallback(MOCK_CONTEXT, null);
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+    expect(getSchemaDownloadLocation).not.toHaveBeenCalled();
+    expect(downloadIntrospectionSchema).not.toHaveBeenCalled();
+    expect(LOAD_CONFIG_METHODS.addProject).not.toHaveBeenCalled();
+    expect(generateTypes).not.toBeCalled();
+    expect(generateStatements).not.toBeCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/callbacks/prePushAddCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/prePushAddCallback.test.js
@@ -1,0 +1,79 @@
+const addWalkthrough = require('../../src/walkthrough/add');
+const askShouldGenerateCode = require('../../src/walkthrough/questions/generateCode');
+
+const prePushAddCallback = require('../../src/callbacks/prePushAddCallback');
+const prePushUpdateCallback = require('../../src/callbacks/prePushUpdateCallback');
+const { isCodegenConfigured } = require('../../src/utils');
+
+const MOCK_CONTEXT = {
+  exeInfo: {},
+  print: {
+    info: jest.fn(),
+  },
+};
+jest.mock('../../src/walkthrough/add');
+jest.mock('../../src/walkthrough/questions/generateCode');
+jest.mock('../../src/utils');
+jest.mock('../../src/callbacks/prePushUpdateCallback');
+
+jest.mock('graphql-transformer-core');
+jest.mock('amplify-cli-core', () => ({
+  pathManager: {
+    getBackendDirPath: () => 'backend',
+  },
+}));
+
+const MOCK_RESOURCE_NAME = 'MOCK_API_NAME';
+const MOCK_INCLUDE_PATTERN = 'MOCK_INCLUDE';
+const MOCK_EXCLUDE_PATTERN = 'MOCK_EXCLUDE';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_DOCS_FILE_PATH = 'MOCK_DOCS_FILE_PATH';
+const SHOULD_GENERATE_DOC = 'YES';
+
+const MOCK_ANSWERS = {
+  includePattern: MOCK_INCLUDE_PATTERN,
+  excludePattern: MOCK_EXCLUDE_PATTERN,
+  target: MOCK_TARGET,
+  generatedFileName: MOCK_GENERATED_FILE_NAME,
+  docsFilePath: MOCK_DOCS_FILE_PATH,
+  shouldGenerateDocs: SHOULD_GENERATE_DOC,
+};
+
+describe('callback - prePushAddCallback', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    addWalkthrough.mockReturnValue(MOCK_ANSWERS);
+    askShouldGenerateCode.mockReturnValue(true);
+    isCodegenConfigured.mockReturnValue(false);
+  });
+
+  it('should walkthrough add questions', async () => {
+    const { gqlConfig, shouldGenerateDocs } = await prePushAddCallback(MOCK_CONTEXT, MOCK_RESOURCE_NAME);
+
+    expect(gqlConfig).toEqual({
+      projectName: MOCK_RESOURCE_NAME,
+      includes: MOCK_INCLUDE_PATTERN,
+      excludes: MOCK_EXCLUDE_PATTERN,
+      amplifyExtension: {
+        codeGenTarget: MOCK_TARGET,
+        generatedFileName: MOCK_GENERATED_FILE_NAME,
+        docsFilePath: MOCK_DOCS_FILE_PATH,
+      },
+    });
+
+    expect(shouldGenerateDocs).toBe(SHOULD_GENERATE_DOC);
+  });
+
+  it('should not ask any question if user declines codeGeneration', async () => {
+    askShouldGenerateCode.mockReturnValue(false);
+    const result = await prePushAddCallback(MOCK_CONTEXT, MOCK_RESOURCE_NAME);
+    expect(result).toBeUndefined();
+  });
+
+  it('should call prePushUpdate if the codegen config is already added', async () => {
+    isCodegenConfigured.mockReturnValue(true);
+    await prePushAddCallback(MOCK_CONTEXT, MOCK_RESOURCE_NAME);
+    expect(prePushUpdateCallback).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_RESOURCE_NAME);
+  });
+});

--- a/packages/amplify-codegen/tests/callbacks/prePushUpdateCallback.test.js
+++ b/packages/amplify-codegen/tests/callbacks/prePushUpdateCallback.test.js
@@ -1,0 +1,61 @@
+const loadConfig = require('../../src/codegen-config');
+const askShouldUpdateCode = require('../../src/walkthrough/questions/updateCode');
+const askShouldUpdateStatements = require('../../src/walkthrough/questions/updateDocs');
+
+const prePushUpdateCallback = require('../../src/callbacks/prePushUpdateCallback');
+
+const MOCK_CONTEXT = {
+  exeInfo: {},
+  print: {
+    info: jest.fn(),
+  },
+};
+
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/walkthrough/questions/updateCode');
+jest.mock('../../src/walkthrough/questions/updateDocs');
+
+jest.mock('graphql-transformer-core');
+jest.mock('amplify-cli-core', () => ({
+  pathManager: {
+    getBackendDirPath: () => 'backend',
+  },
+}));
+
+const MOCK_PROJECT_NAME = 'MOCK_PROJECT';
+const MOCK_SELECTED_PROJECT = { projectName: MOCK_PROJECT_NAME, foo: 'bar' };
+const MOCK_PROJECTS = [MOCK_SELECTED_PROJECT];
+
+const LOAD_CONFIG_METHODS = {
+  getProjects: jest.fn(),
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+describe('callback - prepushUpdate AppSync API', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    loadConfig.mockReturnValue(LOAD_CONFIG_METHODS);
+    LOAD_CONFIG_METHODS.getProjects.mockReturnValue(MOCK_PROJECTS);
+    askShouldUpdateCode.mockReturnValue(true);
+    askShouldUpdateStatements.mockReturnValue(true);
+  });
+
+  it('should ask prompt user to update statements and types', async () => {
+    const result = await prePushUpdateCallback(MOCK_CONTEXT, MOCK_PROJECT_NAME);
+    expect(result.gqlConfig).toEqual(MOCK_SELECTED_PROJECT);
+    expect(result.shouldGenerateDocs).toEqual(true);
+  });
+
+  it('should not return anything if the user declines updating code', async () => {
+    askShouldUpdateCode.mockReturnValue(false);
+    const result = await prePushUpdateCallback(MOCK_CONTEXT, MOCK_PROJECT_NAME);
+    expect(result).toBeUndefined();
+  });
+
+  it('should set shouldGenerateDocs when user declines statement generation', async () => {
+    askShouldUpdateStatements.mockReturnValue(false);
+    const result = await prePushUpdateCallback(MOCK_CONTEXT, MOCK_PROJECT_NAME);
+    expect(result.shouldGenerateDocs).toEqual(false);
+  });
+});

--- a/packages/amplify-codegen/tests/codegen-config/AmplifyCodegenConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/AmplifyCodegenConfig.test.js
@@ -1,0 +1,39 @@
+const AmplifyCodeGenConfig = require('../../src/codegen-config/AmplifyCodeGenConfig');
+
+describe('AmplifyCodeGenConfig', () => {
+  describe('normalizePath', () => {
+    let winPathConfig;
+
+    beforeEach(() => {
+      winPathConfig = {
+        schemaPath: 'foo\\schema.graphql',
+        includes: ['foo\\**\\*.grpahql'],
+        excludes: ['bar\\**\\*.grpahql'],
+        extensions: {
+          amplify: {
+            generatedFileName: 'src\\api.ts',
+            docsFilePath: 'src\\graphql\\',
+          },
+        },
+      };
+    });
+    it('should convert windows style path to unix style path', () => {
+      const normalizedConfig = AmplifyCodeGenConfig.normalizePath(winPathConfig);
+      expect(normalizedConfig.schemaPath).toEqual('foo/schema.graphql');
+      expect(normalizedConfig.includes).toEqual(['foo/**/*.grpahql']);
+      expect(normalizedConfig.excludes).toEqual(['bar/**/*.grpahql']);
+      expect(normalizedConfig.extensions.amplify.generatedFileName).toEqual('src/api.ts');
+      expect(normalizedConfig.extensions.amplify.docsFilePath).toEqual('src/graphql/');
+    });
+
+    it('should handle config where generatedFileName is missing', () => {
+      delete winPathConfig.extensions.amplify.generatedFileName;
+      const normalizedConfig = AmplifyCodeGenConfig.normalizePath(winPathConfig);
+      expect(normalizedConfig.schemaPath).toEqual('foo/schema.graphql');
+      expect(normalizedConfig.includes).toEqual(['foo/**/*.grpahql']);
+      expect(normalizedConfig.excludes).toEqual(['bar/**/*.grpahql']);
+      expect(normalizedConfig.extensions.amplify.generatedFileName).toBeUndefined();
+      expect(normalizedConfig.extensions.amplify.docsFilePath).toEqual('src/graphql/');
+    });
+  });
+});

--- a/packages/amplify-codegen/tests/codegen-config/index.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/index.test.js
@@ -1,0 +1,15 @@
+const AmplifyCodeGenConfig = require('../../src/codegen-config/AmplifyCodeGenConfig');
+
+const loadConfig = require('../../src/codegen-config');
+
+jest.mock('../../src/codegen-config/AmplifyCodeGenConfig');
+const MOCK_CONTEXT = 'MOCK_CONTEXT';
+
+describe('codegen-config', () => {
+  it('is singleton', () => {
+    loadConfig(MOCK_CONTEXT);
+    expect(AmplifyCodeGenConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    loadConfig(MOCK_CONTEXT);
+    expect(AmplifyCodeGenConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/utils/graphQlToAmplifyConfig.test.js
@@ -1,0 +1,81 @@
+const graphQlToAmplifyConfig = require('../../../src/codegen-config/utils/graphQlToAmplifyConfig');
+
+describe('graphQlToAmplifyConfig', () => {
+  const schemaPath = './src/schema.json';
+  const includes = ['**/*.gql'];
+  const excludes = ['temp/**/*.gql'];
+  const graphQLApiId = 'gql-api-id';
+  const codeGenTarget = 'typescript';
+
+  const projectName = 'proj1';
+  const schemaPath1 = './proj1/schema.json';
+  const includes1 = ['proj/**/*.gql'];
+  const excludes1 = ['proj/temp/**/*.gql'];
+  const graphQLApiId1 = 'proj1';
+  const codeGenTarget1 = 'flow';
+
+  it('should return items with amplify extensions', () => {
+    const projects = {
+      [projectName]: {
+        config: {
+          schemaPath: schemaPath1,
+          includes: includes1,
+          excludes: excludes1,
+          extensions: {
+            amplify: {
+              codeGenTarget: codeGenTarget1,
+              graphQLApiId: graphQLApiId1,
+            },
+          },
+        },
+      },
+      proj2: {
+        schemaPath,
+        includes: includes1,
+      },
+    };
+
+    const getProjects = jest.fn().mockReturnValue(projects);
+
+    const gqlConfig = {
+      config: {
+        schemaPath,
+        includes,
+        excludes,
+        extensions: {
+          amplify: {
+            codeGenTarget,
+            graphQLApiId,
+          },
+        },
+      },
+      getProjects,
+    };
+
+    const expectedAmplifyConfig = [
+      {
+        schema: schemaPath,
+        __root__: true,
+        includes,
+        excludes,
+        amplifyExtension: {
+          graphQLApiId,
+          codeGenTarget,
+        },
+      },
+      {
+        schema: schemaPath1,
+        __root__: false,
+        projectName,
+        includes: includes1,
+        excludes: excludes1,
+        amplifyExtension: {
+          graphQLApiId: graphQLApiId1,
+          codeGenTarget: codeGenTarget1,
+        },
+      },
+    ];
+
+    expect(graphQlToAmplifyConfig(gqlConfig)).toEqual(expectedAmplifyConfig);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/add.test.js
+++ b/packages/amplify-codegen/tests/commands/add.test.js
@@ -1,0 +1,166 @@
+const loadConfig = require('../../src/codegen-config');
+const generateStatements = require('../../src/commands/statements');
+const generateTypes = require('../../src/commands/types');
+const addWalkthrough = require('../../src/walkthrough/add');
+const changeAppSyncRegions = require('../../src/walkthrough/changeAppSyncRegions');
+const { AmplifyCodeGenAPINotFoundError } = require('../../src/errors');
+
+const add = require('../../src/commands/add');
+
+const { getAppSyncAPIDetails, getAppSyncAPIInfo, getProjectAwsRegion, getSDLSchemaLocation } = require('../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getProjectMeta: jest.fn(),
+  },
+};
+jest.mock('../../src/walkthrough/add');
+jest.mock('../../src/walkthrough/changeAppSyncRegions');
+jest.mock('../../src/commands/types');
+jest.mock('../../src/commands/statements');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/utils');
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_INCLUDE_PATTERN = 'MOCK_INCLUDE';
+const MOCK_EXCLUDE_PATTERN = 'MOCK_EXCLUDE';
+const MOCK_SCHEMA_LOCATION = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_DOCS_FILE_PATH = 'MOCK_DOCS_FILE_PATH';
+const MOCK_ENDPOINT = 'MOCK_APPSYNC_ENDPOINT';
+const MOCK_API_NAME = 'MOCK_API_NAME';
+const MOCK_SCHEMA_FILE_LOCATION = 'amplify/backend/api/MOCK_API_NAME/build/schema.graphql';
+const MOCK_AWS_REGION = 'MOCK_AWS_PROJECT_REGION';
+
+const MOCK_ANSWERS = {
+  includePattern: MOCK_INCLUDE_PATTERN,
+  excludePattern: MOCK_EXCLUDE_PATTERN,
+  target: MOCK_TARGET,
+  generatedFileName: MOCK_GENERATED_FILE_NAME,
+  docsFilePath: MOCK_DOCS_FILE_PATH,
+  schemaLocation: MOCK_SCHEMA_LOCATION,
+  shouldGenerateDocs: true,
+  shouldGenerateCode: true,
+};
+
+const MOCK_APPSYNC_API_DETAIL = {
+  id: MOCK_API_ID,
+  endpoint: MOCK_ENDPOINT,
+  name: MOCK_API_NAME,
+};
+
+const LOAD_CONFIG_METHODS = {
+  getProjects: jest.fn(),
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+describe('command - add', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    LOAD_CONFIG_METHODS.getProjects.mockReturnValue([]);
+    addWalkthrough.mockReturnValue(MOCK_ANSWERS);
+    getAppSyncAPIDetails.mockReturnValue([MOCK_APPSYNC_API_DETAIL]);
+    loadConfig.mockReturnValue(LOAD_CONFIG_METHODS);
+    getProjectAwsRegion.mockReturnValue(MOCK_AWS_REGION);
+    getSDLSchemaLocation.mockReturnValue(MOCK_SCHEMA_FILE_LOCATION);
+  });
+
+  it('should walkthrough add questions', async () => {
+    await add(MOCK_CONTEXT);
+    expect(getAppSyncAPIDetails).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(getAppSyncAPIInfo).not.toHaveBeenCalled();
+    expect(LOAD_CONFIG_METHODS.getProjects).toHaveBeenCalledWith();
+    expect(LOAD_CONFIG_METHODS.addProject).toHaveBeenCalled();
+    const newProjectConfig = LOAD_CONFIG_METHODS.addProject.mock.calls[0][0];
+    expect(newProjectConfig.projectName).toEqual(MOCK_API_NAME);
+    expect(newProjectConfig.includes).toEqual(MOCK_INCLUDE_PATTERN);
+    expect(newProjectConfig.excludes).toEqual(MOCK_EXCLUDE_PATTERN);
+    expect(newProjectConfig.schema).toEqual(MOCK_SCHEMA_FILE_LOCATION);
+    expect(newProjectConfig.amplifyExtension.codeGenTarget).toEqual(MOCK_TARGET);
+    expect(newProjectConfig.amplifyExtension.generatedFileName).toEqual(MOCK_GENERATED_FILE_NAME);
+    expect(newProjectConfig.amplifyExtension.docsFilePath).toEqual(MOCK_DOCS_FILE_PATH);
+
+    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false, undefined, false, undefined);
+    expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false, false, undefined);
+
+    expect(LOAD_CONFIG_METHODS.save).toHaveBeenCalledWith();
+  });
+
+  it('should fetch the info from cloud if an apiId is passed', async () => {
+    getAppSyncAPIInfo.mockReturnValue(MOCK_APPSYNC_API_DETAIL);
+    await add(MOCK_CONTEXT, MOCK_API_ID);
+    expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+    expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+    expect(changeAppSyncRegions).not.toHaveBeenCalled();
+  });
+
+  describe('AppSync API in a different region', () => {
+    it('should use the user provided region', async () => {
+      const MOCK_NEW_REGION = 'NEW_AWS_REGION';
+      getAppSyncAPIInfo.mockImplementationOnce(() => {
+        getAppSyncAPIInfo.mockReturnValue(MOCK_APPSYNC_API_DETAIL);
+        throw new AmplifyCodeGenAPINotFoundError();
+      });
+      changeAppSyncRegions.mockReturnValue({ shouldRetry: true, region: MOCK_NEW_REGION });
+      await add(MOCK_CONTEXT, MOCK_API_ID);
+      expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+      expect(changeAppSyncRegions).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_AWS_REGION);
+      expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+      expect(LOAD_CONFIG_METHODS.save).toHaveBeenCalledWith();
+    });
+
+    it('should not add if user chooses not change region', async () => {
+      getAppSyncAPIInfo.mockImplementationOnce(() => {
+        throw new AmplifyCodeGenAPINotFoundError();
+      });
+      changeAppSyncRegions.mockReturnValue({ shouldRetry: false });
+      await add(MOCK_CONTEXT, MOCK_API_ID);
+      expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+      expect(changeAppSyncRegions).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_AWS_REGION);
+      expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+      expect(LOAD_CONFIG_METHODS.save).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should throw an error if an AppSync API is already added', async () => {
+    LOAD_CONFIG_METHODS.getProjects.mockReturnValue([{ id: MOCK_API_ID }]);
+    await expect(add(MOCK_CONTEXT)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('should throw an error if no AppSync APIs are available in project', async () => {
+    getAppSyncAPIDetails.mockReturnValue([]);
+    await expect(add(MOCK_CONTEXT)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('should not generate statements when user chooses not to', async () => {
+    addWalkthrough.mockReturnValue({ ...MOCK_ANSWERS, shouldGenerateDocs: false });
+    await add(MOCK_CONTEXT);
+    expect(generateStatements).not.toHaveBeenCalled();
+  });
+
+  it('should not generate types when user chooses not to', async () => {
+    addWalkthrough.mockReturnValue({ ...MOCK_ANSWERS, shouldGenerateCode: false });
+    await add(MOCK_CONTEXT);
+    expect(generateTypes).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/commands/configure.test.js
+++ b/packages/amplify-codegen/tests/commands/configure.test.js
@@ -1,0 +1,62 @@
+const configure = require('../../src/commands/configure');
+const add = require('../../src/commands/add');
+const loadConfig = require('../../src/codegen-config');
+const configureProjectWalkThrough = require('../../src/walkthrough/configure');
+
+jest.mock('../../src/commands/add');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/walkthrough/configure');
+
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_CONFIG_METHOD = {
+  getProjects: jest.fn(),
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+const MOCK_CONFIG_WALK_THROUGH = 'MOCK_CONFIG_WALK_THROUGH';
+const MOCK_APPSYNC_APIS = ['API1'];
+const MOCK_CONTEXT = { amplify: { getProjectMeta: jest.fn() } };
+describe('command - configure', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    loadConfig.mockReturnValue(MOCK_CONFIG_METHOD);
+    MOCK_CONFIG_METHOD.getProjects.mockReturnValue(MOCK_APPSYNC_APIS);
+    configureProjectWalkThrough.mockReturnValue(MOCK_CONFIG_WALK_THROUGH);
+  });
+
+  it('should update the configuration of project', async () => {
+    await configure(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(configureProjectWalkThrough).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_APPSYNC_APIS, false);
+    expect(MOCK_CONFIG_METHOD.addProject).toHaveBeenCalledWith(MOCK_CONFIG_WALK_THROUGH);
+    expect(MOCK_CONFIG_METHOD.save).toHaveBeenCalledWith();
+
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('should call add project when there are no App Sync API configured for codegen', async () => {
+    MOCK_CONFIG_METHOD.getProjects.mockReturnValue([]);
+    await configure(MOCK_CONTEXT);
+
+    expect(configureProjectWalkThrough).not.toHaveBeenCalled();
+    expect(MOCK_CONFIG_METHOD.addProject).not.toHaveBeenCalled();
+    expect(MOCK_CONFIG_METHOD.save).not.toHaveBeenCalled();
+    expect(add).toHaveBeenCalledWith(MOCK_CONTEXT);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -1,0 +1,103 @@
+const loadConfig = require('../../src/codegen-config');
+const generateStatements = require('../../src/commands/statements');
+const generateTypes = require('../../src/commands/types');
+const generateStatementsAndTypes = require('../../src/commands/generateStatementsAndType');
+const { AmplifyCodeGenNoAppSyncAPIAvailableError } = require('../../src/errors');
+const path = require('path');
+
+const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('../../src/commands/types');
+jest.mock('../../src/commands/statements');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/utils');
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      })
+    },
+  };
+});
+
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_PROJECT = {
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET,
+    docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
+  },
+};
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+
+describe('command - generateStatementsAndTypes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate statements and types', async () => {
+    const forceDownload = false;
+    await generateStatementsAndTypes(MOCK_CONTEXT, forceDownload);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false, undefined, false, undefined);
+    expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false, false, undefined);
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateStatementsAndTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await expect(generateStatementsAndTypes(MOCK_CONTEXT, false)).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/legacy-tests/add.test.js
+++ b/packages/amplify-codegen/tests/commands/legacy-tests/add.test.js
@@ -1,0 +1,166 @@
+const loadConfig = require('../../../src/codegen-config');
+const generateStatements = require('../../../src/commands/statements');
+const generateTypes = require('../../../src/commands/types');
+const addWalkthrough = require('../../../src/walkthrough/add');
+const changeAppSyncRegions = require('../../../src/walkthrough/changeAppSyncRegions');
+const { AmplifyCodeGenAPINotFoundError } = require('../../../src/errors');
+
+const add = require('../../../src/commands/add');
+
+const { getAppSyncAPIDetails, getAppSyncAPIInfo, getProjectAwsRegion, getSDLSchemaLocation } = require('../../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getProjectMeta: jest.fn(),
+  },
+};
+jest.mock('../../../src/walkthrough/add');
+jest.mock('../../../src/walkthrough/changeAppSyncRegions');
+jest.mock('../../../src/commands/types');
+jest.mock('../../../src/commands/statements');
+jest.mock('../../../src/codegen-config');
+jest.mock('../../../src/utils');
+// Mock the Feature flags for statements and types generation to use legacy packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return false;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return false;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_INCLUDE_PATTERN = 'MOCK_INCLUDE';
+const MOCK_EXCLUDE_PATTERN = 'MOCK_EXCLUDE';
+const MOCK_SCHEMA_LOCATION = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_DOCS_FILE_PATH = 'MOCK_DOCS_FILE_PATH';
+const MOCK_ENDPOINT = 'MOCK_APPSYNC_ENDPOINT';
+const MOCK_API_NAME = 'MOCK_API_NAME';
+const MOCK_SCHEMA_FILE_LOCATION = 'amplify/backend/api/MOCK_API_NAME/build/schema.graphql';
+const MOCK_AWS_REGION = 'MOCK_AWS_PROJECT_REGION';
+
+const MOCK_ANSWERS = {
+  includePattern: MOCK_INCLUDE_PATTERN,
+  excludePattern: MOCK_EXCLUDE_PATTERN,
+  target: MOCK_TARGET,
+  generatedFileName: MOCK_GENERATED_FILE_NAME,
+  docsFilePath: MOCK_DOCS_FILE_PATH,
+  schemaLocation: MOCK_SCHEMA_LOCATION,
+  shouldGenerateDocs: true,
+  shouldGenerateCode: true,
+};
+
+const MOCK_APPSYNC_API_DETAIL = {
+  id: MOCK_API_ID,
+  endpoint: MOCK_ENDPOINT,
+  name: MOCK_API_NAME,
+};
+
+const LOAD_CONFIG_METHODS = {
+  getProjects: jest.fn(),
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+describe('command - add', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    LOAD_CONFIG_METHODS.getProjects.mockReturnValue([]);
+    addWalkthrough.mockReturnValue(MOCK_ANSWERS);
+    getAppSyncAPIDetails.mockReturnValue([MOCK_APPSYNC_API_DETAIL]);
+    loadConfig.mockReturnValue(LOAD_CONFIG_METHODS);
+    getProjectAwsRegion.mockReturnValue(MOCK_AWS_REGION);
+    getSDLSchemaLocation.mockReturnValue(MOCK_SCHEMA_FILE_LOCATION);
+  });
+
+  it('should walkthrough add questions', async () => {
+    await add(MOCK_CONTEXT);
+    expect(getAppSyncAPIDetails).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(getAppSyncAPIInfo).not.toHaveBeenCalled();
+    expect(LOAD_CONFIG_METHODS.getProjects).toHaveBeenCalledWith();
+    expect(LOAD_CONFIG_METHODS.addProject).toHaveBeenCalled();
+    const newProjectConfig = LOAD_CONFIG_METHODS.addProject.mock.calls[0][0];
+    expect(newProjectConfig.projectName).toEqual(MOCK_API_NAME);
+    expect(newProjectConfig.includes).toEqual(MOCK_INCLUDE_PATTERN);
+    expect(newProjectConfig.excludes).toEqual(MOCK_EXCLUDE_PATTERN);
+    expect(newProjectConfig.schema).toEqual(MOCK_SCHEMA_FILE_LOCATION);
+    expect(newProjectConfig.amplifyExtension.codeGenTarget).toEqual(MOCK_TARGET);
+    expect(newProjectConfig.amplifyExtension.generatedFileName).toEqual(MOCK_GENERATED_FILE_NAME);
+    expect(newProjectConfig.amplifyExtension.docsFilePath).toEqual(MOCK_DOCS_FILE_PATH);
+
+    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false, undefined, false, undefined);
+    expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false, false, undefined);
+
+    expect(LOAD_CONFIG_METHODS.save).toHaveBeenCalledWith();
+  });
+
+  it('should fetch the info from cloud if an apiId is passed', async () => {
+    getAppSyncAPIInfo.mockReturnValue(MOCK_APPSYNC_API_DETAIL);
+    await add(MOCK_CONTEXT, MOCK_API_ID);
+    expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+    expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+    expect(changeAppSyncRegions).not.toHaveBeenCalled();
+  });
+
+  describe('AppSync API in a different region', () => {
+    it('should use the user provided region', async () => {
+      const MOCK_NEW_REGION = 'NEW_AWS_REGION';
+      getAppSyncAPIInfo.mockImplementationOnce(() => {
+        getAppSyncAPIInfo.mockReturnValue(MOCK_APPSYNC_API_DETAIL);
+        throw new AmplifyCodeGenAPINotFoundError();
+      });
+      changeAppSyncRegions.mockReturnValue({ shouldRetry: true, region: MOCK_NEW_REGION });
+      await add(MOCK_CONTEXT, MOCK_API_ID);
+      expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+      expect(changeAppSyncRegions).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_AWS_REGION);
+      expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+      expect(LOAD_CONFIG_METHODS.save).toHaveBeenCalledWith();
+    });
+
+    it('should not add if user chooses not change region', async () => {
+      getAppSyncAPIInfo.mockImplementationOnce(() => {
+        throw new AmplifyCodeGenAPINotFoundError();
+      });
+      changeAppSyncRegions.mockReturnValue({ shouldRetry: false });
+      await add(MOCK_CONTEXT, MOCK_API_ID);
+      expect(getAppSyncAPIInfo).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_API_ID, MOCK_AWS_REGION);
+      expect(changeAppSyncRegions).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_AWS_REGION);
+      expect(getAppSyncAPIDetails).not.toHaveBeenCalled();
+      expect(LOAD_CONFIG_METHODS.save).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should throw an error if an AppSync API is already added', async () => {
+    LOAD_CONFIG_METHODS.getProjects.mockReturnValue([{ id: MOCK_API_ID }]);
+    await expect(add(MOCK_CONTEXT)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('should throw an error if no AppSync APIs are available in project', async () => {
+    getAppSyncAPIDetails.mockReturnValue([]);
+    await expect(add(MOCK_CONTEXT)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('should not generate statements when user chooses not to', async () => {
+    addWalkthrough.mockReturnValue({ ...MOCK_ANSWERS, shouldGenerateDocs: false });
+    await add(MOCK_CONTEXT);
+    expect(generateStatements).not.toHaveBeenCalled();
+  });
+
+  it('should not generate types when user chooses not to', async () => {
+    addWalkthrough.mockReturnValue({ ...MOCK_ANSWERS, shouldGenerateCode: false });
+    await add(MOCK_CONTEXT);
+    expect(generateTypes).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/commands/legacy-tests/configure.test.js
+++ b/packages/amplify-codegen/tests/commands/legacy-tests/configure.test.js
@@ -1,0 +1,62 @@
+const configure = require('../../../src/commands/configure');
+const add = require('../../../src/commands/add');
+const loadConfig = require('../../../src/codegen-config');
+const configureProjectWalkThrough = require('../../../src/walkthrough/configure');
+
+jest.mock('../../../src/commands/add');
+jest.mock('../../../src/codegen-config');
+jest.mock('../../../src/walkthrough/configure');
+
+// Mock the Feature flags for statements and types generation to use legacy packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return false;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return false;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_CONFIG_METHOD = {
+  getProjects: jest.fn(),
+  addProject: jest.fn(),
+  save: jest.fn(),
+};
+
+const MOCK_CONFIG_WALK_THROUGH = 'MOCK_CONFIG_WALK_THROUGH';
+const MOCK_APPSYNC_APIS = ['API1'];
+const MOCK_CONTEXT = { amplify: { getProjectMeta: jest.fn() } };
+describe('command - configure', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    loadConfig.mockReturnValue(MOCK_CONFIG_METHOD);
+    MOCK_CONFIG_METHOD.getProjects.mockReturnValue(MOCK_APPSYNC_APIS);
+    configureProjectWalkThrough.mockReturnValue(MOCK_CONFIG_WALK_THROUGH);
+  });
+
+  it('should update the configuration of project', async () => {
+    await configure(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(configureProjectWalkThrough).toHaveBeenCalledWith(MOCK_CONTEXT, MOCK_APPSYNC_APIS, false);
+    expect(MOCK_CONFIG_METHOD.addProject).toHaveBeenCalledWith(MOCK_CONFIG_WALK_THROUGH);
+    expect(MOCK_CONFIG_METHOD.save).toHaveBeenCalledWith();
+
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('should call add project when there are no App Sync API configured for codegen', async () => {
+    MOCK_CONFIG_METHOD.getProjects.mockReturnValue([]);
+    await configure(MOCK_CONTEXT);
+
+    expect(configureProjectWalkThrough).not.toHaveBeenCalled();
+    expect(MOCK_CONFIG_METHOD.addProject).not.toHaveBeenCalled();
+    expect(MOCK_CONFIG_METHOD.save).not.toHaveBeenCalled();
+    expect(add).toHaveBeenCalledWith(MOCK_CONTEXT);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/legacy-tests/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/legacy-tests/generateStatementsAndTypes.test.js
@@ -1,0 +1,103 @@
+const loadConfig = require('../../../src/codegen-config');
+const generateStatements = require('../../../src/commands/statements');
+const generateTypes = require('../../../src/commands/types');
+const generateStatementsAndTypes = require('../../../src/commands/generateStatementsAndType');
+const { AmplifyCodeGenNoAppSyncAPIAvailableError } = require('../../../src/errors');
+const path = require('path');
+
+const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('../../../src/commands/types');
+jest.mock('../../../src/commands/statements');
+jest.mock('../../../src/codegen-config');
+jest.mock('../../../src/utils');
+// Mock the Feature flags for statements and types generation to use legacy packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return false;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return false;
+        }
+      })
+    },
+  };
+});
+
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_PROJECT = {
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET,
+    docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
+  },
+};
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+
+describe('command - generateStatementsAndTypes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate statements and types', async () => {
+    const forceDownload = false;
+    await generateStatementsAndTypes(MOCK_CONTEXT, forceDownload);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(generateStatements).toHaveBeenCalledWith(MOCK_CONTEXT, false, undefined, false, undefined);
+    expect(generateTypes).toHaveBeenCalledWith(MOCK_CONTEXT, false, false, undefined);
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateStatementsAndTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await expect(generateStatementsAndTypes(MOCK_CONTEXT, false)).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/legacy-tests/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/legacy-tests/statements.test.js
@@ -1,0 +1,135 @@
+const path = require('path');
+const { generate } = require('amplify-graphql-docs-generator');
+const fs = require('fs-extra');
+
+const loadConfig = require('../../../src/codegen-config');
+const generateStatements = require('../../../src/commands/statements');
+const constants = require('../../../src/constants');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('amplify-graphql-docs-generator');
+jest.mock('../../../src/codegen-config');
+jest.mock('../../../src/utils');
+jest.mock('fs-extra');
+// Mock the Feature flags for statements and types generation to use legacy packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return false;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return false;
+        }
+      })
+    },
+  };
+});
+
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET_LANGUAGE = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+const MOCK_PROJECT = {
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET_LANGUAGE,
+    graphQLApiId: MOCK_API_ID,
+    docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
+  },
+};
+
+getFrontEndHandler.mockReturnValue('javascript');
+
+describe('command - statements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(true);
+    getFrontEndHandler.mockReturnValue('javascript');
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate statements', async () => {
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+
+    expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
+      separateFiles: true,
+      language: MOCK_TARGET_LANGUAGE,
+    });
+  });
+
+  it('should generate graphql statements for non JS projects', async () => {
+    getFrontEndHandler.mockReturnValue('ios');
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
+      separateFiles: true,
+      language: 'graphql',
+    });
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should download the schema if the schema file is missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await generateStatements(MOCK_CONTEXT, false);
+    expect(MOCK_CONTEXT.print.info).toHaveBeenCalledWith(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/legacy-tests/types.test.js
+++ b/packages/amplify-codegen/tests/commands/legacy-tests/types.test.js
@@ -1,0 +1,154 @@
+const { sync } = require('glob-all');
+const path = require('path');
+const { generate } = require('amplify-graphql-types-generator');
+const fs = require('fs-extra');
+
+const loadConfig = require('../../../src/codegen-config');
+const generateTypes = require('../../../src/commands/types');
+const constants = require('../../../src/constants');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('glob-all');
+jest.mock('amplify-graphql-types-generator');
+jest.mock('../../../src/codegen-config');
+jest.mock('../../../src/utils');
+jest.mock('fs-extra');
+// Mock the Feature flags for statements and types generation to use legacy packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return false;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return false;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_EXCLUDE_PATH = 'MOCK_EXCLUDE';
+const MOCK_QUERIES = ['q1.gql', 'q2.gql'];
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_PROJECT = {
+  excludes: [MOCK_EXCLUDE_PATH],
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET,
+    graphQLApiId: MOCK_API_ID,
+    region: MOCK_REGION,
+  },
+};
+sync.mockReturnValue(MOCK_QUERIES);
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+
+getFrontEndHandler.mockReturnValue('javascript');
+
+describe('command - types', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(true);
+    getFrontEndHandler.mockReturnValue('javascript');
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate types', async () => {
+    const forceDownload = false;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT, absolute: true });
+    expect(generate).toHaveBeenCalledWith(
+      MOCK_QUERIES,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      path.join(MOCK_PROJECT_ROOT, MOCK_GENERATED_FILE_NAME),
+      '',
+      MOCK_TARGET,
+      '',
+      { addTypename: true, complexObjectSupport: 'auto' }
+    );
+  });
+
+  it('should not generate type if the frontend is android', async () => {
+    const forceDownload = false;
+    getFrontEndHandler.mockReturnValue('android');
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should download the schema if the schema file is missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const forceDownload = false;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await generateTypes(MOCK_CONTEXT, false);
+    expect(MOCK_CONTEXT.print.info).toHaveBeenCalledWith(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  });
+
+  it('should not generate types when includePattern is empty', async () => {
+    MOCK_PROJECT.includes = [];
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('should not generate type when generatedFileName is missing', async () => {
+    MOCK_PROJECT.amplifyExtension.generatedFileName = '';
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -1,0 +1,135 @@
+const path = require('path');
+const { generate } = require('@aws-amplify/graphql-docs-generator');
+const fs = require('fs-extra');
+
+const loadConfig = require('../../src/codegen-config');
+const generateStatements = require('../../src/commands/statements');
+const constants = require('../../src/constants');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('@aws-amplify/graphql-docs-generator');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/utils');
+jest.mock('fs-extra');
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      })
+    },
+  };
+});
+
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET_LANGUAGE = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+const MOCK_PROJECT = {
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET_LANGUAGE,
+    graphQLApiId: MOCK_API_ID,
+    docsFilePath: MOCK_STATEMENTS_PATH,
+    region: MOCK_REGION,
+  },
+};
+
+getFrontEndHandler.mockReturnValue('javascript');
+
+describe('command - statements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(true);
+    getFrontEndHandler.mockReturnValue('javascript');
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate statements', async () => {
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+
+    expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
+      separateFiles: true,
+      language: MOCK_TARGET_LANGUAGE,
+    });
+  });
+
+  it('should generate graphql statements for non JS projects', async () => {
+    getFrontEndHandler.mockReturnValue('ios');
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
+      separateFiles: true,
+      language: 'graphql',
+    });
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should download the schema if the schema file is missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const forceDownload = false;
+    await generateStatements(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await generateStatements(MOCK_CONTEXT, false);
+    expect(MOCK_CONTEXT.print.info).toHaveBeenCalledWith(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  });
+});

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -1,0 +1,154 @@
+const { sync } = require('glob-all');
+const path = require('path');
+const { generate } = require('@aws-amplify/graphql-types-generator');
+const fs = require('fs-extra');
+
+const loadConfig = require('../../src/codegen-config');
+const generateTypes = require('../../src/commands/types');
+const constants = require('../../src/constants');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../../src/utils');
+
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getEnvInfo: jest.fn(),
+    getProjectMeta: jest.fn(),
+  },
+};
+
+jest.mock('glob-all');
+jest.mock('@aws-amplify/graphql-types-generator');
+jest.mock('../../src/codegen-config');
+jest.mock('../../src/utils');
+jest.mock('fs-extra');
+// Mock the Feature flags for statements and types generation to use migrated packages
+jest.mock('amplify-cli-core', () => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useDocsGeneratorPlugin') {
+          return true;
+        }
+        if (name === 'codegen.useTypesGeneratorPlugin') {
+          return true;
+        }
+      })
+    },
+  };
+});
+
+const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
+const MOCK_EXCLUDE_PATH = 'MOCK_EXCLUDE';
+const MOCK_QUERIES = ['q1.gql', 'q2.gql'];
+const MOCK_SCHEMA = 'INTROSPECTION_SCHEMA.JSON';
+const MOCK_TARGET = 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE';
+const MOCK_GENERATED_FILE_NAME = 'API.TS';
+const MOCK_API_ID = 'MOCK_API_ID';
+const MOCK_REGION = 'MOCK_AWS_REGION';
+const MOCK_PROJECT_ROOT = 'MOCK_PROJECT_ROOT';
+
+const MOCK_PROJECT = {
+  excludes: [MOCK_EXCLUDE_PATH],
+  includes: [MOCK_INCLUDE_PATH],
+  schema: MOCK_SCHEMA,
+  amplifyExtension: {
+    generatedFileName: MOCK_GENERATED_FILE_NAME,
+    codeGenTarget: MOCK_TARGET,
+    graphQLApiId: MOCK_API_ID,
+    region: MOCK_REGION,
+  },
+};
+sync.mockReturnValue(MOCK_QUERIES);
+const MOCK_APIS = [
+  {
+    id: MOCK_API_ID,
+  },
+];
+
+getFrontEndHandler.mockReturnValue('javascript');
+
+describe('command - types', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(true);
+    getFrontEndHandler.mockReturnValue('javascript');
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([MOCK_PROJECT]),
+    });
+    MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
+    getAppSyncAPIDetails.mockReturnValue(MOCK_APIS);
+  });
+
+  it('should generate types', async () => {
+    const forceDownload = false;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
+    expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
+    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT, absolute: true });
+    expect(generate).toHaveBeenCalledWith(
+      MOCK_QUERIES,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      path.join(MOCK_PROJECT_ROOT, MOCK_GENERATED_FILE_NAME),
+      '',
+      MOCK_TARGET,
+      '',
+      { addTypename: true, complexObjectSupport: 'auto' }
+    );
+  });
+
+  it('should not generate type if the frontend is android', async () => {
+    const forceDownload = false;
+    getFrontEndHandler.mockReturnValue('android');
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it('should download the schema if forceDownload flag is passed', async () => {
+    const forceDownload = true;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should download the schema if the schema file is missing', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const forceDownload = false;
+    await generateTypes(MOCK_CONTEXT, forceDownload);
+    expect(ensureIntrospectionSchema).toHaveBeenCalledWith(
+      MOCK_CONTEXT,
+      path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
+      MOCK_APIS[0],
+      MOCK_REGION,
+      forceDownload
+    );
+  });
+
+  it('should show a warning if there are no projects configured', async () => {
+    loadConfig.mockReturnValue({
+      getProjects: jest.fn().mockReturnValue([]),
+    });
+    await generateTypes(MOCK_CONTEXT, false);
+    expect(MOCK_CONTEXT.print.info).toHaveBeenCalledWith(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+  });
+
+  it('should not generate types when includePattern is empty', async () => {
+    MOCK_PROJECT.includes = [];
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('should not generate type when generatedFileName is missing', async () => {
+    MOCK_PROJECT.amplifyExtension.generatedFileName = '';
+    await generateTypes(MOCK_CONTEXT, true);
+    expect(generate).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/utils/downloadIntrospectionSchema.test.js
+++ b/packages/amplify-codegen/tests/utils/downloadIntrospectionSchema.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const downloadIntrospectionSchema = require('../../src/utils/downloadIntrospectionSchema');
+
+jest.mock('fs-extra');
+
+describe('downloadIntrospectionSchema', () => {
+  const mockExecuteProviderUtils = jest.fn();
+  const mockGetEnvInfo = jest.fn();
+
+  const mockIntroSchema = 'MOCK_INTROSPECTION_SCHEMA';
+  const mockProjectPath = '/User/someone/Documents/Project/amplify-test';
+  const mockContext = {
+    amplify: {
+      executeProviderUtils: mockExecuteProviderUtils,
+      getEnvInfo: mockGetEnvInfo,
+    },
+  };
+  const mockApiId = 'mock-api-123';
+  const mockDownloadDirectory = 'MOCK_DOWNLOAD_DIRECTORY';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockExecuteProviderUtils.mockReturnValue(mockIntroSchema);
+    mockGetEnvInfo.mockReturnValue({
+      projectPath: mockProjectPath,
+    });
+  });
+  it('should download the schema', async () => {
+    const introSchemaPath = await downloadIntrospectionSchema(mockContext, mockApiId, path.join(mockDownloadDirectory, 'schema.json'));
+    expect(mockExecuteProviderUtils).toHaveBeenCalledWith(mockContext, 'awscloudformation', 'getIntrospectionSchema', { apiId: mockApiId });
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(mockDownloadDirectory);
+    const expectedIntrospectionFileName = path.join(mockDownloadDirectory, 'schema.json');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expectedIntrospectionFileName, mockIntroSchema, 'utf8');
+
+    expect(introSchemaPath).toEqual(path.relative(mockProjectPath, expectedIntrospectionFileName));
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getAppSyncAPIDetail.test.js
+++ b/packages/amplify-codegen/tests/utils/getAppSyncAPIDetail.test.js
@@ -1,0 +1,52 @@
+const getAppSyncDetail = require('../../src/utils/getAppSyncAPIDetails');
+const getAppSyncAPIs = require('../../src/utils/getAppSyncAPIs');
+
+jest.mock('../../src/utils/getAppSyncAPIs');
+
+describe('getAppSyncDetail', () => {
+  const getProjectMeta = jest.fn();
+  const context = {
+    amplify: {
+      getProjectMeta,
+    },
+  };
+
+  const mockProjectMeta = { api: ['api1', 'api2'] };
+
+  const mockAppSyncAPIs = [
+    {
+      name: 'api1',
+      output: {
+        GraphQLAPIEndpointOutput: 'http://appsync.aws.com/api1',
+        GraphQLAPIIdOutput: 'some-random-id',
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AWS_IAM',
+          },
+        },
+      },
+    },
+  ];
+
+  it('should get the project meta from context', () => {
+    getProjectMeta.mockReturnValueOnce(mockProjectMeta);
+    getAppSyncAPIs.mockReturnValueOnce(mockAppSyncAPIs);
+    const expectedResult = [
+      {
+        name: mockAppSyncAPIs[0].name,
+        endpoint: mockAppSyncAPIs[0].output.GraphQLAPIEndpointOutput,
+        id: mockAppSyncAPIs[0].output.GraphQLAPIIdOutput,
+        authConfig: mockAppSyncAPIs[0].output.authConfig,
+      },
+    ];
+    expect(getAppSyncDetail(context)).toEqual(expectedResult);
+    expect(getProjectMeta).toHaveBeenCalled();
+    expect(getAppSyncAPIs).toHaveBeenCalledWith(mockProjectMeta.api);
+  });
+
+  it('should return an empty list when there are no app sync APIs included in the project', () => {
+    getProjectMeta.mockReturnValueOnce(mockProjectMeta);
+    getAppSyncAPIs.mockReturnValueOnce([]);
+    expect(getAppSyncDetail(context)).toHaveLength(0);
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getAppSyncAPIs.test.js
+++ b/packages/amplify-codegen/tests/utils/getAppSyncAPIs.test.js
@@ -1,0 +1,64 @@
+const getAppSyncAPIs = require('../../src/utils/getAppSyncAPIs');
+
+describe('getAppSyncAPIs', () => {
+  const apiMeta = {
+    appSync1: {
+      service: 'AppSync',
+      output: {
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AWS_IAM',
+          },
+        },
+        GraphQLApiId: 'rmez4smy7bbqrpanvaaefywt64',
+        GraphQLApiEndpoint: 'https://fp772p7p3faoldgp54vxicfyjy.appsync-api.us-east-1.amazonaws.com/graphql',
+        Region: 'us-east-1',
+      },
+    },
+    appSync2: {
+      service: 'AppSync',
+      output: {
+        authConfig: {
+          defaultAuthentication: {
+            authenticationType: 'AWS_IAM',
+          },
+        },
+        GraphQLApiId: '2c6gvpbh6jfjhjdazm2d5cixtm',
+        GraphQLApiEndpoint: 'https://vq5t7rm63fazjlbn74duugnyle.appsync-api.us-east-1.amazonaws.com/graphql',
+        Region: 'us-east-1',
+        GraphQLApiARN: 'arn:aws:appsync:us-east-1:744586199449:apis/2c6gvpbh6jfjhjdazm2d5cixtm',
+        PostDynamoDBTableDataSourceARN:
+          'arn:aws:appsync:us-east-1:744586199449:apis/2c6gvpbh6jfjhjdazm2d5cixtm/datasources/PostDynamoDBTable',
+        PostDynamoDBTableDataSourceName: 'PostDynamoDBTable',
+      },
+    },
+    someThingElse: {
+      service: 'ApiGW',
+      output: {
+        securityType: 'AWS_IAM',
+        GraphQLApiId: '2c6gvpbh6jfjhjdazm2d5cixtm',
+        GraphQLApiEndpoint: 'https://vq5t7rm63fazjlbn74duugnyle.appsync-api.us-east-1.amazonaws.com/graphql',
+        Region: 'us-east-1',
+        GraphQLApiARN: 'arn:aws:appsync:us-east-1:744586199449:apis/2c6gvpbh6jfjhjdazm2d5cixtm',
+        PostDynamoDBTableDataSourceARN:
+          'arn:aws:appsync:us-east-1:744586199449:apis/2c6gvpbh6jfjhjdazm2d5cixtm/datasources/PostDynamoDBTable',
+        PostDynamoDBTableDataSourceName: 'PostDynamoDBTable',
+      },
+    },
+  };
+
+  it('should return the projects array with name', () => {
+    const expectedApiList = [
+      { ...apiMeta.appSync1, name: 'appSync1' },
+      { ...apiMeta.appSync2, name: 'appSync2' },
+    ];
+    expect(getAppSyncAPIs(apiMeta)).toEqual(expectedApiList);
+  });
+
+  it('should return an empty list when there are no APIs in the meta data', () => {
+    expect(getAppSyncAPIs()).toEqual([]);
+    expect(getAppSyncAPIs({})).toEqual([]);
+    expect(getAppSyncAPIs([])).toEqual([]);
+    expect(getAppSyncAPIs({ someRandomAPI: {} })).toEqual([]);
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getDocsgenPackage.test.js
+++ b/packages/amplify-codegen/tests/utils/getDocsgenPackage.test.js
@@ -1,0 +1,26 @@
+const { getDocsgenPackage } = require('../../src/utils/getDocsgenPackage');
+
+// old graphQL statements generator package
+jest.mock('amplify-graphql-docs-generator', () => {
+  const module = jest.requireActual('amplify-graphql-docs-generator');
+  return {
+    ...module,
+    name: 'OldDocsgenPackage',
+  };
+});
+
+// new graphQL statements generator package
+jest.mock('@aws-amplify/graphql-docs-generator', () => {
+  const module = jest.requireActual('@aws-amplify/graphql-docs-generator');
+  return {
+    ...module,
+    name: 'NewDocsgenPackage',
+  };
+});
+
+it('getDocsgenPackage', () => {
+  expect(getDocsgenPackage(false)).toBeDefined();
+  expect(getDocsgenPackage(false).name).toEqual('OldDocsgenPackage');
+  expect(getDocsgenPackage(true)).toBeDefined();
+  expect(getDocsgenPackage(true).name).toEqual('NewDocsgenPackage');
+});

--- a/packages/amplify-codegen/tests/utils/getFrontendHandler.test.js
+++ b/packages/amplify-codegen/tests/utils/getFrontendHandler.test.js
@@ -1,0 +1,21 @@
+const getFrontendHandler = require('../../src/utils/getFrontEndHandler');
+
+describe('getFrontendHandler', () => {
+  const mockFrontEndHandler = 'someRandomHandler';
+  const mockProjectConfig = {
+    frontend: 'someRandomHandler',
+  };
+  const mockGetProjectConfig = jest.fn();
+  const mockContext = {
+    amplify: {
+      getProjectConfig: mockGetProjectConfig,
+    },
+  };
+  beforeEach(() => {
+    mockGetProjectConfig.mockReturnValue(mockProjectConfig);
+  });
+  it('should get the frontend handler from the project config', () => {
+    expect(getFrontendHandler(mockContext)).toEqual(mockFrontEndHandler);
+    expect(mockGetProjectConfig).toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
+++ b/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
@@ -1,0 +1,21 @@
+const getGraphQLDocPath = require('../../src/utils/getGraphQLDocPath');
+const getIncludePatterns = require('../../src/utils/getIncludePattern')
+
+describe('getGraphQLDocPath', () => {
+  it('should return com/amplify/generated/graphql when used in android project', () => {
+    const SCHEMA_LOCATION = 'app/src/main/graphql/schema.json';
+    const graphQLDirectory = getIncludePatterns('android', SCHEMA_LOCATION).graphQLDirectory;
+    expect(getGraphQLDocPath('android', graphQLDirectory)).toEqual('app/src/main/graphql/com/amazonaws/amplify/generated/graphql');
+  });
+
+  it('should return default folder when frontend is not android and include path not defined', () => {
+    const graphQLDirectory = getIncludePatterns('javascript').graphQLDirectory;
+    expect(getGraphQLDocPath('javascript', graphQLDirectory)).toEqual('src/graphql');
+  });
+
+  it('should return parent folder for include glob path when frontend is not android and include path is defined', () => {
+    const graphQLDirectory = getIncludePatterns('javascript').graphQLDirectory;
+    const includePathGlob = 'path/to/graphql/**/*.js';
+    expect(getGraphQLDocPath('javascript', graphQLDirectory, includePathGlob)).toEqual('path/to/graphql');
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getModelgenPackage.test.js
+++ b/packages/amplify-codegen/tests/utils/getModelgenPackage.test.js
@@ -1,0 +1,26 @@
+const { getModelgenPackage } = require('../../src/utils/getModelgenPackage');
+
+// old codegen package
+jest.mock('amplify-codegen-appsync-model-plugin', () => {
+  const module = jest.requireActual('amplify-codegen-appsync-model-plugin');
+  return {
+    ...module,
+    name: 'OldModelgenPackage',
+  };
+});
+
+// new codegen package
+jest.mock('@aws-amplify/appsync-modelgen-plugin', () => {
+  const module = jest.requireActual('@aws-amplify/appsync-modelgen-plugin');
+  return {
+    ...module,
+    name: 'NewModelgenPackage',
+  };
+});
+
+it('getModelgenPackage', () => {
+  expect(getModelgenPackage(false)).toBeDefined();
+  expect(getModelgenPackage(false).name).toEqual('OldModelgenPackage');
+  expect(getModelgenPackage(true)).toBeDefined();
+  expect(getModelgenPackage(true).name).toEqual('NewModelgenPackage');
+});

--- a/packages/amplify-codegen/tests/utils/getOutputFileName.test.js
+++ b/packages/amplify-codegen/tests/utils/getOutputFileName.test.js
@@ -1,0 +1,23 @@
+const getOutputFileName = require('../../src/utils/getOutputFileName');
+
+describe('getOutputFileName', () => {
+  it('should return the file name with by adding extension based on the language target', () => {
+    expect(getOutputFileName('Foo', 'typescript')).toEqual('Foo.ts');
+  });
+
+  it('should not add extension if the file extension is already present', () => {
+    expect(getOutputFileName('Foo.swift', 'swift')).toEqual('Foo.swift');
+  });
+
+  it('should add .service.ts extension when the target is angular', () => {
+    expect(getOutputFileName('Foo', 'angular')).toEqual('Foo.service.ts');
+  });
+
+  it('should return api.service.ts when input name is missing and target is angular', () => {
+    expect(getOutputFileName(null, 'angular')).toEqual('src/app/api.service.ts');
+  });
+
+  it('should not add any extension if the code generation target is unknown', () => {
+    expect(getOutputFileName('Foo', 'bar')).toEqual('Foo');
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getSchemaDownloadLocation.test.js
+++ b/packages/amplify-codegen/tests/utils/getSchemaDownloadLocation.test.js
@@ -1,0 +1,92 @@
+const { join, dirname } = require('path');
+const { pathManager } = require('amplify-cli-core');
+
+const getSchemaDownloadLocation = require('../../src/utils/getSchemaDownloadLocation');
+const getAndroidResDir = require('../../src/utils/getAndroidResDir');
+const getFrontendHandler = require('../../src/utils/getFrontEndHandler');
+
+jest.mock('../../src/utils/getAndroidResDir');
+jest.mock('../../src/utils/getFrontEndHandler');
+jest.mock('amplify-cli-core');
+
+let mockContext;
+const mockProjectConfigDefault = 'MOCK_PROJECT_CONFIG';
+const mockProjectConfig = {
+  frontend: 'javascript',
+  javascript: {
+    config: {
+      SourceDir: 'web-client/src',
+    },
+  },
+};
+const mockResDir = 'MOCK_RES_DIR/Res';
+const mockAPIName = 'FooAPI';
+const mockProjectRoot = '/home/user/project/proj1';
+
+const mockGetProjectConfigDefault = jest.fn();
+const mockGetProjectConfig = jest.fn();
+describe('getSchemaDownloadLocation', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    pathManager.findProjectRoot.mockReturnValue(mockProjectRoot);
+    mockGetProjectConfigDefault.mockReturnValue(mockProjectConfigDefault);
+    mockGetProjectConfig.mockReturnValue(mockProjectConfig);
+    getAndroidResDir.mockImplementation(() => {
+      throw new Error();
+    });
+    getFrontendHandler.mockReturnValue('javascript');
+  });
+
+  it('should use the src/graphql directory when used in JS frontend', () => {
+    mockContext = {
+      amplify: {
+        getProjectConfig: mockGetProjectConfigDefault,
+      },
+    };
+    const downloadLocation = getSchemaDownloadLocation(mockContext);
+    expect(downloadLocation).toEqual(join(mockProjectRoot, 'src', 'graphql', 'schema.json'));
+  });
+
+  it('should use the defined project config directory when used in JS frontend', () => {
+    mockContext = {
+      amplify: {
+        getProjectConfig: mockGetProjectConfig,
+      },
+    };
+    const downloadLocation = getSchemaDownloadLocation(mockContext);
+    expect(downloadLocation).toEqual(join(mockProjectRoot, 'web-client', 'src', 'graphql', 'schema.json'));
+  });
+
+  it('should use the graphql directory when used in iOS frontend', () => {
+    mockContext = {
+      amplify: {
+        getProjectConfig: mockGetProjectConfig,
+      },
+    };
+    getFrontendHandler.mockReturnValue('iOS');
+    const downloadLocation = getSchemaDownloadLocation(mockContext);
+    expect(downloadLocation).toEqual(join(mockProjectRoot, 'graphql', 'schema.json'));
+  });
+
+  it('should use main directory in Android', () => {
+    mockContext = {
+      amplify: {
+        getProjectConfig: mockGetProjectConfig,
+      },
+    };
+    getAndroidResDir.mockReturnValue(mockResDir);
+    const downloadLocation = getSchemaDownloadLocation(mockContext);
+    expect(downloadLocation).toEqual(join(mockProjectRoot, dirname(mockResDir), 'graphql', 'schema.json'));
+  });
+
+  it('should return the download location inside the project root', () => {
+    mockContext = {
+      amplify: {
+        getProjectConfig: mockGetProjectConfig,
+      },
+    };
+    getAndroidResDir.mockReturnValue(mockResDir);
+    const downloadLocation = getSchemaDownloadLocation(mockContext);
+    expect(downloadLocation).toContain(mockProjectRoot);
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getTypesgenPackage.test.js
+++ b/packages/amplify-codegen/tests/utils/getTypesgenPackage.test.js
@@ -1,0 +1,26 @@
+const { getTypesgenPackage } = require('../../src/utils/getTypesgenPackage');
+
+// old types generator package
+jest.mock('amplify-graphql-types-generator', () => {
+  const module = jest.requireActual('amplify-graphql-types-generator');
+  return {
+    ...module,
+    name: 'OldTypesgenPackage',
+  };
+});
+
+// new types generator package
+jest.mock('@aws-amplify/graphql-types-generator', () => {
+  const module = jest.requireActual('@aws-amplify/graphql-types-generator');
+  return {
+    ...module,
+    name: 'NewTypesgenPackage',
+  };
+});
+
+it('getTypesgenPackage', () => {
+  expect(getTypesgenPackage(false)).toBeDefined();
+  expect(getTypesgenPackage(false).name).toEqual('OldTypesgenPackage');
+  expect(getTypesgenPackage(true)).toBeDefined();
+  expect(getTypesgenPackage(true).name).toEqual('NewTypesgenPackage');
+});

--- a/packages/amplify-codegen/tests/utils/isAppSyncApiPendingPush.test.js
+++ b/packages/amplify-codegen/tests/utils/isAppSyncApiPendingPush.test.js
@@ -1,0 +1,69 @@
+const isAppSyncApiPendingPush = require('../../src/utils/isAppSyncApiPendingPush');
+
+const mockGetResourceStatus = jest.fn();
+const MOCK_CONTEXT = {
+  amplify: {
+    getResourceStatus: mockGetResourceStatus,
+  },
+};
+
+let resourceStatus = {};
+describe('isAppSyncApiPendingPush', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    resourceStatus = {
+      resourcesToBeCreated: [],
+      resourcesToBeUpdated: [],
+      resourcesToBeDeleted: [],
+    };
+    mockGetResourceStatus.mockReturnValue(resourceStatus);
+  });
+
+  it('should return false if there is a resource to be created', async () => {
+    const status = await isAppSyncApiPendingPush(MOCK_CONTEXT);
+    expect(status).toBeFalsy();
+  });
+
+  it('should return false if pending push is a non AppSync resource', async () => {
+    resourceStatus.resourcesToBeCreated = [
+      {
+        service: 'something else',
+      },
+    ];
+    resourceStatus.resourcesToBeUpdated = [
+      {
+        service: 'something else',
+      },
+    ];
+    resourceStatus.resourcesToBeDeleted = [
+      {
+        service: 'something else',
+      },
+    ];
+
+    const status = await isAppSyncApiPendingPush(MOCK_CONTEXT);
+    expect(status).toBeFalsy();
+  });
+
+  it('should return true if resourcesToBeCreated contains AppSync resource', async () => {
+    resourceStatus.resourcesToBeCreated = [
+      {
+        service: 'AppSync',
+      },
+    ];
+
+    const status = await isAppSyncApiPendingPush(MOCK_CONTEXT);
+    expect(status).toBeTruthy();
+  });
+
+  it('should return true if resourcesToBeUpdated contains AppSync resource', async () => {
+    resourceStatus.resourcesToBeUpdated = [
+      {
+        service: 'AppSync',
+      },
+    ];
+
+    const status = await isAppSyncApiPendingPush(MOCK_CONTEXT);
+    expect(status).toBeTruthy();
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/add.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/add.test.js
@@ -1,0 +1,117 @@
+const askCodegenTargetLanguage = require('../../src/walkthrough/questions/languageTarget');
+const askCodegneQueryFilePattern = require('../../src/walkthrough/questions/queryFilePattern');
+const askGeneratedFileName = require('../../src/walkthrough/questions/generatedFileName');
+const askGenerateCode = require('../../src/walkthrough/questions/generateCode');
+const askShouldGenerateDocs = require('../../src/walkthrough/questions/generateDocs');
+const askMaxDepth = require('../../src/walkthrough/questions/maxDepth');
+const { getGraphQLDocPath, getSchemaDownloadLocation, getFrontEndHandler, getIncludePattern } = require('../../src/utils');
+const add = require('../../src/walkthrough/add');
+
+jest.mock('../../src/walkthrough/questions/languageTarget');
+jest.mock('../../src/walkthrough/questions/queryFilePattern');
+jest.mock('../../src/walkthrough/questions/generatedFileName');
+jest.mock('../../src/utils');
+jest.mock('../../src/walkthrough/questions/generateCode');
+jest.mock('../../src/walkthrough/questions/generateDocs');
+jest.mock('../../src/walkthrough/questions/maxDepth');
+
+describe('Add walk-through', () => {
+  const MOCK_TARGET_LANGUAGE = 'MOCK_TARGET_LANGUAGE';
+  const MOCK_INCLUDE_PATTERN = 'MOCK_INCLUDE_PATTERN';
+  const MOCK_CONTEXT = {
+    exeInfo: {},
+  };
+  const MOCK_GENERATED_FILE_NAME = 'MOCK_FILE_NAME.ts';
+  const MOCK_DOWNLOAD_LOCATION = 'MOCK_SCHEMA_DIR/graphql/schema.json';
+  const MOCK_DOCS_FILE_PATH = 'mockDocFilesPath';
+  const MOCK_FRONTEND_HANDLER = 'mockFrontEndHandler';
+  const MOCK_MAX_DEPTH = 20;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    askCodegenTargetLanguage.mockReturnValue(MOCK_TARGET_LANGUAGE);
+    askGeneratedFileName.mockReturnValue(MOCK_GENERATED_FILE_NAME);
+    askGenerateCode.mockReturnValue(true);
+    askShouldGenerateDocs.mockReturnValue(true);
+    getSchemaDownloadLocation.mockReturnValue(MOCK_DOWNLOAD_LOCATION);
+    askCodegneQueryFilePattern.mockReturnValue(MOCK_INCLUDE_PATTERN);
+    getFrontEndHandler.mockReturnValue(MOCK_FRONTEND_HANDLER);
+    getGraphQLDocPath.mockReturnValue(MOCK_DOCS_FILE_PATH);
+    getIncludePattern.mockReturnValue({
+      graphQLDirectory: 'src/graphql',
+      graphQLExtension: '*.js',
+    });
+    askMaxDepth.mockReturnValue(MOCK_MAX_DEPTH);
+  });
+
+  it('should show questions in walkthrough', async () => {
+    const results = await add(MOCK_CONTEXT);
+    expect(askCodegenTargetLanguage).toHaveBeenCalledWith(MOCK_CONTEXT, undefined, undefined, undefined, undefined);
+    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith(['src/graphql/**/*.js']);
+    expect(askGeneratedFileName).toHaveBeenCalledWith('API', MOCK_TARGET_LANGUAGE);
+    expect(getGraphQLDocPath).toHaveBeenCalledWith(MOCK_FRONTEND_HANDLER, 'src/graphql', MOCK_INCLUDE_PATTERN);
+    expect(results).toEqual({
+      target: MOCK_TARGET_LANGUAGE,
+      includePattern: MOCK_INCLUDE_PATTERN,
+      excludePattern: ['./amplify/**'],
+      generatedFileName: MOCK_GENERATED_FILE_NAME,
+      shouldGenerateCode: true,
+      schemaLocation: MOCK_DOWNLOAD_LOCATION,
+      docsFilePath: MOCK_DOCS_FILE_PATH,
+      shouldGenerateDocs: true,
+      maxDepth: MOCK_MAX_DEPTH,
+    });
+  });
+
+  it('should not ask code generation specific questions in android projects', async () => {
+    getFrontEndHandler.mockReturnValue('android');
+    const results = await add(MOCK_CONTEXT);
+    expect(askCodegenTargetLanguage).not.toHaveBeenCalled();
+    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith(['src/graphql/**/*.js']);
+    expect(askGeneratedFileName).not.toHaveBeenCalled();
+    expect(results).toEqual({
+      includePattern: MOCK_INCLUDE_PATTERN,
+      excludePattern: ['./amplify/**'],
+      schemaLocation: MOCK_DOWNLOAD_LOCATION,
+      docsFilePath: MOCK_DOCS_FILE_PATH,
+      shouldGenerateDocs: true,
+      maxDepth: MOCK_MAX_DEPTH,
+    });
+  });
+
+  it('should should skip includePattern when asked to skip', async () => {
+    const skip = ['includePattern'];
+    const results = await add(MOCK_CONTEXT, skip);
+    expect(askCodegneQueryFilePattern).not.toHaveBeenCalled();
+    expect(results).not.toHaveProperty('includePattern');
+  });
+
+  it('should should skip includePattern when asked to skip', async () => {
+    const skip = ['targetLanguage'];
+    const results = await add(MOCK_CONTEXT, skip);
+    expect(askCodegenTargetLanguage).not.toHaveBeenCalled();
+    expect(results).not.toHaveProperty('target');
+  });
+
+  it('should should skip generatedFileName when asked to skip', async () => {
+    const skip = ['generatedFileName'];
+    const results = await add(MOCK_CONTEXT, skip);
+    expect(askGeneratedFileName).not.toHaveBeenCalled();
+    expect(results).not.toHaveProperty('generatedFileName');
+  });
+
+  it('should should skip shouldGenerateCode when asked to skip', async () => {
+    const skip = ['shouldGenerateCode'];
+    const results = await add(MOCK_CONTEXT, skip);
+    expect(askGenerateCode).not.toHaveBeenCalled();
+    expect(results).not.toHaveProperty('shouldGenerateCode');
+  });
+
+  it('should should skip shouldGenerateDocs when asked to skip', async () => {
+    const skip = ['shouldGenerateDocs'];
+    const results = await add(MOCK_CONTEXT, skip);
+    expect(askShouldGenerateDocs).not.toHaveBeenCalled();
+    expect(results).not.toHaveProperty('shouldGenerateDocs');
+    expect(results).not.toHaveProperty('docsFilePath');
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/configure.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/configure.test.js
@@ -1,0 +1,97 @@
+const { join } = require('path');
+const selectProject = require('../../src/walkthrough/questions/selectProject');
+const askCodegenTargetLanguage = require('../../src/walkthrough/questions/languageTarget');
+const askCodegneQueryFilePattern = require('../../src/walkthrough/questions/queryFilePattern');
+const askGeneratedFileName = require('../../src/walkthrough/questions/generatedFileName');
+const askMaxDepth = require('../../src/walkthrough/questions/maxDepth');
+const configure = require('../../src/walkthrough/configure');
+const { getIncludePattern } = require('../../src/utils');
+
+jest.mock('../../src/walkthrough/questions/selectProject');
+jest.mock('../../src/walkthrough/questions/languageTarget');
+jest.mock('../../src/walkthrough/questions/queryFilePattern');
+jest.mock('../../src/walkthrough/questions/generatedFileName');
+jest.mock('../../src/walkthrough/questions/maxDepth');
+jest.mock('../../src/utils');
+
+describe('configure walk-through', () => {
+  const mockAPI = 'two';
+  const mockTargetLanguage = 'MOCK_TARGET_LANGUAGE';
+  const mockIncludes = 'MOCK_INCLUDE_PATTERN';
+  const mockContext = 'MOCK_CONTEXT';
+  const mockGeneratedFileName = 'MOCK_FILE_NAME.ts';
+  const mockGraphQLDirectory = 'MOCK_GQL_DIR';
+  const mockGraphQLExtension = 'MOCK_GQL_EXTENSION';
+  const MOCK_MAX_DEPTH = 'MOCK_MAX_DEPTH';
+
+  const mockConfigs = [
+    {
+      projectName: 'One',
+      includes: ['one/**/*.gql', 'one/**/*.graohql'],
+      amplifyExtension: {
+        graphQLApiId: 'one',
+        generatedFileName: 'one-1.ts',
+        codeGenTarget: 'language-one',
+        maxDepth: 5,
+      },
+    },
+    {
+      projectName: 'Two',
+      includes: ['two/**/*.gql', 'two/**/*.graohql'],
+      amplifyExtension: {
+        graphQLApiId: 'two',
+        maxDepth: 10,
+        generatedFileName: 'two-2.ts',
+        codeGenTarget: 'language-two',
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    selectProject.mockReturnValue(mockAPI);
+    askCodegenTargetLanguage.mockReturnValue(mockTargetLanguage);
+    askCodegneQueryFilePattern.mockReturnValue(mockIncludes);
+    askGeneratedFileName.mockReturnValue(mockGeneratedFileName);
+    askMaxDepth.mockReturnValue(MOCK_MAX_DEPTH);
+    getIncludePattern.mockReturnValue({
+      graphQLDirectory: mockGraphQLDirectory,
+      graphQLExtension: mockGraphQLExtension,
+    });
+  });
+
+  it('should pass the available list of AppSync APIs', async () => {
+    const results = await configure(mockContext, mockConfigs);
+    const mockProjectSelect = [
+      {
+        name: mockConfigs[0].projectName,
+        value: mockConfigs[0].amplifyExtension.graphQLApiId,
+      },
+      {
+        name: mockConfigs[1].projectName,
+        value: mockConfigs[1].amplifyExtension.graphQLApiId,
+      },
+    ];
+    expect(selectProject).toHaveBeenCalledWith(mockContext, mockProjectSelect);
+    expect(askCodegenTargetLanguage).toHaveBeenCalledWith(
+      mockContext,
+      mockConfigs[1].amplifyExtension.codeGenTarget,
+      false,
+      undefined,
+      undefined
+    );
+    expect(askCodegneQueryFilePattern).toHaveBeenCalledWith([join(mockGraphQLDirectory, '**', mockGraphQLExtension)]);
+    expect(askGeneratedFileName).toHaveBeenCalledWith(mockConfigs[1].amplifyExtension.generatedFileName, mockTargetLanguage);
+    expect(askMaxDepth).toHaveBeenCalledWith(10);
+    expect(results).toEqual({
+      projectName: mockConfigs[1].projectName,
+      includes: mockIncludes,
+      amplifyExtension: {
+        graphQLApiId: mockConfigs[1].amplifyExtension.graphQLApiId,
+        generatedFileName: mockGeneratedFileName,
+        codeGenTarget: mockTargetLanguage,
+        maxDepth: MOCK_MAX_DEPTH,
+      },
+    });
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/apiTarget.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/apiTarget.test.js
@@ -1,0 +1,40 @@
+const inquirer = require('inquirer');
+
+const askAppSyncAPITarget = require('../../../src/walkthrough/questions/apiTarget');
+
+jest.mock('inquirer');
+
+describe('askAppSyncAPITarget', () => {
+  const mockContext = 'MOCK_CONTEXT';
+  const selectedAPI = 'appsync-selected-api';
+  const appSyncAPIs = [
+    { name: 'api1', id: selectedAPI },
+    { name: 'api2', id: 'non-selected-api' },
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    inquirer.prompt.mockReturnValue({ apiId: selectedAPI });
+  });
+
+  it('should show a list of APIs', async () => {
+    const api = await askAppSyncAPITarget(mockContext, appSyncAPIs, selectedAPI);
+    expect(api).toEqual(selectedAPI);
+    const promptParams = inquirer.prompt.mock.calls[0][0];
+    const expectedChoices = appSyncAPIs.map(a => ({ name: a.name, value: a.id }));
+    expect(promptParams[0].choices).toEqual(expectedChoices);
+    expect(promptParams[0].type).toEqual('list');
+  });
+
+  it('should not prompt if there is only one API available', async () => {
+    const api = await askAppSyncAPITarget(mockContext, [appSyncAPIs[0]], selectedAPI);
+    expect(api).toEqual(appSyncAPIs[0].id);
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('should use the selected API as default value for choice', async () => {
+    await askAppSyncAPITarget(mockContext, appSyncAPIs, selectedAPI);
+    const promptParams = inquirer.prompt.mock.calls[0][0];
+    expect(promptParams[0].default).toEqual(selectedAPI);
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/generateCode.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/generateCode.test.js
@@ -1,0 +1,17 @@
+const inquirer = require('inquirer');
+
+const askGenerateCode = require('../../../src/walkthrough/questions/generateCode');
+
+jest.mock('inquirer');
+
+describe('shouldGenerateCode', () => {
+  inquirer.prompt.mockReturnValue({ confirmGenerateCode: false });
+  it('should confirm users if they want to generate the code', async () => {
+    const answer = await askGenerateCode();
+    expect(answer).toBe(false);
+    const questions = inquirer.prompt.mock.calls[0][0];
+    expect(questions[0].name).toEqual('confirmGenerateCode');
+    expect(questions[0].type).toEqual('confirm');
+    expect(questions[0].default).toEqual(true);
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/generateDocs.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/generateDocs.test.js
@@ -1,0 +1,16 @@
+const generateDocs = require('../../../src/walkthrough/questions/generateDocs');
+const { prompt } = require('inquirer');
+
+jest.mock('inquirer');
+prompt.mockReturnValue({
+  confirmGenerateOperations: true,
+});
+describe('generateDocs', () => {
+  it('should ask if the user if they want to generate GraphQL Docs from schema', async () => {
+    const asnwer = await generateDocs();
+    expect(asnwer).toEqual(true);
+    expect(prompt).toHaveBeenCalled();
+    const callArgs = prompt.mock.calls[0][0][0];
+    expect(callArgs.name).toEqual('confirmGenerateOperations');
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
@@ -1,0 +1,44 @@
+const inquirer = require('inquirer');
+
+const { getFrontEndHandler } = require('../../../src/utils');
+const { AmplifyCodeGenNotSupportedError } = require('../../../src/errors');
+const askCodegenTargetLanguage = require('../../../src/walkthrough/questions/languageTarget');
+
+jest.mock('inquirer');
+jest.mock('../../../src/utils');
+
+describe('askCodegenTargetLanguage', () => {
+  const mockContext = {
+    print: {
+      info: jest.fn(),
+    },
+  };
+  it('should prompt when the front end framework is iOS', async () => {
+    getFrontEndHandler.mockReturnValue('ios');
+    const targetLanguage = await askCodegenTargetLanguage(mockContext);
+    expect(targetLanguage).toEqual('swift');
+    expect(getFrontEndHandler).toHaveBeenCalledWith(mockContext);
+  });
+
+  it('should throw error if the front end handler is for unsupported front end handlers', async () => {
+    getFrontEndHandler.mockReturnValue('android');
+    try {
+      await askCodegenTargetLanguage(mockContext);
+    } catch (e) {
+      expect(e).toBeInstanceOf(AmplifyCodeGenNotSupportedError);
+      expect(getFrontEndHandler).toHaveBeenCalledWith(mockContext);
+    }
+  });
+
+  it('should allow user to select the language target when front end is javascript', async () => {
+    getFrontEndHandler.mockReturnValue('javascript');
+    inquirer.prompt.mockReturnValue({ target: 'typescript' });
+    await askCodegenTargetLanguage(mockContext);
+    expect(inquirer.prompt).toHaveBeenCalled();
+
+    const questions = inquirer.prompt.mock.calls[0][0];
+    expect(questions[0].type).toEqual('list');
+    expect(questions[0].name).toEqual('target');
+    expect(questions[0].choices).toEqual(['javascript', 'typescript', 'flow']);
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/queryFilePattern.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/queryFilePattern.test.js
@@ -1,0 +1,17 @@
+const inquirer = require('inquirer');
+
+const askCodegneQueryFilePattern = require('../../../src/walkthrough/questions/queryFilePattern');
+
+jest.mock('inquirer');
+
+describe('askCodegneQueryFilePattern', () => {
+  const includePattern = 'src/**/*.gql';
+  inquirer.prompt.mockReturnValue({ includePattern });
+  it('should ask user for query file pattern', async () => {
+    const answer = await askCodegneQueryFilePattern();
+    expect(answer).toEqual([includePattern]);
+    const questions = inquirer.prompt.mock.calls[0][0];
+    expect(questions[0].name).toEqual('includePattern');
+    expect(questions[0].type).toEqual('input');
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/selectProject.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/selectProject.test.js
@@ -1,0 +1,36 @@
+const inquirer = require('inquirer');
+
+const askForProject = require('../../../src/walkthrough/questions/selectProject');
+
+jest.mock('inquirer');
+
+describe('Select project', () => {
+  const mockContext = 'CONTEXT';
+  const mockProjects = [
+    { name: 'proj1', value: 'prj-1' },
+    { name: 'Proj2', value: 'prj2' },
+  ];
+  const selectedProject = 'prj2';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    inquirer.prompt.mockReturnValue({
+      projectName: selectedProject,
+    });
+  });
+
+  it('should show a prompt and allow user to select projects', async () => {
+    const answer = await askForProject(mockContext, mockProjects);
+    expect(answer).toEqual(selectedProject);
+    const promptParam = inquirer.prompt.mock.calls[0][0];
+    expect(promptParam[0].type).toEqual('list');
+    expect(promptParam[0].name).toEqual('projectName');
+    expect(promptParam[0].choices).toEqual(mockProjects);
+  });
+
+  it('should not prompt when there is a single project', async () => {
+    const answer = await askForProject(mockContext, [mockProjects[0]]);
+    expect(answer).toEqual(mockProjects[0].value);
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/amplify-codegen/tests/walkthrough/questions/updateDocs.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/updateDocs.test.js
@@ -1,0 +1,17 @@
+const inquirer = require('inquirer');
+
+const updateDocs = require('../../../src/walkthrough/questions/updateDocs');
+
+jest.mock('inquirer');
+
+describe('shouldUpdateDocs', () => {
+  inquirer.prompt.mockReturnValue({ confirmUpdateDocs: false });
+  it('should confirm users if they want to update the docs', async () => {
+    const answer = await updateDocs();
+    expect(answer).toBe(false);
+    const questions = inquirer.prompt.mock.calls[0][0];
+    expect(questions[0].name).toEqual('confirmUpdateDocs');
+    expect(questions[0].type).toEqual('confirm');
+    expect(questions[0].default).toEqual(true);
+  });
+});


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Migrate `amplify-codegen` from cli to codegen repo.
Bump the version to the next minor version: **2.22.0**
_How are these changes tested:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
