### PR TITLE
fix(amplify-codegen-appsync-model-plugin): include isNullable & isList in version hash

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -25,7 +25,7 @@ export 'SimpleModel.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = \\"dc3c6d4f5a93c447c05a7adb901ee79e\\";
+  String version = \\"20078c21a81919792555926e238b194e\\";
   @override
   List<ModelSchema> modelSchemas = [SimpleModel.schema];
   static final ModelProvider _instance = ModelProvider();

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -25,7 +25,7 @@ export 'SimpleModel.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = \\"c93024b4cb5966d577b5aa548edfb992\\";
+  String version = \\"dc3c6d4f5a93c447c05a7adb901ee79e\\";
   @override
   List<ModelSchema> modelSchemas = [SimpleModel.schema];
   static final ModelProvider _instance = ModelProvider();

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -338,7 +338,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "ace65a3762ae8764a52a487c71055733",
+            "version": "c67353403fbe0ce39751869febc23e9b",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -422,7 +422,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -499,7 +499,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -642,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -750,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"ace65a3762ae8764a52a487c71055733\\"
+            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
         };"
       `);
     });
@@ -854,7 +854,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
+            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
         };"
       `);
     });
@@ -943,7 +943,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"bff2efaf6e138056991c723932df2763\\"
+            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
         };"
       `);
     });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -338,7 +338,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "25c4cd8292ab7a24eb7810bf1244c416",
+            "version": "bc1b6d35e990f16a49dbb447a8876025",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -422,7 +422,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -499,7 +499,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -642,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -750,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -338,7 +338,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "c67353403fbe0ce39751869febc23e9b",
+            "version": "25c4cd8292ab7a24eb7810bf1244c416",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -422,7 +422,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
+            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
         };"
       `);
     });
@@ -499,7 +499,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
+            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
         };"
       `);
     });
@@ -642,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
+            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
         };"
       `);
     });
@@ -750,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"c67353403fbe0ce39751869febc23e9b\\"
+            \\"version\\": \\"25c4cd8292ab7a24eb7810bf1244c416\\"
         };"
       `);
     });
@@ -854,7 +854,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
+            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
         };"
       `);
     });
@@ -943,7 +943,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"07b159e5243ee5817fb1e965dbc3ffdb\\"
+            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
         };"
       `);
     });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -867,7 +867,7 @@ describe('AppSyncSwiftVisitor', () => {
       // Contains the set of classes that conforms to the \`Model\` protocol. 
 
       final public class AmplifyModels: AmplifyModelRegistration {
-        public let version: String = \\"ca73d7dc63498f675fff2b260548d216\\"
+        public let version: String = \\"cc0c3fc03caae9e6458da692ebe0b460\\"
         
         public func registerModels(registry: ModelRegistry.Type) {
           ModelRegistry.register(modelType: Attraction.self)

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -867,7 +867,7 @@ describe('AppSyncSwiftVisitor', () => {
       // Contains the set of classes that conforms to the \`Model\` protocol. 
 
       final public class AmplifyModels: AmplifyModelRegistration {
-        public let version: String = \\"cc0c3fc03caae9e6458da692ebe0b460\\"
+        public let version: String = \\"7ad0a5459a63e207a3c53b584eac6a58\\"
         
         public func registerModels(registry: ModelRegistry.Type) {
           ModelRegistry.register(modelType: Attraction.self)

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -867,7 +867,7 @@ describe('AppSyncSwiftVisitor', () => {
       // Contains the set of classes that conforms to the \`Model\` protocol. 
 
       final public class AmplifyModels: AmplifyModelRegistration {
-        public let version: String = \\"7ad0a5459a63e207a3c53b584eac6a58\\"
+        public let version: String = \\"11dddb282be1f7ba4eabda5ee4c56430\\"
         
         public func registerModels(registry: ModelRegistry.Type) {
           ModelRegistry.register(modelType: Attraction.self)

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -198,6 +198,29 @@ describe('AppSyncModelVisitor', () => {
     expect(notRequiredVersion).not.toBe(requiredVersion);
   });
 
+  it('should generate different version if field array changes to required', () => {
+    const schemaNotRequired = /* GraphQL */ `
+      type Post @model {
+        id: ID!
+        title: [String]
+      }
+    `;
+    const visitorNotRequired = createAndGenerateVisitor(schemaNotRequired);
+
+    const schemaRequired = /* GraphQL */ `
+      type Post @model {
+        id: ID!
+        title: [String]!
+      }
+    `;
+    const visitorRequired = createAndGenerateVisitor(schemaRequired);
+
+    const notRequiredVersion = (visitorNotRequired as any).computeVersion();
+    const requiredVersion = (visitorRequired as any).computeVersion();
+
+    expect(notRequiredVersion).not.toBe(requiredVersion);
+  });
+
   describe(' 2 Way Connection', () => {
     describe('with connection name', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -392,6 +392,7 @@ export class AppSyncModelVisitor<
             directives: fieldDirectives,
             type: field.type,
             isNullable: field.isNullable,
+            isList: field.isList,
           };
         })
         .sort((a, b) => sortFields(a, b));

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -391,6 +391,7 @@ export class AppSyncModelVisitor<
             name: field.name,
             directives: fieldDirectives,
             type: field.type,
+            isNullable: field.isNullable,
           };
         })
         .sort((a, b) => sortFields(a, b));

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -393,6 +393,7 @@ export class AppSyncModelVisitor<
             type: field.type,
             isNullable: field.isNullable,
             isList: field.isList,
+            isListNullable: field.isListNullable,
           };
         })
         .sort((a, b) => sortFields(a, b));


### PR DESCRIPTION
*Issue #, if available:*
Given a basic schema in a JavaScript project:
```graphql
type Post @model {
  id: ID!
  title: String
}
```
after running `amplify models codegen` for the first time, the `schema.js` file is populated as expected with a unique `version` hash based on the type and the fields.

However, after changing `title` to be required with `String!`, and then running `amplify models codegen` again, the `version` doesn't change.

The same behavior also applies when changing a field from `String` to `[String]`.

My expectation is that a field's `isNullable` & `isList` attribute should be considered in this hash.

*Description of changes:*
- include `isNullable` & `isList` when calculating the `version` hash.

_How are these changes tested:_
- tested locally with a sample app as described above.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
