### PR TITLE
feat(modelgen): fetch graphql schemas from nested input folder

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -48,5 +48,8 @@
       "jsx",
       "node"
     ]
+  },
+  "devDependencies": {
+    "mock-fs": "^4.13.0"
   }
 }

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const { parse } = require('graphql');
+const glob  = require('glob-all');
 const { FeatureFlags, pathManager } = require('amplify-cli-core');
 const gqlCodeGen = require('@graphql-codegen/core');
 const { getModelgenPackage } = require('../utils/getModelgenPackage');
@@ -104,12 +105,11 @@ function loadSchema(apiResourcePath) {
     return fs.readFileSync(schemaFilePath, 'utf8');
   }
   if (fs.pathExistsSync(schemaDirectory) && fs.lstatSync(schemaDirectory).isDirectory()) {
-    return fs
-      .readdirSync(schemaDirectory)
-      .map(file => path.join(schemaDirectory, file))
-      .filter(file => file.endsWith('.graphql') && fs.lstatSync(file).isFile())
-      .map(file => fs.readFileSync(file, 'utf8'))
-      .join('\n');
+    // search recursively for graphql schema files inside `schema` directory
+    const schemas = glob.sync([
+      path.join(schemaDirectory, '**/*.graphql')
+    ]);
+    return schemas.map(file => fs.readFileSync(file, 'utf8')).join('\n');
   }
 
   throw new Error('Could not load the schema');

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -109,5 +109,5 @@ describe('command-models-generates models in expected output path', () => {
         });
     };
 
-    afterEach(mock.restore);
+    afterEach(mockFs.restore);
   });

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -1,0 +1,113 @@
+const generateModels = require('../../src/commands/models');
+const mock = require('mock-fs');
+const graphqlCodegen = require('@graphql-codegen/core');
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('@graphql-codegen/core');
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+  },
+  amplify: {
+    getProjectMeta: jest.fn(),
+    getEnvInfo: jest.fn(),
+    getResourceStatus: jest.fn(),
+    executeProviderUtils: jest.fn(),
+    pathManager: {
+        getBackendDirPath: jest.fn()
+    },
+    getProjectConfig: jest.fn()
+  },
+};
+const OUTPUT_PATHS = {
+    javascript: 'src',
+    android: 'app/src/main/java',
+    ios: 'amplify/generated/models',
+    flutter: 'lib/models'
+};
+const MOCK_PROJECT_ROOT = 'project';
+const MOCK_PROJECT_NAME = 'myapp';
+const MOCK_BACKEND_DIRECTORY = 'backend';
+const MOCK_GENERATED_CODE = 'This code is auto-generated!';
+
+// Mock the Feature flag to use migrated moldegen
+jest.mock('amplify-cli-core', (MOCK_PROJECT_ROOT) => {
+  return {
+    FeatureFlags: {
+      getBoolean: jest.fn().mockImplementation((name, defaultValue) => {
+        if (name === 'codegen.useappsyncmodelgenplugin') {
+          return true;
+        }
+      })
+    },
+    pathManager: {
+        findProjectRoot: jest.fn().mockReturnValue(MOCK_PROJECT_ROOT)
+    }
+  };
+});
+
+describe('command - models', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({projectPath: MOCK_PROJECT_ROOT});
+      MOCK_CONTEXT.amplify.getResourceStatus.mockReturnValue(
+           {
+              allResources: [
+                  {
+                      service: 'AppSync', 
+                      providerPlugin: 'awscloudformation',
+                      resourceName: MOCK_PROJECT_NAME
+                    }
+                ]
+            }
+        );
+      MOCK_CONTEXT.amplify.executeProviderUtils.mockReturnValue([]);
+      MOCK_CONTEXT.amplify.pathManager.getBackendDirPath.mockReturnValue(MOCK_BACKEND_DIRECTORY);
+      graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
+    });
+
+    for (const frontend in OUTPUT_PATHS) {
+        it(frontend + ': Should generate models from a single schema file', async () => {
+            // mock the input and output file structure
+            const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
+            const mockedFiles = {};
+            mockedFiles[schemaFilePath] = {
+                'schema.graphql': ' type SimpleModel { id: ID! status: String } '
+            };
+            mockedFiles[path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend])] = {}
+            mock(mockedFiles);
+            MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+            const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+            // assert empty folder before generation
+            expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+            await generateModels(MOCK_CONTEXT);
+            // assert model generation succeeds with a single schema file
+            expect(graphqlCodegen.codegen).toBeCalled();
+            // assert model files are generated in expected output directory
+            expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+        });
+
+        it(frontend + ': Should generate models from any subdirectory in schema folder', async () => {
+            // mock the input and output file structure
+            const schemaFolderPath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME, 'schema', 'nested', 'deeply');
+            const mockedFiles = {};
+            mockedFiles[schemaFolderPath] = {
+                'myschema.graphql': ' type SimpleModel { id: ID! status: String } '
+            };
+            mockedFiles[path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend])] = {}
+            mock(mockedFiles);
+            MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+            const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+            // assert empty folder before generation
+            expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+            await generateModels(MOCK_CONTEXT);
+            // assert model generation succeeds with a single schema file
+            expect(graphqlCodegen.codegen).toBeCalled();
+            // assert model files are generated in expected output directory
+            expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+        });
+    };
+
+    afterEach(mock.restore);
+  });

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -1,5 +1,5 @@
 const generateModels = require('../../src/commands/models');
-const mock = require('mock-fs');
+const mockFs = require('mock-fs');
 const graphqlCodegen = require('@graphql-codegen/core');
 const fs = require('fs');
 const path = require('path');
@@ -47,7 +47,7 @@ jest.mock('amplify-cli-core', (MOCK_PROJECT_ROOT) => {
   };
 });
 
-describe('command - models', () => {
+describe('command-models-generates models in expected output path', () => {
     beforeEach(() => {
       jest.resetAllMocks();
       MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({projectPath: MOCK_PROJECT_ROOT});
@@ -76,7 +76,7 @@ describe('command - models', () => {
                 'schema.graphql': ' type SimpleModel { id: ID! status: String } '
             };
             mockedFiles[path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend])] = {}
-            mock(mockedFiles);
+            mockFs(mockedFiles);
             MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
             const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
             // assert empty folder before generation
@@ -96,7 +96,7 @@ describe('command - models', () => {
                 'myschema.graphql': ' type SimpleModel { id: ID! status: String } '
             };
             mockedFiles[path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend])] = {}
-            mock(mockedFiles);
+            mockFs(mockedFiles);
             MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
             const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
             // assert empty folder before generation


### PR DESCRIPTION
_Issue #, if available:_.  #75 

_Description of changes:_
These changes enable developers to organize their GraphQL schema files in nested directories eliminating the hard constraint to have all schema files at the root of `schema` folder. 

Note:
If the developer however, also has a `schema.graphql` file in the path as specified in prompt `Edit your schema at project/typescriptapp/amplify/backend/api/typescriptapp/schema.graphql or place .graphql files in a directory at project/typescriptapp/amplify/backend/api/typescriptapp/schema`, that takes precedence and the `schema` folder is not searched. 

_How are these changes tested:_
- using unit tests
- using sample typescript and flutter apps

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
