### PR TITLE
fix(docsgen):handling different case types

### DIFF
--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -61,6 +61,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
         separateFiles: true,
         language,
         maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
+        retainCaseStyle: FeatureFlags.getBoolean('codegen.docsgen.retainCaseStyle')
       });
       opsGenSpinner.succeed(constants.INFO_MESSAGE_OPS_GEN_SUCCESS + path.relative(path.resolve('.'), opsGenDirectory));
     } finally {

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -61,7 +61,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
         separateFiles: true,
         language,
         maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
-        retainCaseStyle: FeatureFlags.getBoolean('codegen.docsgen.retainCaseStyle')
+        retainCaseStyle: FeatureFlags.getBoolean('codegen.retainCaseStyle')
       });
       opsGenSpinner.succeed(constants.INFO_MESSAGE_OPS_GEN_SUCCESS + path.relative(path.resolve('.'), opsGenDirectory));
     } finally {

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -1996,3 +1996,2348 @@ export const reviewAdded = /* GraphQL */ \`
 \`;
 "
 `;
+
+exports[`end 2 end tests to check naming types with different cases should generate statements 1`] = `
+"# this is an auto generated file. This will be overwritten
+query GetUPPERCASE($id: ID!) {
+  getUPPERCASE(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListUPPERCASEs(
+  $filter: ModelUPPERCASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query GetLowercase($id: ID!) {
+  getLowercase(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListLowercases(
+  $filter: ModellowercaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query GetCamelCase($id: ID!) {
+  getCamelCase(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListCamelCases(
+  $filter: ModelcamelCaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query GetPascalCase($id: ID!) {
+  getPascalCase(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListPascalCases(
+  $filter: ModelPascalCaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query GetSnake_case($id: ID!) {
+  getSnake_case(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListSnake_cases(
+  $filter: Modelsnake_caseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query GetUPPER_SNAKE_CASE($id: ID!) {
+  getUPPER_SNAKE_CASE(id: $id) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+query ListUPPER_SNAKE_CASEs(
+  $filter: ModelUPPER_SNAKE_CASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listUPPER_SNAKE_CASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+query QueryByOwner(
+  $owner: String
+  $sortDirection: ModelSortDirection
+  $filter: ModelUPPERCASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  queryByOwner(
+    owner: $owner
+    sortDirection: $sortDirection
+    filter: $filter
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+  }
+}
+mutation CreateUPPERCASE(
+  $input: CreateUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  createUPPERCASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateUPPERCASE(
+  $input: UpdateUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  updateUPPERCASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteUPPERCASE(
+  $input: DeleteUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  deleteUPPERCASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateLowercase(
+  $input: CreateLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  createLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateLowercase(
+  $input: UpdateLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  updateLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteLowercase(
+  $input: DeleteLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  deleteLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateCamelCase(
+  $input: CreateCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  createCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateCamelCase(
+  $input: UpdateCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  updateCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteCamelCase(
+  $input: DeleteCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  deleteCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreatePascalCase(
+  $input: CreatePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  createPascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdatePascalCase(
+  $input: UpdatePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  updatePascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeletePascalCase(
+  $input: DeletePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  deletePascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateSnake_case(
+  $input: CreateSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  createSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateSnake_case(
+  $input: UpdateSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  updateSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteSnake_case(
+  $input: DeleteSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  deleteSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateUPPER_SNAKE_CASE(
+  $input: CreateUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateUPPER_SNAKE_CASE(
+  $input: UpdateUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteUPPER_SNAKE_CASE(
+  $input: DeleteUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateUPPERCASE {
+  onCreateUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateUPPERCASE {
+  onUpdateUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteUPPERCASE {
+  onDeleteUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateLowercase {
+  onCreateLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateLowercase {
+  onUpdateLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteLowercase {
+  onDeleteLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateCamelCase {
+  onCreateCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateCamelCase {
+  onUpdateCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteCamelCase {
+  onDeleteCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreatePascalCase {
+  onCreatePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdatePascalCase {
+  onUpdatePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeletePascalCase {
+  onDeletePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateSnake_case {
+  onCreateSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateSnake_case {
+  onUpdateSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteSnake_case {
+  onDeleteSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateUPPER_SNAKE_CASE {
+  onCreateUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateUPPER_SNAKE_CASE {
+  onUpdateUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteUPPER_SNAKE_CASE {
+  onDeleteUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+"
+`;
+
+exports[`end 2 end tests to check naming types with different cases should generate statements in JS 1`] = `
+"/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests to check naming types with different cases should generate statements in Typescript 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests to check naming types with different cases should generate statements in flow 1`] = `
+"// @flow
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
+`;

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -1997,7 +1997,7 @@ export const reviewAdded = /* GraphQL */ \`
 "
 `;
 
-exports[`end 2 end tests to check naming types with different cases should generate statements 1`] = `
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements 1`] = `
 "# this is an auto generated file. This will be overwritten
 query GetUPPERCASE($id: ID!) {
   getUPPERCASE(id: $id) {
@@ -2505,7 +2505,7 @@ subscription OnDeleteUPPER_SNAKE_CASE {
 "
 `;
 
-exports[`end 2 end tests to check naming types with different cases should generate statements in JS 1`] = `
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in JS 1`] = `
 "/* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
@@ -3117,7 +3117,7 @@ export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
 "
 `;
 
-exports[`end 2 end tests to check naming types with different cases should generate statements in Typescript 1`] = `
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in Typescript 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
@@ -3730,7 +3730,7 @@ export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
 "
 `;
 
-exports[`end 2 end tests to check naming types with different cases should generate statements in flow 1`] = `
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in flow 1`] = `
 "// @flow
 // this is an auto generated file. This will be overwritten
 

--- a/packages/graphql-docs-generator/__integration__/e2e.test.ts
+++ b/packages/graphql-docs-generator/__integration__/e2e.test.ts
@@ -39,3 +39,41 @@ describe('end 2 end tests', () => {
     expect(generatedOutput).toMatchSnapshot();
   });
 });
+
+describe('end 2 end tests to check naming types with different cases', () => {
+  const schemaPath = resolve(__dirname, '../fixtures/caseTypes.graphql');
+  const outputpath = resolve(__dirname, './output.graphql');
+
+  afterEach(() => {
+    // delete the generated file
+    try {
+      fs.unlinkSync(outputpath);
+    } catch (e) {
+      // CircleCI throws exception, no harm done if the file is not deleted
+    }
+  });
+
+  it('should generate statements', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'graphql' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  });
+
+  it('should generate statements in JS', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'javascript' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  });
+
+  it('should generate statements in Typescript', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'typescript' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  });
+
+  it('should generate statements in flow', () => {
+    generate(schemaPath, outputpath, { separateFiles: false, maxDepth: 3, language: 'flow' });
+    const generatedOutput = fs.readFileSync(outputpath, 'utf8');
+    expect(generatedOutput).toMatchSnapshot();
+  });
+});

--- a/packages/graphql-docs-generator/__integration__/e2e.test.ts
+++ b/packages/graphql-docs-generator/__integration__/e2e.test.ts
@@ -40,7 +40,7 @@ describe('end 2 end tests', () => {
   });
 });
 
-describe('end 2 end tests to check naming types with different cases', () => {
+describe('end 2 end tests to test if the case style is retained for type names', () => {
   const schemaPath = resolve(__dirname, '../fixtures/caseTypes.graphql');
   const outputpath = resolve(__dirname, './output.graphql');
 

--- a/packages/graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
@@ -22,12 +22,12 @@ const operations = {
 const maxDepth = 10;
 
 const mockSchema = 'MOCK_SCHEMA';
-const generateOptions: GQLDocsGenOptions = { useExternalFragmentForS3Object: true };
 describe('generateAllOperations', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  const generateOptions: GQLDocsGenOptions = { useExternalFragmentForS3Object: true, retainCaseStyle: true };
   it('generateQueries - should call generateOperation', () => {
     expect(generateQueries(operations, mockSchema, maxDepth, generateOptions)).toEqual([
       {
@@ -67,6 +67,54 @@ describe('generateAllOperations', () => {
     expect(generateOperation).toHaveBeenCalledTimes(1);
     expect(getFields).toHaveBeenCalledTimes(1);
     expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions);
+  });
+});
+
+describe('Test generating operations by not retaining case style', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getFields.mockReturnValue({UPPERCASE: 'value'});
+  });
+  const generateOptions: GQLDocsGenOptions = { useExternalFragmentForS3Object: true, retainCaseStyle: false };
+  it('generateQueries - should call generateOperation', () => {
+    expect(generateQueries(operations, mockSchema, maxDepth, generateOptions)).toEqual([
+      {
+        type: 'query',
+        name: 'Uppercase',
+        ...mockOperationResult,
+      },
+    ]);
+    expect(generateOperation).toHaveBeenCalledWith('value', mockSchema, maxDepth, generateOptions);
+    expect(getFields).toHaveBeenCalled();
+    expect(generateOperation).toHaveBeenCalledTimes(1);
+    expect(getFields).toHaveBeenCalledTimes(1);
+  });
+
+  it('generateMutation - should call generateOperation', () => {
+    expect(generateMutations(operations, mockSchema, maxDepth, generateOptions)).toEqual([
+      {
+        type: 'mutation',
+        name: 'Uppercase',
+        ...mockOperationResult,
+      },
+    ]);
+    expect(generateOperation).toHaveBeenCalledWith('value', mockSchema, maxDepth, generateOptions);
+    expect(getFields).toHaveBeenCalled();
+    expect(generateOperation).toHaveBeenCalledTimes(1);
+    expect(getFields).toHaveBeenCalledTimes(1);
+  });
+
+  it('generateSubscription - should call generateOperation', () => {
+    expect(generateSubscriptions(operations, mockSchema, maxDepth, generateOptions)).toEqual([
+      {
+        type: 'subscription',
+        name: 'Uppercase',
+        ...mockOperationResult,
+      },
+    ]);
+    expect(generateOperation).toHaveBeenCalledTimes(1);
+    expect(getFields).toHaveBeenCalledTimes(1);
+    expect(generateOperation).toHaveBeenCalledWith('value', mockSchema, maxDepth, generateOptions);
   });
 });
 

--- a/packages/graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/generateAllOperations.test.ts
@@ -1,4 +1,4 @@
-import { generateQueries, generateMutations, generateSubscriptions } from '../../src/generator/generateAllOperations';
+import { generateQueries, generateMutations, generateSubscriptions, capitalizeFirstLetter, lowerCaseFirstLetter } from '../../src/generator/generateAllOperations';
 
 import generateOperation from '../../src/generator/generateOperation';
 import { GQLDocsGenOptions } from '../../src/generator/types';
@@ -67,5 +67,65 @@ describe('generateAllOperations', () => {
     expect(generateOperation).toHaveBeenCalledTimes(1);
     expect(getFields).toHaveBeenCalledTimes(1);
     expect(generateOperation).toHaveBeenCalledWith(mockFields.f1, mockSchema, maxDepth, generateOptions);
+  });
+});
+
+describe('test capitalizeFirstLetter', () =>{
+  it('test capitalize first letter with empty string', () => {
+    expect(capitalizeFirstLetter('')).toEqual('');
+  });
+
+  it('test capitalize first letter with lowercase string', () => {
+    expect(capitalizeFirstLetter('lowercase')).toEqual('Lowercase');
+  });
+
+  it('test capitalize first letter with UPPERCASE string', () => {
+    expect(capitalizeFirstLetter('UPPERCASE')).toEqual('UPPERCASE');
+  });
+
+  it('test capitalize first letter with snake_case string', () => {
+    expect(capitalizeFirstLetter('snake_case')).toEqual('Snake_case');
+  });
+
+  it('test capitalize first letter with UPPER_SNAKE_CASE string', () => {
+    expect(capitalizeFirstLetter('UPPER_SNAKE_CASE')).toEqual('UPPER_SNAKE_CASE');
+  });
+
+  it('test capitalize first letter with camelCase string', () => {
+    expect(capitalizeFirstLetter('camelCase')).toEqual('CamelCase');
+  });
+
+  it('test capitalize first letter with PascalCase string', () => {
+    expect(capitalizeFirstLetter('PascalCase')).toEqual('PascalCase');
+  });
+});
+
+describe('test lowerCaseFirstLetter', () =>{
+  it('test lower casing first letter with empty string', () => {
+    expect(lowerCaseFirstLetter('')).toEqual('');
+  });
+
+  it('test lower casing first letter with lowercase string', () => {
+    expect(lowerCaseFirstLetter('lowercase')).toEqual('lowercase');
+  });
+
+  it('test lower casing first letter with UPPERCASE string', () => {
+    expect(lowerCaseFirstLetter('UPPERCASE')).toEqual('uPPERCASE');
+  });
+
+  it('test lower casing first letter with snake_case string', () => {
+    expect(lowerCaseFirstLetter('snake_case')).toEqual('snake_case');
+  });
+
+  it('test lower casing first letter with UPPER_SNAKE_CASE string', () => {
+    expect(lowerCaseFirstLetter('UPPER_SNAKE_CASE')).toEqual('uPPER_SNAKE_CASE');
+  });
+
+  it('test lower casing first letter with camelCase string', () => {
+    expect(lowerCaseFirstLetter('camelCase')).toEqual('camelCase');
+  });
+
+  it('test lower casing first letter with PascalCase string', () => {
+    expect(lowerCaseFirstLetter('PascalCase')).toEqual('pascalCase');
   });
 });

--- a/packages/graphql-docs-generator/fixtures/caseTypes.graphql
+++ b/packages/graphql-docs-generator/fixtures/caseTypes.graphql
@@ -1,0 +1,442 @@
+type UPPERCASE {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+type lowercase {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+type camelCase {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+type PascalCase {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+type snake_case {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+type UPPER_SNAKE_CASE {
+  id: ID!
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+enum ModelSortDirection {
+  ASC
+  DESC
+}
+
+type ModelUPPERCASEConnection {
+  items: [UPPERCASE]
+  nextToken: String
+}
+
+input ModelStringInput {
+  ne: String
+  eq: String
+  le: String
+  lt: String
+  ge: String
+  gt: String
+  contains: String
+  notContains: String
+  between: [String]
+  beginsWith: String
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIDInput {
+  ne: ID
+  eq: ID
+  le: ID
+  lt: ID
+  ge: ID
+  gt: ID
+  contains: ID
+  notContains: ID
+  between: [ID]
+  beginsWith: ID
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+  size: ModelSizeInput
+}
+
+input ModelIntInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelFloatInput {
+  ne: Float
+  eq: Float
+  le: Float
+  lt: Float
+  ge: Float
+  gt: Float
+  between: [Float]
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelBooleanInput {
+  ne: Boolean
+  eq: Boolean
+  attributeExists: Boolean
+  attributeType: ModelAttributeTypes
+}
+
+input ModelSizeInput {
+  ne: Int
+  eq: Int
+  le: Int
+  lt: Int
+  ge: Int
+  gt: Int
+  between: [Int]
+}
+
+input ModelUPPERCASEFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelUPPERCASEFilterInput]
+  or: [ModelUPPERCASEFilterInput]
+  not: ModelUPPERCASEFilterInput
+}
+
+enum ModelAttributeTypes {
+  binary
+  binarySet
+  bool
+  list
+  map
+  number
+  numberSet
+  string
+  stringSet
+  _null
+}
+
+type Query {
+  getUPPERCASE(id: ID!): UPPERCASE
+  listUPPERCASEs(filter: ModelUPPERCASEFilterInput, limit: Int, nextToken: String): ModelUPPERCASEConnection
+  getLowercase(id: ID!): lowercase
+  listLowercases(filter: ModellowercaseFilterInput, limit: Int, nextToken: String): ModellowercaseConnection
+  getCamelCase(id: ID!): camelCase
+  listCamelCases(filter: ModelcamelCaseFilterInput, limit: Int, nextToken: String): ModelcamelCaseConnection
+  getPascalCase(id: ID!): PascalCase
+  listPascalCases(filter: ModelPascalCaseFilterInput, limit: Int, nextToken: String): ModelPascalCaseConnection
+  getSnake_case(id: ID!): snake_case
+  listSnake_cases(filter: Modelsnake_caseFilterInput, limit: Int, nextToken: String): Modelsnake_caseConnection
+  getUPPER_SNAKE_CASE(id: ID!): UPPER_SNAKE_CASE
+  listUPPER_SNAKE_CASEs(filter: ModelUPPER_SNAKE_CASEFilterInput, limit: Int, nextToken: String): ModelUPPER_SNAKE_CASEConnection
+  queryByOwner(owner: String, sortDirection: ModelSortDirection, filter: ModelUPPERCASEFilterInput, limit: Int, nextToken: String): ModelUPPERCASEConnection
+}
+
+input CreateUPPERCASEInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdateUPPERCASEInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeleteUPPERCASEInput {
+  id: ID
+}
+
+type Mutation {
+  createUPPERCASE(input: CreateUPPERCASEInput!, condition: ModelUPPERCASEConditionInput): UPPERCASE
+  updateUPPERCASE(input: UpdateUPPERCASEInput!, condition: ModelUPPERCASEConditionInput): UPPERCASE
+  deleteUPPERCASE(input: DeleteUPPERCASEInput!, condition: ModelUPPERCASEConditionInput): UPPERCASE
+  createLowercase(input: CreateLowercaseInput!, condition: ModellowercaseConditionInput): lowercase
+  updateLowercase(input: UpdateLowercaseInput!, condition: ModellowercaseConditionInput): lowercase
+  deleteLowercase(input: DeleteLowercaseInput!, condition: ModellowercaseConditionInput): lowercase
+  createCamelCase(input: CreateCamelCaseInput!, condition: ModelcamelCaseConditionInput): camelCase
+  updateCamelCase(input: UpdateCamelCaseInput!, condition: ModelcamelCaseConditionInput): camelCase
+  deleteCamelCase(input: DeleteCamelCaseInput!, condition: ModelcamelCaseConditionInput): camelCase
+  createPascalCase(input: CreatePascalCaseInput!, condition: ModelPascalCaseConditionInput): PascalCase
+  updatePascalCase(input: UpdatePascalCaseInput!, condition: ModelPascalCaseConditionInput): PascalCase
+  deletePascalCase(input: DeletePascalCaseInput!, condition: ModelPascalCaseConditionInput): PascalCase
+  createSnake_case(input: CreateSnake_caseInput!, condition: Modelsnake_caseConditionInput): snake_case
+  updateSnake_case(input: UpdateSnake_caseInput!, condition: Modelsnake_caseConditionInput): snake_case
+  deleteSnake_case(input: DeleteSnake_caseInput!, condition: Modelsnake_caseConditionInput): snake_case
+  createUPPER_SNAKE_CASE(input: CreateUPPER_SNAKE_CASEInput!, condition: ModelUPPER_SNAKE_CASEConditionInput): UPPER_SNAKE_CASE
+  updateUPPER_SNAKE_CASE(input: UpdateUPPER_SNAKE_CASEInput!, condition: ModelUPPER_SNAKE_CASEConditionInput): UPPER_SNAKE_CASE
+  deleteUPPER_SNAKE_CASE(input: DeleteUPPER_SNAKE_CASEInput!, condition: ModelUPPER_SNAKE_CASEConditionInput): UPPER_SNAKE_CASE
+}
+
+input ModelUPPERCASEConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelUPPERCASEConditionInput]
+  or: [ModelUPPERCASEConditionInput]
+  not: ModelUPPERCASEConditionInput
+}
+
+type Subscription {
+  onCreateUPPERCASE: UPPERCASE @aws_subscribe(mutations: ["createUPPERCASE"])
+  onUpdateUPPERCASE: UPPERCASE @aws_subscribe(mutations: ["updateUPPERCASE"])
+  onDeleteUPPERCASE: UPPERCASE @aws_subscribe(mutations: ["deleteUPPERCASE"])
+  onCreateLowercase: lowercase @aws_subscribe(mutations: ["createLowercase"])
+  onUpdateLowercase: lowercase @aws_subscribe(mutations: ["updateLowercase"])
+  onDeleteLowercase: lowercase @aws_subscribe(mutations: ["deleteLowercase"])
+  onCreateCamelCase: camelCase @aws_subscribe(mutations: ["createCamelCase"])
+  onUpdateCamelCase: camelCase @aws_subscribe(mutations: ["updateCamelCase"])
+  onDeleteCamelCase: camelCase @aws_subscribe(mutations: ["deleteCamelCase"])
+  onCreatePascalCase: PascalCase @aws_subscribe(mutations: ["createPascalCase"])
+  onUpdatePascalCase: PascalCase @aws_subscribe(mutations: ["updatePascalCase"])
+  onDeletePascalCase: PascalCase @aws_subscribe(mutations: ["deletePascalCase"])
+  onCreateSnake_case: snake_case @aws_subscribe(mutations: ["createSnake_case"])
+  onUpdateSnake_case: snake_case @aws_subscribe(mutations: ["updateSnake_case"])
+  onDeleteSnake_case: snake_case @aws_subscribe(mutations: ["deleteSnake_case"])
+  onCreateUPPER_SNAKE_CASE: UPPER_SNAKE_CASE @aws_subscribe(mutations: ["createUPPER_SNAKE_CASE"])
+  onUpdateUPPER_SNAKE_CASE: UPPER_SNAKE_CASE @aws_subscribe(mutations: ["updateUPPER_SNAKE_CASE"])
+  onDeleteUPPER_SNAKE_CASE: UPPER_SNAKE_CASE @aws_subscribe(mutations: ["deleteUPPER_SNAKE_CASE"])
+}
+
+type ModellowercaseConnection {
+  items: [lowercase]
+  nextToken: String
+}
+
+input ModellowercaseFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModellowercaseFilterInput]
+  or: [ModellowercaseFilterInput]
+  not: ModellowercaseFilterInput
+}
+
+input CreateLowercaseInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdateLowercaseInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeleteLowercaseInput {
+  id: ID
+}
+
+input ModellowercaseConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModellowercaseConditionInput]
+  or: [ModellowercaseConditionInput]
+  not: ModellowercaseConditionInput
+}
+
+type ModelcamelCaseConnection {
+  items: [camelCase]
+  nextToken: String
+}
+
+input ModelcamelCaseFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelcamelCaseFilterInput]
+  or: [ModelcamelCaseFilterInput]
+  not: ModelcamelCaseFilterInput
+}
+
+input CreateCamelCaseInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdateCamelCaseInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeleteCamelCaseInput {
+  id: ID
+}
+
+input ModelcamelCaseConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelcamelCaseConditionInput]
+  or: [ModelcamelCaseConditionInput]
+  not: ModelcamelCaseConditionInput
+}
+
+type ModelPascalCaseConnection {
+  items: [PascalCase]
+  nextToken: String
+}
+
+input ModelPascalCaseFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelPascalCaseFilterInput]
+  or: [ModelPascalCaseFilterInput]
+  not: ModelPascalCaseFilterInput
+}
+
+input CreatePascalCaseInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdatePascalCaseInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeletePascalCaseInput {
+  id: ID
+}
+
+input ModelPascalCaseConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelPascalCaseConditionInput]
+  or: [ModelPascalCaseConditionInput]
+  not: ModelPascalCaseConditionInput
+}
+
+type Modelsnake_caseConnection {
+  items: [snake_case]
+  nextToken: String
+}
+
+input Modelsnake_caseFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [Modelsnake_caseFilterInput]
+  or: [Modelsnake_caseFilterInput]
+  not: Modelsnake_caseFilterInput
+}
+
+input CreateSnake_caseInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdateSnake_caseInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeleteSnake_caseInput {
+  id: ID
+}
+
+input Modelsnake_caseConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [Modelsnake_caseConditionInput]
+  or: [Modelsnake_caseConditionInput]
+  not: Modelsnake_caseConditionInput
+}
+
+type ModelUPPER_SNAKE_CASEConnection {
+  items: [UPPER_SNAKE_CASE]
+  nextToken: String
+}
+
+input ModelUPPER_SNAKE_CASEFilterInput {
+  id: ModelIDInput
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelUPPER_SNAKE_CASEFilterInput]
+  or: [ModelUPPER_SNAKE_CASEFilterInput]
+  not: ModelUPPER_SNAKE_CASEFilterInput
+}
+
+input CreateUPPER_SNAKE_CASEInput {
+  id: ID
+  owner: String!
+  createdAt: String
+  updatedAt: String
+}
+
+input UpdateUPPER_SNAKE_CASEInput {
+  id: ID!
+  owner: String
+  createdAt: String
+  updatedAt: String
+}
+
+input DeleteUPPER_SNAKE_CASEInput {
+  id: ID
+}
+
+input ModelUPPER_SNAKE_CASEConditionInput {
+  owner: ModelStringInput
+  createdAt: ModelStringInput
+  updatedAt: ModelStringInput
+  and: [ModelUPPER_SNAKE_CASEConditionInput]
+  or: [ModelUPPER_SNAKE_CASEConditionInput]
+  not: ModelUPPER_SNAKE_CASEConditionInput
+}

--- a/packages/graphql-docs-generator/src/cli.ts
+++ b/packages/graphql-docs-generator/src/cli.ts
@@ -52,9 +52,13 @@ export function run(argv: Array<String>): void {
           default: false,
           type: 'boolean',
         },
+        retainCaseStyle: {
+          default: true,
+          type: 'boolean'
+        }
       },
       async argv => {
-        generate(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth });
+        generate(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth, retainCaseStyle: argv.retainCaseStyle });
       }
     )
     .help()

--- a/packages/graphql-docs-generator/src/generator/generateAllOperations.ts
+++ b/packages/graphql-docs-generator/src/generator/generateAllOperations.ts
@@ -1,6 +1,4 @@
 import { GraphQLObjectType, GraphQLSchema } from 'graphql';
-import { pascalCase } from 'change-case';
-
 import generateOperation from './generateOperation';
 import {
   GQLTemplateOp,
@@ -22,7 +20,7 @@ export function generateQueries(
     const processedQueries: Array<GQLTemplateOp> = Object.keys(allQueries).map(queryName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.QUERY;
       const op = generateOperation(allQueries[queryName], schema, maxDepth, options);
-      const name: string = pascalCase(queryName);
+      const name: string = capitalizeFirstLetter(queryName);
       return { type, name, ...op };
     });
     return processedQueries;
@@ -40,7 +38,7 @@ export function generateMutations(
     const processedMutations = Object.keys(allMutations).map(mutationName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.MUTATION;
       const op = generateOperation(allMutations[mutationName], schema, maxDepth, options);
-      const name = pascalCase(mutationName);
+      const name = capitalizeFirstLetter(mutationName);
       return { type, name, ...op };
     });
     return processedMutations;
@@ -58,7 +56,7 @@ export function generateSubscriptions(
     const processedMutations = Object.keys(allSubscriptions).map(subscriptionName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.SUBSCRIPTION;
       const op = generateOperation(allSubscriptions[subscriptionName], schema, maxDepth, options);
-      const name = pascalCase(subscriptionName);
+      const name = capitalizeFirstLetter(subscriptionName);
       return { type, name, ...op };
     });
     return processedMutations;
@@ -85,4 +83,12 @@ function getExternalFragment(field: GQLTemplateField, externalFragments: object 
   });
 
   return externalFragments;
+}
+
+export function capitalizeFirstLetter(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export function lowerCaseFirstLetter(string: string): string {
+  return string.charAt(0).toLocaleLowerCase() + string.slice(1);
 }

--- a/packages/graphql-docs-generator/src/generator/generateAllOperations.ts
+++ b/packages/graphql-docs-generator/src/generator/generateAllOperations.ts
@@ -1,4 +1,6 @@
 import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { pascalCase } from 'change-case';
+
 import generateOperation from './generateOperation';
 import {
   GQLTemplateOp,
@@ -20,7 +22,7 @@ export function generateQueries(
     const processedQueries: Array<GQLTemplateOp> = Object.keys(allQueries).map(queryName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.QUERY;
       const op = generateOperation(allQueries[queryName], schema, maxDepth, options);
-      const name: string = capitalizeFirstLetter(queryName);
+      const name: string = options.retainCaseStyle ? capitalizeFirstLetter(queryName) : pascalCase(queryName);
       return { type, name, ...op };
     });
     return processedQueries;
@@ -38,7 +40,7 @@ export function generateMutations(
     const processedMutations = Object.keys(allMutations).map(mutationName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.MUTATION;
       const op = generateOperation(allMutations[mutationName], schema, maxDepth, options);
-      const name = capitalizeFirstLetter(mutationName);
+      const name: string = options.retainCaseStyle ? capitalizeFirstLetter(mutationName) : pascalCase(mutationName);
       return { type, name, ...op };
     });
     return processedMutations;
@@ -56,7 +58,7 @@ export function generateSubscriptions(
     const processedMutations = Object.keys(allSubscriptions).map(subscriptionName => {
       const type: GQLOperationTypeEnum = GQLOperationTypeEnum.SUBSCRIPTION;
       const op = generateOperation(allSubscriptions[subscriptionName], schema, maxDepth, options);
-      const name = capitalizeFirstLetter(subscriptionName);
+      const name: string = options.retainCaseStyle ? capitalizeFirstLetter(subscriptionName) : pascalCase(subscriptionName);
       return { type, name, ...op };
     });
     return processedMutations;

--- a/packages/graphql-docs-generator/src/generator/index.ts
+++ b/packages/graphql-docs-generator/src/generator/index.ts
@@ -2,5 +2,5 @@ import * as types from './types';
 
 export * from './types';
 import generate from './generate';
-export { generateMutations, generateSubscriptions, generateQueries } from './generateAllOperations';
+export { generateMutations, generateSubscriptions, generateQueries, lowerCaseFirstLetter } from './generateAllOperations';
 export default generate;

--- a/packages/graphql-docs-generator/src/generator/types.ts
+++ b/packages/graphql-docs-generator/src/generator/types.ts
@@ -71,5 +71,6 @@ export type GQLAllOperations = {
 };
 
 export type GQLDocsGenOptions = {
-  useExternalFragmentForS3Object: boolean;
+  useExternalFragmentForS3Object: boolean,
+  retainCaseStyle: boolean
 };

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as handlebars from 'handlebars';
 import * as prettier from 'prettier';
+import { camelCase } from 'change-case';
 const DEFAULT_MAX_DEPTH = 3;
 
 import generateAllOps, { GQLTemplateOp, GQLAllOperations, GQLTemplateFragment, lowerCaseFirstLetter } from './generator';
@@ -18,7 +19,7 @@ const FILE_EXTENSION_MAP = {
 export function generate(
   schemaPath: string,
   outputPath: string,
-  options: { separateFiles: boolean; language: string; maxDepth: number },
+  options: { separateFiles: boolean; language: string; maxDepth: number, retainCaseStyle: boolean },
 ): void {
   const language = options.language || 'graphql';
   const schemaData = loadSchema(schemaPath);
@@ -28,11 +29,13 @@ export function generate(
 
   const maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH;
   const useExternalFragmentForS3Object = options.language === 'graphql';
+  const retainCaseStyle = options.retainCaseStyle || true;
   const gqlOperations: GQLAllOperations = generateAllOps(schemaData, maxDepth, {
     useExternalFragmentForS3Object,
+    retainCaseStyle
   });
   registerPartials();
-  registerHelpers();
+  registerHelpers(retainCaseStyle);
 
   const fileExtension = FILE_EXTENSION_MAP[language];
   if (options.separateFiles) {
@@ -90,13 +93,14 @@ function registerPartials() {
   });
 }
 
-function registerHelpers() {
+function registerHelpers(retainCaseStyle: boolean) {
   handlebars.registerHelper('format', function(options: any) {
     const result = options.fn(this);
     return format(result);
   });
 
-  handlebars.registerHelper('lowerCaseFirstLetter', lowerCaseFirstLetter);
+  const formatNameHelper = retainCaseStyle ? lowerCaseFirstLetter : camelCase;
+  handlebars.registerHelper('formatName', formatNameHelper);
 }
 
 function format(str: string, language: string = 'graphql'): string {

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -2,10 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as handlebars from 'handlebars';
 import * as prettier from 'prettier';
-import { camelCase } from 'change-case';
 const DEFAULT_MAX_DEPTH = 3;
 
-import generateAllOps, { GQLTemplateOp, GQLAllOperations, GQLTemplateFragment } from './generator';
+import generateAllOps, { GQLTemplateOp, GQLAllOperations, GQLTemplateFragment, lowerCaseFirstLetter } from './generator';
 import { loadSchema } from './generator/utils/loading';
 const TEMPLATE_DIR = path.resolve(path.join(__dirname, '../templates'));
 const FILE_EXTENSION_MAP = {
@@ -97,7 +96,7 @@ function registerHelpers() {
     return format(result);
   });
 
-  handlebars.registerHelper('camelCase', camelCase);
+  handlebars.registerHelper('lowerCaseFirstLetter', lowerCaseFirstLetter);
 }
 
 function format(str: string, language: string = 'graphql'): string {

--- a/packages/graphql-docs-generator/templates/_renderToVariable.hbs
+++ b/packages/graphql-docs-generator/templates/_renderToVariable.hbs
@@ -1,5 +1,5 @@
 {{#each operations }}
-  export const {{camelCase name}} =  /* GraphQL */`{{#format }}
+  export const {{lowerCaseFirstLetter name}} =  /* GraphQL */`{{#format }}
       {{> renderOp }}
     {{/format}}`;
 {{/each}}

--- a/packages/graphql-docs-generator/templates/_renderToVariable.hbs
+++ b/packages/graphql-docs-generator/templates/_renderToVariable.hbs
@@ -1,5 +1,5 @@
 {{#each operations }}
-  export const {{lowerCaseFirstLetter name}} =  /* GraphQL */`{{#format }}
+  export const {{formatName name}} =  /* GraphQL */`{{#format }}
       {{> renderOp }}
     {{/format}}`;
 {{/each}}


### PR DESCRIPTION
_Issue #, if available:_   #37

_Description of changes:_
This changes brings more uniformity to the names of operations and variables generated as parts of statements generation during `amplify codegen statements`. It takes into account various cases possible for naming graphQL types and retains them in the generated operation names. 
This would allow developers to programmatically reference operation names as described in this customer issue #37.

_How are these changes tested:_
Added unit tests and e2e tests for all codegen target platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
