### PR TITLE
fix(amplify-codegen): use correct array type for includePattern

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -31,7 +31,7 @@
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",
     "glob-all": "^3.1.0",
-    "glob-parent": "5.1.1",
+    "glob-parent": "^5.1.1",
     "graphql": "^14.5.8",
     "graphql-config": "^2.2.1",
     "graphql-transformer-core": "^6.26.2",

--- a/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
+++ b/packages/amplify-codegen/src/utils/getGraphQLDocPath.js
@@ -5,7 +5,9 @@ function getGraphQLDocPath(frontend, graphQLDirectory, includePathGlob) {
   if (frontend === 'android') {
     return join(graphQLDirectory, 'com/amazonaws/amplify/generated/graphql');
   }
-  return includePathGlob ? globParent(includePathGlob) : graphQLDirectory;
+  return Array.isArray(includePathGlob) && includePathGlob.length > 0
+    ? globParent(includePathGlob[0])
+    : graphQLDirectory;
 }
 
 module.exports = getGraphQLDocPath;

--- a/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
+++ b/packages/amplify-codegen/tests/utils/getGraphQLDocPath.test.js
@@ -15,7 +15,7 @@ describe('getGraphQLDocPath', () => {
 
   it('should return parent folder for include glob path when frontend is not android and include path is defined', () => {
     const graphQLDirectory = getIncludePatterns('javascript').graphQLDirectory;
-    const includePathGlob = 'path/to/graphql/**/*.js';
+    const includePathGlob = ['path/to/graphql/**/*.js'];
     expect(getGraphQLDocPath('javascript', graphQLDirectory, includePathGlob)).toEqual('path/to/graphql');
   });
 });


### PR DESCRIPTION
_Issue #, if available:_
The wrong type casting of `includePattern` results in failing push in Windows OS
_Description of changes:_
Hot fix from https://github.com/aws-amplify/amplify-cli/pull/6722
_How are these changes tested:_
`jest`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
