### PR TITLE
fix(@aws-amplify/appsync-modelgen-plugin): JS targetName for hasOne

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -949,3 +949,200 @@ describe('Metadata visitor for auth process in field level', () => {
     });
   });
 });
+
+describe('Metadata visitor has one relation', () => {
+  const schema = /* GraphQL */ `
+    type Project @model {
+      id: ID!
+      name: String
+      teamID: ID!
+      team: Team @connection(fields: ["teamID"])
+    }
+    type Team @model {
+      id: ID!
+      name: String!
+    }
+  `;
+  let visitor: AppSyncJSONVisitor;
+  beforeEach(() => {
+    visitor = getVisitor(schema);
+  });
+
+  it('should generate for Javascript', () => {
+    const jsVisitor = getVisitor(schema, 'javascript');
+    expect(jsVisitor.generate()).toMatchInlineSnapshot(`
+      "export const schema = {
+          \\"models\\": {
+              \\"Project\\": {
+                  \\"name\\": \\"Project\\",
+                  \\"fields\\": {
+                      \\"id\\": {
+                          \\"name\\": \\"id\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"name\\": {
+                          \\"name\\": \\"name\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"String\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"teamID\\": {
+                          \\"name\\": \\"teamID\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"team\\": {
+                          \\"name\\": \\"team\\",
+                          \\"isArray\\": false,
+                          \\"type\\": {
+                              \\"model\\": \\"Team\\"
+                          },
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"association\\": {
+                              \\"connectionType\\": \\"HAS_ONE\\",
+                              \\"associatedWith\\": \\"id\\",
+                              \\"targetName\\": \\"teamID\\"
+                          }
+                      }
+                  },
+                  \\"syncable\\": true,
+                  \\"pluralName\\": \\"Projects\\",
+                  \\"attributes\\": [
+                      {
+                          \\"type\\": \\"model\\",
+                          \\"properties\\": {}
+                      }
+                  ]
+              },
+              \\"Team\\": {
+                  \\"name\\": \\"Team\\",
+                  \\"fields\\": {
+                      \\"id\\": {
+                          \\"name\\": \\"id\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"name\\": {
+                          \\"name\\": \\"name\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"String\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      }
+                  },
+                  \\"syncable\\": true,
+                  \\"pluralName\\": \\"Teams\\",
+                  \\"attributes\\": [
+                      {
+                          \\"type\\": \\"model\\",
+                          \\"properties\\": {}
+                      }
+                  ]
+              }
+          },
+          \\"enums\\": {},
+          \\"nonModels\\": {},
+          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+      };"
+    `);
+  });
+
+  it('should generate for TypeScript', () => {
+    const tsVisitor = getVisitor(schema, 'typescript');
+    expect(tsVisitor.generate()).toMatchInlineSnapshot(`
+      "import { Schema } from \\"@aws-amplify/datastore\\";
+
+      export const schema: Schema = {
+          \\"models\\": {
+              \\"Project\\": {
+                  \\"name\\": \\"Project\\",
+                  \\"fields\\": {
+                      \\"id\\": {
+                          \\"name\\": \\"id\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"name\\": {
+                          \\"name\\": \\"name\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"String\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"teamID\\": {
+                          \\"name\\": \\"teamID\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"team\\": {
+                          \\"name\\": \\"team\\",
+                          \\"isArray\\": false,
+                          \\"type\\": {
+                              \\"model\\": \\"Team\\"
+                          },
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"association\\": {
+                              \\"connectionType\\": \\"HAS_ONE\\",
+                              \\"associatedWith\\": \\"id\\",
+                              \\"targetName\\": \\"teamID\\"
+                          }
+                      }
+                  },
+                  \\"syncable\\": true,
+                  \\"pluralName\\": \\"Projects\\",
+                  \\"attributes\\": [
+                      {
+                          \\"type\\": \\"model\\",
+                          \\"properties\\": {}
+                      }
+                  ]
+              },
+              \\"Team\\": {
+                  \\"name\\": \\"Team\\",
+                  \\"fields\\": {
+                      \\"id\\": {
+                          \\"name\\": \\"id\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"ID\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      },
+                      \\"name\\": {
+                          \\"name\\": \\"name\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"String\\",
+                          \\"isRequired\\": true,
+                          \\"attributes\\": []
+                      }
+                  },
+                  \\"syncable\\": true,
+                  \\"pluralName\\": \\"Teams\\",
+                  \\"attributes\\": [
+                      {
+                          \\"type\\": \\"model\\",
+                          \\"properties\\": {}
+                      }
+                  ]
+              }
+          },
+          \\"enums\\": {},
+          \\"nonModels\\": {},
+          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+      };"
+    `);
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -48,6 +48,7 @@ export type AssociationHasMany = AssociationBaseType & {
 };
 type AssociationHasOne = AssociationHasMany & {
   connectionType: CodeGenConnectionType.HAS_ONE;
+  targetName: string;
 };
 
 type AssociationBelongsTo = AssociationBaseType & {
@@ -168,8 +169,11 @@ export class AppSyncJSONVisitor<
     if (field.connectionInfo) {
       const { connectionInfo } = field;
       const connectionAttribute: any = { connectionType: connectionInfo.kind };
-      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
         connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+      } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+        connectionAttribute.targetName = connectionInfo.targetName;
       } else {
         connectionAttribute.targetName = connectionInfo.targetName;
       }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-js/issues/6560

Adding the same change to JS as was added to iOS in [this PR](https://github.com/aws-amplify/amplify-cli/pull/6031/files#diff-6afc42087dd9ca87a26c81fe25d4b97f27a677500dbdb95ca19c5db8d090c637R250)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.