### PR TITLE
Move top level Feature Flag instance calls into the generate Methods

### DIFF
--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -37,7 +37,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
 
   const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
   const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
-    
+
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
@@ -56,7 +56,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
-    
+
     try {
       fs.ensureDirSync(opsGenDirectory);
       generate(schemaPath, opsGenDirectory, {

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -7,6 +7,7 @@ const constants = require('../constants');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 const { FeatureFlags } = require('amplify-cli-core');
 const { getDocsgenPackage } = require('../utils/getDocsgenPackage');
+const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
 
 async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
   try {
@@ -35,7 +36,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     return;
   }
 
-  const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
   const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
 
   for (const cfg of projects) {

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -8,9 +8,6 @@ const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = 
 const { FeatureFlags } = require('amplify-cli-core');
 const { getDocsgenPackage } = require('../utils/getDocsgenPackage');
 
-const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
-const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
-
 async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
   try {
     context.amplify.getProjectMeta();
@@ -37,6 +34,10 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
+
+  const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
+  const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
+    
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
@@ -55,6 +56,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
+    
     try {
       fs.ensureDirSync(opsGenDirectory);
       generate(schemaPath, opsGenDirectory, {

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -8,9 +8,6 @@ const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = 
 const { FeatureFlags } = require('amplify-cli-core');
 const { getTypesgenPackage } = require('../utils/getTypesgenPackage');
 
-const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
-const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
-
 async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
   let frontend = decoupleFrontend;
   try {
@@ -39,7 +36,9 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
     if (!withoutInit) {
       ({ projectPath } = context.amplify.getEnvInfo());
     }
-
+    const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
+    const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
+    
     try {
       projects.forEach(async cfg => {
         const { generatedFileName } = cfg.amplifyExtension || {};

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -36,9 +36,10 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
     if (!withoutInit) {
       ({ projectPath } = context.amplify.getEnvInfo());
     }
+
     const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
     const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
-    
+
     try {
       projects.forEach(async cfg => {
         const { generatedFileName } = cfg.amplifyExtension || {};

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -7,6 +7,7 @@ const loadConfig = require('../codegen-config');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 const { FeatureFlags } = require('amplify-cli-core');
 const { getTypesgenPackage } = require('../utils/getTypesgenPackage');
+const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
 
 async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
   let frontend = decoupleFrontend;
@@ -37,7 +38,6 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
       ({ projectPath } = context.amplify.getEnvInfo());
     }
 
-    const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
     const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
 
     try {


### PR DESCRIPTION
_Description of changes:_
The `FeatureFlags.getBoolean` method was used at the top level in types and statements generator commands. This will break because the Feature Flags are not yet initialized. 
Moving these Feature Flag calls next to where they are required i.e inside the `generateTypes` and `generateStatements` methods.

_How are these changes tested:_
local unit testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
