### PR TITLE
fix(amplify-codegen): move upstream CLI dependencies as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^25.5.0",
     "ts-node": "^8.10.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "amplify-cli-core": "^1.17.2",
+    "graphql-transformer-core": "^6.26.2"
   },
   "config": {
     "commitizen": {

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -24,7 +24,6 @@
     "@aws-amplify/graphql-docs-generator": "2.3.2",
     "@aws-amplify/graphql-types-generator": "2.7.3",
     "@graphql-codegen/core": "1.8.3",
-    "amplify-cli-core": "^1.17.0",
     "amplify-codegen-appsync-model-plugin": "^1.22.3",
     "amplify-graphql-docs-generator": "^2.2.1",
     "amplify-graphql-types-generator": "^2.7.0",
@@ -34,10 +33,13 @@
     "glob-parent": "^5.1.1",
     "graphql": "^14.5.8",
     "graphql-config": "^2.2.1",
-    "graphql-transformer-core": "^6.26.2",
     "inquirer": "^7.3.3",
     "ora": "^4.0.3",
     "slash": "^3.0.0"
+  },
+  "peerDependencies": {
+    "amplify-cli-core": "^1.17.2",
+    "graphql-transformer-core": "^6.26.2"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
_Description of changes:_
For plugin packages in Node, it is recommended to specify the upstream dependencies on host packages as `peerDependencies` so they do not end up getting their own local versions of those host dependencies in their `node_modules`. 

_How are these changes tested:_
tested locally by installing beta amplify CLI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
