### PR TITLE
Fix the dependency issue with respect to upstream CLI packages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^25.5.0",
     "ts-node": "^8.10.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "amplify-cli-core": "^1.17.2",
+    "graphql-transformer-core": "^6.26.2"
   },
   "config": {
     "commitizen": {

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -24,7 +24,6 @@
     "@aws-amplify/graphql-docs-generator": "2.3.2",
     "@aws-amplify/graphql-types-generator": "2.7.3",
     "@graphql-codegen/core": "1.8.3",
-    "amplify-cli-core": "^1.17.0",
     "amplify-codegen-appsync-model-plugin": "^1.22.3",
     "amplify-graphql-docs-generator": "^2.2.1",
     "amplify-graphql-types-generator": "^2.7.0",
@@ -34,10 +33,13 @@
     "glob-parent": "^5.1.1",
     "graphql": "^14.5.8",
     "graphql-config": "^2.2.1",
-    "graphql-transformer-core": "^6.26.2",
     "inquirer": "^7.3.3",
     "ora": "^4.0.3",
     "slash": "^3.0.0"
+  },
+  "peerDependencies": {
+    "amplify-cli-core": "^1.17.2",
+    "graphql-transformer-core": "^6.26.2"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -7,9 +7,7 @@ const constants = require('../constants');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 const { FeatureFlags } = require('amplify-cli-core');
 const { getDocsgenPackage } = require('../utils/getDocsgenPackage');
-
 const docsgenPackageMigrationflag = 'codegen.useDocsGeneratorPlugin';
-const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
 
 async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
   try {
@@ -37,6 +35,9 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
     return;
   }
+
+  const { generate } = getDocsgenPackage(FeatureFlags.getBoolean(docsgenPackageMigrationflag));
+
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
     const opsGenDirectory = cfg.amplifyExtension.docsFilePath
@@ -55,6 +56,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);
     opsGenSpinner.start();
+
     try {
       fs.ensureDirSync(opsGenDirectory);
       generate(schemaPath, opsGenDirectory, {

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -7,9 +7,7 @@ const loadConfig = require('../codegen-config');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
 const { FeatureFlags } = require('amplify-cli-core');
 const { getTypesgenPackage } = require('../utils/getTypesgenPackage');
-
 const typesgenPackageMigrationflag = 'codegen.useTypesGeneratorPlugin';
-const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
 
 async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
   let frontend = decoupleFrontend;
@@ -39,6 +37,8 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
     if (!withoutInit) {
       ({ projectPath } = context.amplify.getEnvInfo());
     }
+
+    const { generate } = getTypesgenPackage(FeatureFlags.getBoolean(typesgenPackageMigrationflag));
 
     try {
       projects.forEach(async cfg => {


### PR DESCRIPTION
_Description of changes:_
Moved the cli-core and transformer-core dependencies as `peerDependencies` as they should be available with the host `Amplify CLI`.

_How are these changes tested:_
tested with beta CLI version locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
