### PR TITLE
fix(amplify-codegen): print syntax error in a readable output

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -89,12 +89,16 @@ async function generateModels(context) {
 }
 
 async function validateSchema(context) {
-  await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-    noConfig: true,
-    forceCompile: true,
-    dryRun: true,
-    disableResolverOverrides: true,
-  });
+  try {
+    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+      noConfig: true,
+      forceCompile: true,
+      dryRun: true,
+      disableResolverOverrides: true,
+    });
+  } catch (err) {
+    context.print.error(err);
+  }
 }
 
 function loadSchema(apiResourcePath) {

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -97,7 +97,7 @@ async function validateSchema(context) {
       disableResolverOverrides: true,
     });
   } catch (err) {
-    context.print.error(err);
+    context.print.error(err.toString());
   }
 }
 


### PR DESCRIPTION
_Issue #, if available:_
fix #103
_Description of changes:_
The syntax error is printed in a readable way.
_How are these changes tested:_
`amplify-dev codegen models`
![image](https://user-images.githubusercontent.com/20614187/110692128-dc8b5e80-819a-11eb-9a44-8b04ca1dd943.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
