### PR TITLE
fix(amplify-codegen): disable cleanGeneratedModels Feature 

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -79,10 +79,10 @@ async function generateModels(context) {
   const generatedCode = await Promise.all(codeGenPromises);
 
   // clean the output directory before re-generating models
-  const cleanOutputPath = FeatureFlags.getBoolean('codegen.cleanGeneratedModelsDirectory');
-  if (cleanOutputPath) {
-    await fs.emptyDir(outputPath);
-  }
+  // const cleanOutputPath = FeatureFlags.getBoolean('codegen.cleanGeneratedModelsDirectory');
+  // if (cleanOutputPath) {
+  //   await fs.emptyDir(outputPath);
+  // }
 
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;


### PR DESCRIPTION
_Issue #, if available:_  https://github.com/aws-amplify/amplify-cli/issues/6868

_Description of changes:_
This PR rollsback the `cleanGeneratedModels` Feature. 

_How are these changes tested:_
using a sample app

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
