### PR TITLE
feat(modelgen): add timestamp fields createdAt & updatedAt for @model

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -25,7 +25,7 @@ export 'SimpleModel.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = \\"7d9c2bb6945570bb4a34fa39ab7a7a4e\\";
+  String version = \\"20078c21a81919792555926e238b194e\\";
   @override
   List<ModelSchema> modelSchemas = [SimpleModel.schema];
   static final ModelProvider _instance = ModelProvider();
@@ -79,8 +79,6 @@ class SimpleModel extends Model {
   static const classType = const SimpleModelType();
   final String id;
   final Status status;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -90,19 +88,11 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal(
-      {@required this.id, this.status, this.createdAt, this.updatedAt});
+  const SimpleModel._internal({@required this.id, this.status});
 
-  factory SimpleModel(
-      {String id,
-      Status status,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory SimpleModel({String id, Status status}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id,
-        status: status,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, status: status);
   }
 
   bool equals(Object other) {
@@ -112,11 +102,7 @@ class SimpleModel extends Model {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is SimpleModel &&
-        id == other.id &&
-        status == other.status &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+    return other is SimpleModel && id == other.id && status == other.status;
   }
 
   @override
@@ -128,51 +114,24 @@ class SimpleModel extends Model {
 
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(
-        \\"status=\\" + (status != null ? enumToString(status) : \\"null\\") + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"status=\\" + (status != null ? enumToString(status) : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith(
-      {String id,
-      Status status,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
-    return SimpleModel(
-        id: id ?? this.id,
-        status: status ?? this.status,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+  SimpleModel copyWith({String id, Status status}) {
+    return SimpleModel(id: id ?? this.id, status: status ?? this.status);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        status = enumFromString<Status>(json['status'], Status.values),
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        status = enumFromString<Status>(json['status'], Status.values);
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'status': enumToString(status),
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'status': enumToString(status)};
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -184,16 +143,6 @@ class SimpleModel extends Model {
         key: SimpleModel.STATUS,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.enumeration)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -266,8 +215,6 @@ class TemporalTimeModel extends Model {
   final List<TemporalDateTime> dateTimeList;
   final List<TemporalTimestamp> timestampList;
   final List<int> intList;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -287,9 +234,7 @@ class TemporalTimeModel extends Model {
       this.timeList,
       this.dateTimeList,
       this.timestampList,
-      this.intList,
-      this.createdAt,
-      this.updatedAt});
+      this.intList});
 
   factory TemporalTimeModel(
       {String id,
@@ -301,9 +246,7 @@ class TemporalTimeModel extends Model {
       List<TemporalTime> timeList,
       List<TemporalDateTime> dateTimeList,
       List<TemporalTimestamp> timestampList,
-      List<int> intList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<int> intList}) {
     return TemporalTimeModel._internal(
         id: id == null ? UUID.getUUID() : id,
         date: date,
@@ -318,9 +261,7 @@ class TemporalTimeModel extends Model {
         timestampList: timestampList != null
             ? List.unmodifiable(timestampList)
             : timestampList,
-        intList: intList != null ? List.unmodifiable(intList) : intList,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        intList: intList != null ? List.unmodifiable(intList) : intList);
   }
 
   bool equals(Object other) {
@@ -340,9 +281,7 @@ class TemporalTimeModel extends Model {
         DeepCollectionEquality().equals(timeList, other.timeList) &&
         DeepCollectionEquality().equals(dateTimeList, other.dateTimeList) &&
         DeepCollectionEquality().equals(timestampList, other.timestampList) &&
-        DeepCollectionEquality().equals(intList, other.intList) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        DeepCollectionEquality().equals(intList, other.intList);
   }
 
   @override
@@ -371,13 +310,7 @@ class TemporalTimeModel extends Model {
     buffer.write(\\"timestampList=\\" +
         (timestampList != null ? timestampList.toString() : \\"null\\") +
         \\", \\");
-    buffer.write(
-        \\"intList=\\" + (intList != null ? intList.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"intList=\\" + (intList != null ? intList.toString() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -393,9 +326,7 @@ class TemporalTimeModel extends Model {
       List<TemporalTime> timeList,
       List<TemporalDateTime> dateTimeList,
       List<TemporalTimestamp> timestampList,
-      List<int> intList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<int> intList}) {
     return TemporalTimeModel(
         id: id ?? this.id,
         date: date ?? this.date,
@@ -406,9 +337,7 @@ class TemporalTimeModel extends Model {
         timeList: timeList ?? this.timeList,
         dateTimeList: dateTimeList ?? this.dateTimeList,
         timestampList: timestampList ?? this.timestampList,
-        intList: intList ?? this.intList,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        intList: intList ?? this.intList);
   }
 
   TemporalTimeModel.fromJson(Map<String, dynamic> json)
@@ -437,13 +366,7 @@ class TemporalTimeModel extends Model {
             ?.toList(),
         intList = (json['intList'] as List<dynamic>)
             ?.map((dynamic e) => e is double ? e.toInt() : e as int)
-            ?.toList(),
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+            ?.toList();
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -455,9 +378,7 @@ class TemporalTimeModel extends Model {
         'timeList': timeList?.map((e) => e.format()).toList(),
         'dateTimeList': dateTimeList?.map((e) => e.format()).toList(),
         'timestampList': timestampList?.map((e) => e.toSeconds()).toList(),
-        'intList': intList,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+        'intList': intList
       };
 
   static final QueryField ID = QueryField(fieldName: \\"temporalTimeModel.id\\");
@@ -471,8 +392,6 @@ class TemporalTimeModel extends Model {
   static final QueryField TIMESTAMPLIST =
       QueryField(fieldName: \\"timestampList\\");
   static final QueryField INTLIST = QueryField(fieldName: \\"intList\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TemporalTimeModel\\";
@@ -534,16 +453,6 @@ class TemporalTimeModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.int))));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TemporalTimeModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TemporalTimeModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -592,8 +501,6 @@ class TestEnumModel extends Model {
   final List<TestEnum> enumNullableList;
   final List<TestEnum> nullableEnumList;
   final List<TestEnum> nullableEnumNullableList;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -610,9 +517,7 @@ class TestEnumModel extends Model {
       @required this.enumList,
       this.enumNullableList,
       @required this.nullableEnumList,
-      this.nullableEnumNullableList,
-      this.createdAt,
-      this.updatedAt});
+      this.nullableEnumNullableList});
 
   factory TestEnumModel(
       {String id,
@@ -621,9 +526,7 @@ class TestEnumModel extends Model {
       @required List<TestEnum> enumList,
       List<TestEnum> enumNullableList,
       @required List<TestEnum> nullableEnumList,
-      List<TestEnum> nullableEnumNullableList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<TestEnum> nullableEnumNullableList}) {
     return TestEnumModel._internal(
         id: id == null ? UUID.getUUID() : id,
         enumVal: enumVal,
@@ -637,9 +540,7 @@ class TestEnumModel extends Model {
             : nullableEnumList,
         nullableEnumNullableList: nullableEnumNullableList != null
             ? List.unmodifiable(nullableEnumNullableList)
-            : nullableEnumNullableList,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+            : nullableEnumNullableList);
   }
 
   bool equals(Object other) {
@@ -659,9 +560,7 @@ class TestEnumModel extends Model {
         DeepCollectionEquality()
             .equals(nullableEnumList, other.nullableEnumList) &&
         DeepCollectionEquality()
-            .equals(nullableEnumNullableList, other.nullableEnumNullableList) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+            .equals(nullableEnumNullableList, other.nullableEnumNullableList);
   }
 
   @override
@@ -687,13 +586,7 @@ class TestEnumModel extends Model {
         nullableEnumList?.map((e) => enumToString(e)).toString() +
         \\", \\");
     buffer.write(\\"nullableEnumNullableList=\\" +
-        nullableEnumNullableList?.map((e) => enumToString(e)).toString() +
-        \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+        nullableEnumNullableList?.map((e) => enumToString(e)).toString());
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -706,9 +599,7 @@ class TestEnumModel extends Model {
       List<TestEnum> enumList,
       List<TestEnum> enumNullableList,
       List<TestEnum> nullableEnumList,
-      List<TestEnum> nullableEnumNullableList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<TestEnum> nullableEnumNullableList}) {
     return TestEnumModel(
         id: id ?? this.id,
         enumVal: enumVal ?? this.enumVal,
@@ -717,9 +608,7 @@ class TestEnumModel extends Model {
         enumNullableList: enumNullableList ?? this.enumNullableList,
         nullableEnumList: nullableEnumList ?? this.nullableEnumList,
         nullableEnumNullableList:
-            nullableEnumNullableList ?? this.nullableEnumNullableList,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+            nullableEnumNullableList ?? this.nullableEnumNullableList);
   }
 
   TestEnumModel.fromJson(Map<String, dynamic> json)
@@ -746,12 +635,6 @@ class TestEnumModel extends Model {
             ? (json['nullableEnumNullableList'] as List)
                 .map((e) => enumFromString<TestEnum>(e, TestEnum.values))
                 .toList()
-            : null,
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -764,9 +647,7 @@ class TestEnumModel extends Model {
         'nullableEnumList':
             nullableEnumList?.map((e) => enumToString(e))?.toList(),
         'nullableEnumNullableList':
-            nullableEnumNullableList?.map((e) => enumToString(e))?.toList(),
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+            nullableEnumNullableList?.map((e) => enumToString(e))?.toList()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"testEnumModel.id\\");
@@ -780,8 +661,6 @@ class TestEnumModel extends Model {
       QueryField(fieldName: \\"nullableEnumList\\");
   static final QueryField NULLABLEENUMNULLABLELIST =
       QueryField(fieldName: \\"nullableEnumNullableList\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestEnumModel\\";
@@ -826,16 +705,6 @@ class TestEnumModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TestEnumModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TestEnumModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -883,8 +752,6 @@ class TestModel extends Model {
   final List<double> floatNullableList;
   final List<double> nullableFloatList;
   final List<double> nullableFloatNullableList;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -901,9 +768,7 @@ class TestModel extends Model {
       @required this.floatList,
       this.floatNullableList,
       @required this.nullableFloatList,
-      this.nullableFloatNullableList,
-      this.createdAt,
-      this.updatedAt});
+      this.nullableFloatNullableList});
 
   factory TestModel(
       {String id,
@@ -912,9 +777,7 @@ class TestModel extends Model {
       @required List<double> floatList,
       List<double> floatNullableList,
       @required List<double> nullableFloatList,
-      List<double> nullableFloatNullableList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<double> nullableFloatNullableList}) {
     return TestModel._internal(
         id: id == null ? UUID.getUUID() : id,
         floatVal: floatVal,
@@ -928,9 +791,7 @@ class TestModel extends Model {
             : nullableFloatList,
         nullableFloatNullableList: nullableFloatNullableList != null
             ? List.unmodifiable(nullableFloatNullableList)
-            : nullableFloatNullableList,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+            : nullableFloatNullableList);
   }
 
   bool equals(Object other) {
@@ -949,10 +810,8 @@ class TestModel extends Model {
             .equals(floatNullableList, other.floatNullableList) &&
         DeepCollectionEquality()
             .equals(nullableFloatList, other.nullableFloatList) &&
-        DeepCollectionEquality().equals(
-            nullableFloatNullableList, other.nullableFloatNullableList) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        DeepCollectionEquality()
+            .equals(nullableFloatNullableList, other.nullableFloatNullableList);
   }
 
   @override
@@ -981,13 +840,7 @@ class TestModel extends Model {
     buffer.write(\\"nullableFloatNullableList=\\" +
         (nullableFloatNullableList != null
             ? nullableFloatNullableList.toString()
-            : \\"null\\") +
-        \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+            : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -1000,9 +853,7 @@ class TestModel extends Model {
       List<double> floatList,
       List<double> floatNullableList,
       List<double> nullableFloatList,
-      List<double> nullableFloatNullableList,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      List<double> nullableFloatNullableList}) {
     return TestModel(
         id: id ?? this.id,
         floatVal: floatVal ?? this.floatVal,
@@ -1011,9 +862,7 @@ class TestModel extends Model {
         floatNullableList: floatNullableList ?? this.floatNullableList,
         nullableFloatList: nullableFloatList ?? this.nullableFloatList,
         nullableFloatNullableList:
-            nullableFloatNullableList ?? this.nullableFloatNullableList,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+            nullableFloatNullableList ?? this.nullableFloatNullableList);
   }
 
   TestModel.fromJson(Map<String, dynamic> json)
@@ -1024,13 +873,7 @@ class TestModel extends Model {
         floatNullableList = json['floatNullableList']?.cast<double>(),
         nullableFloatList = json['nullableFloatList']?.cast<double>(),
         nullableFloatNullableList =
-            json['nullableFloatNullableList']?.cast<double>(),
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+            json['nullableFloatNullableList']?.cast<double>();
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -1039,9 +882,7 @@ class TestModel extends Model {
         'floatList': floatList,
         'floatNullableList': floatNullableList,
         'nullableFloatList': nullableFloatList,
-        'nullableFloatNullableList': nullableFloatNullableList,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+        'nullableFloatNullableList': nullableFloatNullableList
       };
 
   static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
@@ -1055,8 +896,6 @@ class TestModel extends Model {
       QueryField(fieldName: \\"nullableFloatList\\");
   static final QueryField NULLABLEFLOATNULLABLELIST =
       QueryField(fieldName: \\"nullableFloatNullableList\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestModel\\";
@@ -1101,16 +940,6 @@ class TestModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.double))));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TestModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: TestModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1153,8 +982,6 @@ class SimpleModel extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1164,21 +991,11 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const SimpleModel._internal({@required this.id, this.name, this.bar});
 
-  factory SimpleModel(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory SimpleModel({String id, String name, String bar}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -1191,9 +1008,7 @@ class SimpleModel extends Model {
     return other is SimpleModel &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -1206,55 +1021,27 @@ class SimpleModel extends Model {
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  SimpleModel copyWith({String id, String name, String bar}) {
     return SimpleModel(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -1271,16 +1058,6 @@ class SimpleModel extends Model {
         key: SimpleModel.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1323,8 +1100,6 @@ class SimpleModel extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1334,21 +1109,11 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const SimpleModel._internal({@required this.id, this.name, this.bar});
 
-  factory SimpleModel(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory SimpleModel({String id, String name, String bar}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -1361,9 +1126,7 @@ class SimpleModel extends Model {
     return other is SimpleModel &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -1376,55 +1139,27 @@ class SimpleModel extends Model {
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  SimpleModel copyWith({String id, String name, String bar}) {
     return SimpleModel(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -1441,16 +1176,6 @@ class SimpleModel extends Model {
         key: SimpleModel.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: SimpleModel.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1493,8 +1218,6 @@ class customClaim extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1504,21 +1227,11 @@ class customClaim extends Model {
     return id;
   }
 
-  const customClaim._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const customClaim._internal({@required this.id, this.name, this.bar});
 
-  factory customClaim(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory customClaim({String id, String name, String bar}) {
     return customClaim._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -1531,9 +1244,7 @@ class customClaim extends Model {
     return other is customClaim &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -1546,55 +1257,27 @@ class customClaim extends Model {
     buffer.write(\\"customClaim {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  customClaim copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  customClaim copyWith({String id, String name, String bar}) {
     return customClaim(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   customClaim.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"customClaim\\";
@@ -1624,16 +1307,6 @@ class customClaim extends Model {
         key: customClaim.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: customClaim.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: customClaim.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1676,8 +1349,6 @@ class customClaim extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1687,21 +1358,11 @@ class customClaim extends Model {
     return id;
   }
 
-  const customClaim._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const customClaim._internal({@required this.id, this.name, this.bar});
 
-  factory customClaim(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory customClaim({String id, String name, String bar}) {
     return customClaim._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -1714,9 +1375,7 @@ class customClaim extends Model {
     return other is customClaim &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -1729,55 +1388,27 @@ class customClaim extends Model {
     buffer.write(\\"customClaim {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  customClaim copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  customClaim copyWith({String id, String name, String bar}) {
     return customClaim(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   customClaim.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"customClaim\\";
@@ -1809,16 +1440,6 @@ class customClaim extends Model {
         key: customClaim.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: customClaim.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: customClaim.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1861,8 +1482,6 @@ class dynamicGroups extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1872,21 +1491,11 @@ class dynamicGroups extends Model {
     return id;
   }
 
-  const dynamicGroups._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const dynamicGroups._internal({@required this.id, this.name, this.bar});
 
-  factory dynamicGroups(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory dynamicGroups({String id, String name, String bar}) {
     return dynamicGroups._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -1899,9 +1508,7 @@ class dynamicGroups extends Model {
     return other is dynamicGroups &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -1914,55 +1521,27 @@ class dynamicGroups extends Model {
     buffer.write(\\"dynamicGroups {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  dynamicGroups copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  dynamicGroups copyWith({String id, String name, String bar}) {
     return dynamicGroups(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   dynamicGroups.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"dynamicGroups.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"dynamicGroups\\";
@@ -1992,16 +1571,6 @@ class dynamicGroups extends Model {
         key: dynamicGroups.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: dynamicGroups.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: dynamicGroups.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2044,8 +1613,6 @@ class simpleOwnerAuth extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2055,21 +1622,11 @@ class simpleOwnerAuth extends Model {
     return id;
   }
 
-  const simpleOwnerAuth._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const simpleOwnerAuth._internal({@required this.id, this.name, this.bar});
 
-  factory simpleOwnerAuth(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory simpleOwnerAuth({String id, String name, String bar}) {
     return simpleOwnerAuth._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -2082,9 +1639,7 @@ class simpleOwnerAuth extends Model {
     return other is simpleOwnerAuth &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -2097,55 +1652,27 @@ class simpleOwnerAuth extends Model {
     buffer.write(\\"simpleOwnerAuth {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  simpleOwnerAuth copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  simpleOwnerAuth copyWith({String id, String name, String bar}) {
     return simpleOwnerAuth(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   simpleOwnerAuth.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"simpleOwnerAuth.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"simpleOwnerAuth\\";
@@ -2175,16 +1702,6 @@ class simpleOwnerAuth extends Model {
         key: simpleOwnerAuth.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: simpleOwnerAuth.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: simpleOwnerAuth.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2227,8 +1744,6 @@ class allowRead extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2238,21 +1753,11 @@ class allowRead extends Model {
     return id;
   }
 
-  const allowRead._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const allowRead._internal({@required this.id, this.name, this.bar});
 
-  factory allowRead(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory allowRead({String id, String name, String bar}) {
     return allowRead._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -2265,9 +1770,7 @@ class allowRead extends Model {
     return other is allowRead &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -2280,55 +1783,27 @@ class allowRead extends Model {
     buffer.write(\\"allowRead {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  allowRead copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  allowRead copyWith({String id, String name, String bar}) {
     return allowRead(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   allowRead.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"allowRead.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"allowRead\\";
@@ -2357,16 +1832,6 @@ class allowRead extends Model {
         key: allowRead.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: allowRead.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: allowRead.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2409,8 +1874,6 @@ class privateType extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2420,21 +1883,11 @@ class privateType extends Model {
     return id;
   }
 
-  const privateType._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const privateType._internal({@required this.id, this.name, this.bar});
 
-  factory privateType(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory privateType({String id, String name, String bar}) {
     return privateType._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -2447,9 +1900,7 @@ class privateType extends Model {
     return other is privateType &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -2462,55 +1913,27 @@ class privateType extends Model {
     buffer.write(\\"privateType {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  privateType copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  privateType copyWith({String id, String name, String bar}) {
     return privateType(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   privateType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"privateType.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"privateType\\";
@@ -2536,16 +1959,6 @@ class privateType extends Model {
         key: privateType.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: privateType.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: privateType.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2588,8 +2001,6 @@ class publicType extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2599,21 +2010,11 @@ class publicType extends Model {
     return id;
   }
 
-  const publicType._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const publicType._internal({@required this.id, this.name, this.bar});
 
-  factory publicType(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory publicType({String id, String name, String bar}) {
     return publicType._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -2626,9 +2027,7 @@ class publicType extends Model {
     return other is publicType &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -2641,55 +2040,27 @@ class publicType extends Model {
     buffer.write(\\"publicType {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  publicType copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  publicType copyWith({String id, String name, String bar}) {
     return publicType(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   publicType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"publicType.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"publicType\\";
@@ -2715,16 +2086,6 @@ class publicType extends Model {
         key: publicType.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: publicType.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: publicType.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2767,8 +2128,6 @@ class staticGroups extends Model {
   final String id;
   final String name;
   final String bar;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2778,21 +2137,11 @@ class staticGroups extends Model {
     return id;
   }
 
-  const staticGroups._internal(
-      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
+  const staticGroups._internal({@required this.id, this.name, this.bar});
 
-  factory staticGroups(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory staticGroups({String id, String name, String bar}) {
     return staticGroups._internal(
-        id: id == null ? UUID.getUUID() : id,
-        name: name,
-        bar: bar,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
   }
 
   bool equals(Object other) {
@@ -2805,9 +2154,7 @@ class staticGroups extends Model {
     return other is staticGroups &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        bar == other.bar;
   }
 
   @override
@@ -2820,55 +2167,27 @@ class staticGroups extends Model {
     buffer.write(\\"staticGroups {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"bar=\\" + \\"$bar\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  staticGroups copyWith(
-      {String id,
-      String name,
-      String bar,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  staticGroups copyWith({String id, String name, String bar}) {
     return staticGroups(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        bar: bar ?? this.bar,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
   }
 
   staticGroups.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        bar = json['bar'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'bar': bar,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
   static final QueryField ID = QueryField(fieldName: \\"staticGroups.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"staticGroups\\";
@@ -2900,16 +2219,6 @@ class staticGroups extends Model {
         key: staticGroups.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: staticGroups.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: staticGroups.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2952,8 +2261,6 @@ class Post extends Model {
   final String id;
   final String title;
   final String author;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2964,24 +2271,11 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id,
-      @required this.title,
-      @required this.author,
-      this.createdAt,
-      this.updatedAt});
+      {@required this.id, @required this.title, @required this.author});
 
-  factory Post(
-      {String id,
-      @required String title,
-      @required String author,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory Post({String id, @required String title, @required String author}) {
     return Post._internal(
-        id: id == null ? UUID.getUUID() : id,
-        title: title,
-        author: author,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, title: title, author: author);
   }
 
   bool equals(Object other) {
@@ -2994,9 +2288,7 @@ class Post extends Model {
     return other is Post &&
         id == other.id &&
         title == other.title &&
-        author == other.author &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        author == other.author;
   }
 
   @override
@@ -3009,55 +2301,29 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"author=\\" + \\"$author\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"author=\\" + \\"$author\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith(
-      {String id,
-      String title,
-      String author,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  Post copyWith({String id, String title, String author}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
-        author: author ?? this.author,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        author: author ?? this.author);
   }
 
   Post.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         title = json['title'],
-        author = json['author'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        author = json['author'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'title': title,
-        'author': author,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'title': title, 'author': author};
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -3087,16 +2353,6 @@ class Post extends Model {
         key: Post.AUTHOR,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3139,8 +2395,6 @@ class Post extends Model {
   final String id;
   final String title;
   final String owner;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3151,24 +2405,11 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id,
-      @required this.title,
-      @required this.owner,
-      this.createdAt,
-      this.updatedAt});
+      {@required this.id, @required this.title, @required this.owner});
 
-  factory Post(
-      {String id,
-      @required String title,
-      @required String owner,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory Post({String id, @required String title, @required String owner}) {
     return Post._internal(
-        id: id == null ? UUID.getUUID() : id,
-        title: title,
-        owner: owner,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, title: title, owner: owner);
   }
 
   bool equals(Object other) {
@@ -3181,9 +2422,7 @@ class Post extends Model {
     return other is Post &&
         id == other.id &&
         title == other.title &&
-        owner == other.owner &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        owner == other.owner;
   }
 
   @override
@@ -3196,55 +2435,29 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"owner=\\" + \\"$owner\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"owner=\\" + \\"$owner\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith(
-      {String id,
-      String title,
-      String owner,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  Post copyWith({String id, String title, String owner}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
-        owner: owner ?? this.owner,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        owner: owner ?? this.owner);
   }
 
   Post.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         title = json['title'],
-        owner = json['owner'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        owner = json['owner'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'title': title,
-        'owner': owner,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'title': title, 'owner': owner};
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField OWNER = QueryField(fieldName: \\"owner\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -3287,16 +2500,6 @@ class Post extends Model {
         key: Post.OWNER,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3340,8 +2543,6 @@ class Todo extends Model {
   static const classType = const TodoType();
   final String id;
   final List<Task> tasks;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3351,19 +2552,12 @@ class Todo extends Model {
     return id;
   }
 
-  const Todo._internal(
-      {@required this.id, this.tasks, this.createdAt, this.updatedAt});
+  const Todo._internal({@required this.id, this.tasks});
 
-  factory Todo(
-      {String id,
-      List<Task> tasks,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory Todo({String id, List<Task> tasks}) {
     return Todo._internal(
         id: id == null ? UUID.getUUID() : id,
-        tasks: tasks != null ? List.unmodifiable(tasks) : tasks,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        tasks: tasks != null ? List.unmodifiable(tasks) : tasks);
   }
 
   bool equals(Object other) {
@@ -3375,9 +2569,7 @@ class Todo extends Model {
     if (identical(other, this)) return true;
     return other is Todo &&
         id == other.id &&
-        DeepCollectionEquality().equals(tasks, other.tasks) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        DeepCollectionEquality().equals(tasks, other.tasks);
   }
 
   @override
@@ -3388,27 +2580,14 @@ class Todo extends Model {
     var buffer = new StringBuffer();
 
     buffer.write(\\"Todo {\\");
-    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"id=\\" + \\"$id\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Todo copyWith(
-      {String id,
-      List<Task> tasks,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
-    return Todo(
-        id: id ?? this.id,
-        tasks: tasks ?? this.tasks,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+  Todo copyWith({String id, List<Task> tasks}) {
+    return Todo(id: id ?? this.id, tasks: tasks ?? this.tasks);
   }
 
   Todo.fromJson(Map<String, dynamic> json)
@@ -3417,28 +2596,16 @@ class Todo extends Model {
             ? (json['tasks'] as List)
                 .map((e) => Task.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
-            : null,
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'tasks': tasks?.map((e) => e?.toJson())?.toList(),
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() =>
+      {'id': id, 'tasks': tasks?.map((e) => e?.toJson())?.toList()};
 
   static final QueryField ID = QueryField(fieldName: \\"todo.id\\");
   static final QueryField TASKS = QueryField(
       fieldName: \\"tasks\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Task).toString()));
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Todo\\";
@@ -3451,16 +2618,6 @@ class Todo extends Model {
         isRequired: false,
         ofModelName: (Task).toString(),
         associatedKey: Task.TODO));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Todo.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Todo.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3503,8 +2660,6 @@ class Task extends Model {
   static const classType = const TaskType();
   final String id;
   final Todo todo;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3514,19 +2669,10 @@ class Task extends Model {
     return id;
   }
 
-  const Task._internal(
-      {@required this.id, this.todo, this.createdAt, this.updatedAt});
+  const Task._internal({@required this.id, this.todo});
 
-  factory Task(
-      {String id,
-      Todo todo,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
-    return Task._internal(
-        id: id == null ? UUID.getUUID() : id,
-        todo: todo,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+  factory Task({String id, Todo todo}) {
+    return Task._internal(id: id == null ? UUID.getUUID() : id, todo: todo);
   }
 
   bool equals(Object other) {
@@ -3536,11 +2682,7 @@ class Task extends Model {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is Task &&
-        id == other.id &&
-        todo == other.todo &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+    return other is Task && id == other.id && todo == other.todo;
   }
 
   @override
@@ -3552,55 +2694,29 @@ class Task extends Model {
 
     buffer.write(\\"Task {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"todo=\\" + (todo != null ? todo.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"todo=\\" + (todo != null ? todo.toString() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Task copyWith(
-      {String id,
-      Todo todo,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
-    return Task(
-        id: id ?? this.id,
-        todo: todo ?? this.todo,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+  Task copyWith({String id, Todo todo}) {
+    return Task(id: id ?? this.id, todo: todo ?? this.todo);
   }
 
   Task.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         todo = json['todo'] != null
             ? Todo.fromJson(new Map<String, dynamic>.from(json['todo']))
-            : null,
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'todo': todo?.toJson(),
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() => {'id': id, 'todo': todo?.toJson()};
 
   static final QueryField ID = QueryField(fieldName: \\"task.id\\");
   static final QueryField TODO = QueryField(
       fieldName: \\"todo\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Todo).toString()));
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Task\\";
@@ -3613,16 +2729,6 @@ class Task extends Model {
         isRequired: false,
         targetName: \\"taskTodoId\\",
         ofModelName: (Todo).toString()));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Task.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Task.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3668,8 +2774,6 @@ class Blog extends Model {
   final String name;
   final List<Post> posts;
   final List<String> test;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3680,27 +2784,15 @@ class Blog extends Model {
   }
 
   const Blog._internal(
-      {@required this.id,
-      @required this.name,
-      this.posts,
-      this.test,
-      this.createdAt,
-      this.updatedAt});
+      {@required this.id, @required this.name, this.posts, this.test});
 
   factory Blog(
-      {String id,
-      @required String name,
-      List<Post> posts,
-      List<String> test,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      {String id, @required String name, List<Post> posts, List<String> test}) {
     return Blog._internal(
         id: id == null ? UUID.getUUID() : id,
         name: name,
         posts: posts != null ? List.unmodifiable(posts) : posts,
-        test: test != null ? List.unmodifiable(test) : test,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        test: test != null ? List.unmodifiable(test) : test);
   }
 
   bool equals(Object other) {
@@ -3714,9 +2806,7 @@ class Blog extends Model {
         id == other.id &&
         name == other.name &&
         DeepCollectionEquality().equals(posts, other.posts) &&
-        DeepCollectionEquality().equals(test, other.test) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        DeepCollectionEquality().equals(test, other.test);
   }
 
   @override
@@ -3729,31 +2819,18 @@ class Blog extends Model {
     buffer.write(\\"Blog {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"test=\\" + (test != null ? test.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"test=\\" + (test != null ? test.toString() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Blog copyWith(
-      {String id,
-      String name,
-      List<Post> posts,
-      List<String> test,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  Blog copyWith({String id, String name, List<Post> posts, List<String> test}) {
     return Blog(
         id: id ?? this.id,
         name: name ?? this.name,
         posts: posts ?? this.posts,
-        test: test ?? this.test,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        test: test ?? this.test);
   }
 
   Blog.fromJson(Map<String, dynamic> json)
@@ -3764,21 +2841,13 @@ class Blog extends Model {
                 .map((e) => Post.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
             : null,
-        test = json['test']?.cast<String>(),
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        test = json['test']?.cast<String>();
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
         'posts': posts?.map((e) => e?.toJson())?.toList(),
-        'test': test,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+        'test': test
       };
 
   static final QueryField ID = QueryField(fieldName: \\"blog.id\\");
@@ -3788,8 +2857,6 @@ class Blog extends Model {
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Post).toString()));
   static final QueryField TEST = QueryField(fieldName: \\"test\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Blog\\";
@@ -3814,16 +2881,6 @@ class Blog extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.string))));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Blog.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Blog.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3867,8 +2924,6 @@ class Comment extends Model {
   final String id;
   final Post post;
   final String content;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3879,24 +2934,11 @@ class Comment extends Model {
   }
 
   const Comment._internal(
-      {@required this.id,
-      this.post,
-      @required this.content,
-      this.createdAt,
-      this.updatedAt});
+      {@required this.id, this.post, @required this.content});
 
-  factory Comment(
-      {String id,
-      Post post,
-      @required String content,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  factory Comment({String id, Post post, @required String content}) {
     return Comment._internal(
-        id: id == null ? UUID.getUUID() : id,
-        post: post,
-        content: content,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        id: id == null ? UUID.getUUID() : id, post: post, content: content);
   }
 
   bool equals(Object other) {
@@ -3909,9 +2951,7 @@ class Comment extends Model {
     return other is Comment &&
         id == other.id &&
         post == other.post &&
-        content == other.content &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        content == other.content;
   }
 
   @override
@@ -3924,29 +2964,17 @@ class Comment extends Model {
     buffer.write(\\"Comment {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"post=\\" + (post != null ? post.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"content=\\" + \\"$content\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"content=\\" + \\"$content\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Comment copyWith(
-      {String id,
-      Post post,
-      String content,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  Comment copyWith({String id, Post post, String content}) {
     return Comment(
         id: id ?? this.id,
         post: post ?? this.post,
-        content: content ?? this.content,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        content: content ?? this.content);
   }
 
   Comment.fromJson(Map<String, dynamic> json)
@@ -3954,21 +2982,10 @@ class Comment extends Model {
         post = json['post'] != null
             ? Post.fromJson(new Map<String, dynamic>.from(json['post']))
             : null,
-        content = json['content'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        content = json['content'];
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'post': post?.toJson(),
-        'content': content,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
-      };
+  Map<String, dynamic> toJson() =>
+      {'id': id, 'post': post?.toJson(), 'content': content};
 
   static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
   static final QueryField POST = QueryField(
@@ -3976,8 +2993,6 @@ class Comment extends Model {
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Post).toString()));
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Comment\\";
@@ -3995,16 +3010,6 @@ class Comment extends Model {
         key: Comment.CONTENT,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Comment.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Comment.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -4050,8 +3055,6 @@ class Post extends Model {
   final String title;
   final Blog blog;
   final List<Comment> comments;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -4062,27 +3065,15 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id,
-      @required this.title,
-      this.blog,
-      this.comments,
-      this.createdAt,
-      this.updatedAt});
+      {@required this.id, @required this.title, this.blog, this.comments});
 
   factory Post(
-      {String id,
-      @required String title,
-      Blog blog,
-      List<Comment> comments,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      {String id, @required String title, Blog blog, List<Comment> comments}) {
     return Post._internal(
         id: id == null ? UUID.getUUID() : id,
         title: title,
         blog: blog,
-        comments: comments != null ? List.unmodifiable(comments) : comments,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        comments: comments != null ? List.unmodifiable(comments) : comments);
   }
 
   bool equals(Object other) {
@@ -4096,9 +3087,7 @@ class Post extends Model {
         id == other.id &&
         title == other.title &&
         blog == other.blog &&
-        DeepCollectionEquality().equals(comments, other.comments) &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        DeepCollectionEquality().equals(comments, other.comments);
   }
 
   @override
@@ -4111,31 +3100,18 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"blog=\\" + (blog != null ? blog.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"blog=\\" + (blog != null ? blog.toString() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith(
-      {String id,
-      String title,
-      Blog blog,
-      List<Comment> comments,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+  Post copyWith({String id, String title, Blog blog, List<Comment> comments}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
         blog: blog ?? this.blog,
-        comments: comments ?? this.comments,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        comments: comments ?? this.comments);
   }
 
   Post.fromJson(Map<String, dynamic> json)
@@ -4148,21 +3124,13 @@ class Post extends Model {
             ? (json['comments'] as List)
                 .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
-            : null,
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'blog': blog?.toJson(),
-        'comments': comments?.map((e) => e?.toJson())?.toList(),
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+        'comments': comments?.map((e) => e?.toJson())?.toList()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
@@ -4175,8 +3143,6 @@ class Post extends Model {
       fieldName: \\"comments\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Comment).toString()));
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -4200,16 +3166,6 @@ class Post extends Model {
         isRequired: false,
         ofModelName: (Comment).toString(),
         associatedKey: Comment.POST));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: Post.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -4254,8 +3210,6 @@ class authorBook extends Model {
   final String book_id;
   final String author;
   final String book;
-  final TemporalDateTime createdAt;
-  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -4270,26 +3224,20 @@ class authorBook extends Model {
       @required this.author_id,
       @required this.book_id,
       this.author,
-      this.book,
-      this.createdAt,
-      this.updatedAt});
+      this.book});
 
   factory authorBook(
       {String id,
       @required String author_id,
       @required String book_id,
       String author,
-      String book,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      String book}) {
     return authorBook._internal(
         id: id == null ? UUID.getUUID() : id,
         author_id: author_id,
         book_id: book_id,
         author: author,
-        book: book,
-        createdAt: createdAt,
-        updatedAt: updatedAt);
+        book: book);
   }
 
   bool equals(Object other) {
@@ -4304,9 +3252,7 @@ class authorBook extends Model {
         author_id == other.author_id &&
         book_id == other.book_id &&
         author == other.author &&
-        book == other.book &&
-        createdAt == other.createdAt &&
-        updatedAt == other.updatedAt;
+        book == other.book;
   }
 
   @override
@@ -4321,12 +3267,7 @@ class authorBook extends Model {
     buffer.write(\\"author_id=\\" + \\"$author_id\\" + \\", \\");
     buffer.write(\\"book_id=\\" + \\"$book_id\\" + \\", \\");
     buffer.write(\\"author=\\" + \\"$author\\" + \\", \\");
-    buffer.write(\\"book=\\" + \\"$book\\" + \\", \\");
-    buffer.write(\\"createdAt=\\" +
-        (createdAt != null ? createdAt.format() : \\"null\\") +
-        \\", \\");
-    buffer.write(
-        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"book=\\" + \\"$book\\");
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -4337,17 +3278,13 @@ class authorBook extends Model {
       String author_id,
       String book_id,
       String author,
-      String book,
-      TemporalDateTime createdAt,
-      TemporalDateTime updatedAt}) {
+      String book}) {
     return authorBook(
         id: id ?? this.id,
         author_id: author_id ?? this.author_id,
         book_id: book_id ?? this.book_id,
         author: author ?? this.author,
-        book: book ?? this.book,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt);
+        book: book ?? this.book);
   }
 
   authorBook.fromJson(Map<String, dynamic> json)
@@ -4355,22 +3292,14 @@ class authorBook extends Model {
         author_id = json['author_id'],
         book_id = json['book_id'],
         author = json['author'],
-        book = json['book'],
-        createdAt = json['createdAt'] != null
-            ? TemporalDateTime.fromString(json['createdAt'])
-            : null,
-        updatedAt = json['updatedAt'] != null
-            ? TemporalDateTime.fromString(json['updatedAt'])
-            : null;
+        book = json['book'];
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'author_id': author_id,
         'book_id': book_id,
         'author': author,
-        'book': book,
-        'createdAt': createdAt?.format(),
-        'updatedAt': updatedAt?.format()
+        'book': book
       };
 
   static final QueryField ID = QueryField(fieldName: \\"authorBook.id\\");
@@ -4378,8 +3307,6 @@ class authorBook extends Model {
   static final QueryField BOOK_ID = QueryField(fieldName: \\"book_id\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
   static final QueryField BOOK = QueryField(fieldName: \\"book\\");
-  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
-  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"authorBook\\";
@@ -4406,16 +3333,6 @@ class authorBook extends Model {
         key: authorBook.BOOK,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: authorBook.CREATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
-
-    modelSchemaDefinition.addField(ModelFieldDefinition.field(
-        key: authorBook.UPDATEDAT,
-        isRequired: false,
-        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -25,7 +25,7 @@ export 'SimpleModel.dart';
 
 class ModelProvider implements ModelProviderInterface {
   @override
-  String version = \\"20078c21a81919792555926e238b194e\\";
+  String version = \\"7d9c2bb6945570bb4a34fa39ab7a7a4e\\";
   @override
   List<ModelSchema> modelSchemas = [SimpleModel.schema];
   static final ModelProvider _instance = ModelProvider();
@@ -79,6 +79,8 @@ class SimpleModel extends Model {
   static const classType = const SimpleModelType();
   final String id;
   final Status status;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -88,11 +90,19 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal({@required this.id, this.status});
+  const SimpleModel._internal(
+      {@required this.id, this.status, this.createdAt, this.updatedAt});
 
-  factory SimpleModel({String id, Status status}) {
+  factory SimpleModel(
+      {String id,
+      Status status,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id, status: status);
+        id: id == null ? UUID.getUUID() : id,
+        status: status,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -102,7 +112,11 @@ class SimpleModel extends Model {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is SimpleModel && id == other.id && status == other.status;
+    return other is SimpleModel &&
+        id == other.id &&
+        status == other.status &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -114,24 +128,51 @@ class SimpleModel extends Model {
 
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"status=\\" + (status != null ? enumToString(status) : \\"null\\"));
+    buffer.write(
+        \\"status=\\" + (status != null ? enumToString(status) : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith({String id, Status status}) {
-    return SimpleModel(id: id ?? this.id, status: status ?? this.status);
+  SimpleModel copyWith(
+      {String id,
+      Status status,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return SimpleModel(
+        id: id ?? this.id,
+        status: status ?? this.status,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        status = enumFromString<Status>(json['status'], Status.values);
+        status = enumFromString<Status>(json['status'], Status.values),
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'status': enumToString(status)};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'status': enumToString(status),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -143,6 +184,16 @@ class SimpleModel extends Model {
         key: SimpleModel.STATUS,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.enumeration)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -215,6 +266,8 @@ class TemporalTimeModel extends Model {
   final List<TemporalDateTime> dateTimeList;
   final List<TemporalTimestamp> timestampList;
   final List<int> intList;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -234,7 +287,9 @@ class TemporalTimeModel extends Model {
       this.timeList,
       this.dateTimeList,
       this.timestampList,
-      this.intList});
+      this.intList,
+      this.createdAt,
+      this.updatedAt});
 
   factory TemporalTimeModel(
       {String id,
@@ -246,7 +301,9 @@ class TemporalTimeModel extends Model {
       List<TemporalTime> timeList,
       List<TemporalDateTime> dateTimeList,
       List<TemporalTimestamp> timestampList,
-      List<int> intList}) {
+      List<int> intList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TemporalTimeModel._internal(
         id: id == null ? UUID.getUUID() : id,
         date: date,
@@ -261,7 +318,9 @@ class TemporalTimeModel extends Model {
         timestampList: timestampList != null
             ? List.unmodifiable(timestampList)
             : timestampList,
-        intList: intList != null ? List.unmodifiable(intList) : intList);
+        intList: intList != null ? List.unmodifiable(intList) : intList,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -281,7 +340,9 @@ class TemporalTimeModel extends Model {
         DeepCollectionEquality().equals(timeList, other.timeList) &&
         DeepCollectionEquality().equals(dateTimeList, other.dateTimeList) &&
         DeepCollectionEquality().equals(timestampList, other.timestampList) &&
-        DeepCollectionEquality().equals(intList, other.intList);
+        DeepCollectionEquality().equals(intList, other.intList) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -310,7 +371,13 @@ class TemporalTimeModel extends Model {
     buffer.write(\\"timestampList=\\" +
         (timestampList != null ? timestampList.toString() : \\"null\\") +
         \\", \\");
-    buffer.write(\\"intList=\\" + (intList != null ? intList.toString() : \\"null\\"));
+    buffer.write(
+        \\"intList=\\" + (intList != null ? intList.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -326,7 +393,9 @@ class TemporalTimeModel extends Model {
       List<TemporalTime> timeList,
       List<TemporalDateTime> dateTimeList,
       List<TemporalTimestamp> timestampList,
-      List<int> intList}) {
+      List<int> intList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TemporalTimeModel(
         id: id ?? this.id,
         date: date ?? this.date,
@@ -337,7 +406,9 @@ class TemporalTimeModel extends Model {
         timeList: timeList ?? this.timeList,
         dateTimeList: dateTimeList ?? this.dateTimeList,
         timestampList: timestampList ?? this.timestampList,
-        intList: intList ?? this.intList);
+        intList: intList ?? this.intList,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   TemporalTimeModel.fromJson(Map<String, dynamic> json)
@@ -366,7 +437,13 @@ class TemporalTimeModel extends Model {
             ?.toList(),
         intList = (json['intList'] as List<dynamic>)
             ?.map((dynamic e) => e is double ? e.toInt() : e as int)
-            ?.toList();
+            ?.toList(),
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -378,7 +455,9 @@ class TemporalTimeModel extends Model {
         'timeList': timeList?.map((e) => e.format()).toList(),
         'dateTimeList': dateTimeList?.map((e) => e.format()).toList(),
         'timestampList': timestampList?.map((e) => e.toSeconds()).toList(),
-        'intList': intList
+        'intList': intList,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"temporalTimeModel.id\\");
@@ -392,6 +471,8 @@ class TemporalTimeModel extends Model {
   static final QueryField TIMESTAMPLIST =
       QueryField(fieldName: \\"timestampList\\");
   static final QueryField INTLIST = QueryField(fieldName: \\"intList\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TemporalTimeModel\\";
@@ -453,6 +534,16 @@ class TemporalTimeModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.int))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TemporalTimeModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TemporalTimeModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -501,6 +592,8 @@ class TestEnumModel extends Model {
   final List<TestEnum> enumNullableList;
   final List<TestEnum> nullableEnumList;
   final List<TestEnum> nullableEnumNullableList;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -517,7 +610,9 @@ class TestEnumModel extends Model {
       @required this.enumList,
       this.enumNullableList,
       @required this.nullableEnumList,
-      this.nullableEnumNullableList});
+      this.nullableEnumNullableList,
+      this.createdAt,
+      this.updatedAt});
 
   factory TestEnumModel(
       {String id,
@@ -526,7 +621,9 @@ class TestEnumModel extends Model {
       @required List<TestEnum> enumList,
       List<TestEnum> enumNullableList,
       @required List<TestEnum> nullableEnumList,
-      List<TestEnum> nullableEnumNullableList}) {
+      List<TestEnum> nullableEnumNullableList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TestEnumModel._internal(
         id: id == null ? UUID.getUUID() : id,
         enumVal: enumVal,
@@ -540,7 +637,9 @@ class TestEnumModel extends Model {
             : nullableEnumList,
         nullableEnumNullableList: nullableEnumNullableList != null
             ? List.unmodifiable(nullableEnumNullableList)
-            : nullableEnumNullableList);
+            : nullableEnumNullableList,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -560,7 +659,9 @@ class TestEnumModel extends Model {
         DeepCollectionEquality()
             .equals(nullableEnumList, other.nullableEnumList) &&
         DeepCollectionEquality()
-            .equals(nullableEnumNullableList, other.nullableEnumNullableList);
+            .equals(nullableEnumNullableList, other.nullableEnumNullableList) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -586,7 +687,13 @@ class TestEnumModel extends Model {
         nullableEnumList?.map((e) => enumToString(e)).toString() +
         \\", \\");
     buffer.write(\\"nullableEnumNullableList=\\" +
-        nullableEnumNullableList?.map((e) => enumToString(e)).toString());
+        nullableEnumNullableList?.map((e) => enumToString(e)).toString() +
+        \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -599,7 +706,9 @@ class TestEnumModel extends Model {
       List<TestEnum> enumList,
       List<TestEnum> enumNullableList,
       List<TestEnum> nullableEnumList,
-      List<TestEnum> nullableEnumNullableList}) {
+      List<TestEnum> nullableEnumNullableList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TestEnumModel(
         id: id ?? this.id,
         enumVal: enumVal ?? this.enumVal,
@@ -608,7 +717,9 @@ class TestEnumModel extends Model {
         enumNullableList: enumNullableList ?? this.enumNullableList,
         nullableEnumList: nullableEnumList ?? this.nullableEnumList,
         nullableEnumNullableList:
-            nullableEnumNullableList ?? this.nullableEnumNullableList);
+            nullableEnumNullableList ?? this.nullableEnumNullableList,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   TestEnumModel.fromJson(Map<String, dynamic> json)
@@ -635,6 +746,12 @@ class TestEnumModel extends Model {
             ? (json['nullableEnumNullableList'] as List)
                 .map((e) => enumFromString<TestEnum>(e, TestEnum.values))
                 .toList()
+            : null,
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
@@ -647,7 +764,9 @@ class TestEnumModel extends Model {
         'nullableEnumList':
             nullableEnumList?.map((e) => enumToString(e))?.toList(),
         'nullableEnumNullableList':
-            nullableEnumNullableList?.map((e) => enumToString(e))?.toList()
+            nullableEnumNullableList?.map((e) => enumToString(e))?.toList(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"testEnumModel.id\\");
@@ -661,6 +780,8 @@ class TestEnumModel extends Model {
       QueryField(fieldName: \\"nullableEnumList\\");
   static final QueryField NULLABLEENUMNULLABLELIST =
       QueryField(fieldName: \\"nullableEnumNullableList\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestEnumModel\\";
@@ -705,6 +826,16 @@ class TestEnumModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.enumeration))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestEnumModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestEnumModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -752,6 +883,8 @@ class TestModel extends Model {
   final List<double> floatNullableList;
   final List<double> nullableFloatList;
   final List<double> nullableFloatNullableList;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -768,7 +901,9 @@ class TestModel extends Model {
       @required this.floatList,
       this.floatNullableList,
       @required this.nullableFloatList,
-      this.nullableFloatNullableList});
+      this.nullableFloatNullableList,
+      this.createdAt,
+      this.updatedAt});
 
   factory TestModel(
       {String id,
@@ -777,7 +912,9 @@ class TestModel extends Model {
       @required List<double> floatList,
       List<double> floatNullableList,
       @required List<double> nullableFloatList,
-      List<double> nullableFloatNullableList}) {
+      List<double> nullableFloatNullableList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TestModel._internal(
         id: id == null ? UUID.getUUID() : id,
         floatVal: floatVal,
@@ -791,7 +928,9 @@ class TestModel extends Model {
             : nullableFloatList,
         nullableFloatNullableList: nullableFloatNullableList != null
             ? List.unmodifiable(nullableFloatNullableList)
-            : nullableFloatNullableList);
+            : nullableFloatNullableList,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -810,8 +949,10 @@ class TestModel extends Model {
             .equals(floatNullableList, other.floatNullableList) &&
         DeepCollectionEquality()
             .equals(nullableFloatList, other.nullableFloatList) &&
-        DeepCollectionEquality()
-            .equals(nullableFloatNullableList, other.nullableFloatNullableList);
+        DeepCollectionEquality().equals(
+            nullableFloatNullableList, other.nullableFloatNullableList) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -840,7 +981,13 @@ class TestModel extends Model {
     buffer.write(\\"nullableFloatNullableList=\\" +
         (nullableFloatNullableList != null
             ? nullableFloatNullableList.toString()
-            : \\"null\\"));
+            : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -853,7 +1000,9 @@ class TestModel extends Model {
       List<double> floatList,
       List<double> floatNullableList,
       List<double> nullableFloatList,
-      List<double> nullableFloatNullableList}) {
+      List<double> nullableFloatNullableList,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return TestModel(
         id: id ?? this.id,
         floatVal: floatVal ?? this.floatVal,
@@ -862,7 +1011,9 @@ class TestModel extends Model {
         floatNullableList: floatNullableList ?? this.floatNullableList,
         nullableFloatList: nullableFloatList ?? this.nullableFloatList,
         nullableFloatNullableList:
-            nullableFloatNullableList ?? this.nullableFloatNullableList);
+            nullableFloatNullableList ?? this.nullableFloatNullableList,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   TestModel.fromJson(Map<String, dynamic> json)
@@ -873,7 +1024,13 @@ class TestModel extends Model {
         floatNullableList = json['floatNullableList']?.cast<double>(),
         nullableFloatList = json['nullableFloatList']?.cast<double>(),
         nullableFloatNullableList =
-            json['nullableFloatNullableList']?.cast<double>();
+            json['nullableFloatNullableList']?.cast<double>(),
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -882,7 +1039,9 @@ class TestModel extends Model {
         'floatList': floatList,
         'floatNullableList': floatNullableList,
         'nullableFloatList': nullableFloatList,
-        'nullableFloatNullableList': nullableFloatNullableList
+        'nullableFloatNullableList': nullableFloatNullableList,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
@@ -896,6 +1055,8 @@ class TestModel extends Model {
       QueryField(fieldName: \\"nullableFloatList\\");
   static final QueryField NULLABLEFLOATNULLABLELIST =
       QueryField(fieldName: \\"nullableFloatNullableList\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestModel\\";
@@ -940,6 +1101,16 @@ class TestModel extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.double))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TestModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -982,6 +1153,8 @@ class SimpleModel extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -991,11 +1164,21 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal({@required this.id, this.name, this.bar});
+  const SimpleModel._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory SimpleModel({String id, String name, String bar}) {
+  factory SimpleModel(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1008,7 +1191,9 @@ class SimpleModel extends Model {
     return other is SimpleModel &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1021,27 +1206,55 @@ class SimpleModel extends Model {
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith({String id, String name, String bar}) {
+  SimpleModel copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return SimpleModel(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -1058,6 +1271,16 @@ class SimpleModel extends Model {
         key: SimpleModel.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1100,6 +1323,8 @@ class SimpleModel extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1109,11 +1334,21 @@ class SimpleModel extends Model {
     return id;
   }
 
-  const SimpleModel._internal({@required this.id, this.name, this.bar});
+  const SimpleModel._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory SimpleModel({String id, String name, String bar}) {
+  factory SimpleModel(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return SimpleModel._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1126,7 +1361,9 @@ class SimpleModel extends Model {
     return other is SimpleModel &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1139,27 +1376,55 @@ class SimpleModel extends Model {
     buffer.write(\\"SimpleModel {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  SimpleModel copyWith({String id, String name, String bar}) {
+  SimpleModel copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return SimpleModel(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   SimpleModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";
@@ -1176,6 +1441,16 @@ class SimpleModel extends Model {
         key: SimpleModel.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1218,6 +1493,8 @@ class customClaim extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1227,11 +1504,21 @@ class customClaim extends Model {
     return id;
   }
 
-  const customClaim._internal({@required this.id, this.name, this.bar});
+  const customClaim._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory customClaim({String id, String name, String bar}) {
+  factory customClaim(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return customClaim._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1244,7 +1531,9 @@ class customClaim extends Model {
     return other is customClaim &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1257,27 +1546,55 @@ class customClaim extends Model {
     buffer.write(\\"customClaim {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  customClaim copyWith({String id, String name, String bar}) {
+  customClaim copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return customClaim(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   customClaim.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"customClaim\\";
@@ -1307,6 +1624,16 @@ class customClaim extends Model {
         key: customClaim.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: customClaim.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: customClaim.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1349,6 +1676,8 @@ class customClaim extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1358,11 +1687,21 @@ class customClaim extends Model {
     return id;
   }
 
-  const customClaim._internal({@required this.id, this.name, this.bar});
+  const customClaim._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory customClaim({String id, String name, String bar}) {
+  factory customClaim(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return customClaim._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1375,7 +1714,9 @@ class customClaim extends Model {
     return other is customClaim &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1388,27 +1729,55 @@ class customClaim extends Model {
     buffer.write(\\"customClaim {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  customClaim copyWith({String id, String name, String bar}) {
+  customClaim copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return customClaim(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   customClaim.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"customClaim\\";
@@ -1440,6 +1809,16 @@ class customClaim extends Model {
         key: customClaim.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: customClaim.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: customClaim.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1482,6 +1861,8 @@ class dynamicGroups extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1491,11 +1872,21 @@ class dynamicGroups extends Model {
     return id;
   }
 
-  const dynamicGroups._internal({@required this.id, this.name, this.bar});
+  const dynamicGroups._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory dynamicGroups({String id, String name, String bar}) {
+  factory dynamicGroups(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return dynamicGroups._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1508,7 +1899,9 @@ class dynamicGroups extends Model {
     return other is dynamicGroups &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1521,27 +1914,55 @@ class dynamicGroups extends Model {
     buffer.write(\\"dynamicGroups {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  dynamicGroups copyWith({String id, String name, String bar}) {
+  dynamicGroups copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return dynamicGroups(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   dynamicGroups.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"dynamicGroups.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"dynamicGroups\\";
@@ -1571,6 +1992,16 @@ class dynamicGroups extends Model {
         key: dynamicGroups.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: dynamicGroups.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: dynamicGroups.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1613,6 +2044,8 @@ class simpleOwnerAuth extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1622,11 +2055,21 @@ class simpleOwnerAuth extends Model {
     return id;
   }
 
-  const simpleOwnerAuth._internal({@required this.id, this.name, this.bar});
+  const simpleOwnerAuth._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory simpleOwnerAuth({String id, String name, String bar}) {
+  factory simpleOwnerAuth(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return simpleOwnerAuth._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1639,7 +2082,9 @@ class simpleOwnerAuth extends Model {
     return other is simpleOwnerAuth &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1652,27 +2097,55 @@ class simpleOwnerAuth extends Model {
     buffer.write(\\"simpleOwnerAuth {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  simpleOwnerAuth copyWith({String id, String name, String bar}) {
+  simpleOwnerAuth copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return simpleOwnerAuth(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   simpleOwnerAuth.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"simpleOwnerAuth.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"simpleOwnerAuth\\";
@@ -1702,6 +2175,16 @@ class simpleOwnerAuth extends Model {
         key: simpleOwnerAuth.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: simpleOwnerAuth.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: simpleOwnerAuth.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1744,6 +2227,8 @@ class allowRead extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1753,11 +2238,21 @@ class allowRead extends Model {
     return id;
   }
 
-  const allowRead._internal({@required this.id, this.name, this.bar});
+  const allowRead._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory allowRead({String id, String name, String bar}) {
+  factory allowRead(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return allowRead._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1770,7 +2265,9 @@ class allowRead extends Model {
     return other is allowRead &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1783,27 +2280,55 @@ class allowRead extends Model {
     buffer.write(\\"allowRead {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  allowRead copyWith({String id, String name, String bar}) {
+  allowRead copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return allowRead(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   allowRead.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"allowRead.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"allowRead\\";
@@ -1832,6 +2357,16 @@ class allowRead extends Model {
         key: allowRead.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: allowRead.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: allowRead.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -1874,6 +2409,8 @@ class privateType extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -1883,11 +2420,21 @@ class privateType extends Model {
     return id;
   }
 
-  const privateType._internal({@required this.id, this.name, this.bar});
+  const privateType._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory privateType({String id, String name, String bar}) {
+  factory privateType(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return privateType._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -1900,7 +2447,9 @@ class privateType extends Model {
     return other is privateType &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -1913,27 +2462,55 @@ class privateType extends Model {
     buffer.write(\\"privateType {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  privateType copyWith({String id, String name, String bar}) {
+  privateType copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return privateType(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   privateType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"privateType.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"privateType\\";
@@ -1959,6 +2536,16 @@ class privateType extends Model {
         key: privateType.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: privateType.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: privateType.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2001,6 +2588,8 @@ class publicType extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2010,11 +2599,21 @@ class publicType extends Model {
     return id;
   }
 
-  const publicType._internal({@required this.id, this.name, this.bar});
+  const publicType._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory publicType({String id, String name, String bar}) {
+  factory publicType(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return publicType._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2027,7 +2626,9 @@ class publicType extends Model {
     return other is publicType &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2040,27 +2641,55 @@ class publicType extends Model {
     buffer.write(\\"publicType {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  publicType copyWith({String id, String name, String bar}) {
+  publicType copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return publicType(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   publicType.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"publicType.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"publicType\\";
@@ -2086,6 +2715,16 @@ class publicType extends Model {
         key: publicType.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: publicType.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: publicType.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2128,6 +2767,8 @@ class staticGroups extends Model {
   final String id;
   final String name;
   final String bar;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2137,11 +2778,21 @@ class staticGroups extends Model {
     return id;
   }
 
-  const staticGroups._internal({@required this.id, this.name, this.bar});
+  const staticGroups._internal(
+      {@required this.id, this.name, this.bar, this.createdAt, this.updatedAt});
 
-  factory staticGroups({String id, String name, String bar}) {
+  factory staticGroups(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return staticGroups._internal(
-        id: id == null ? UUID.getUUID() : id, name: name, bar: bar);
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        bar: bar,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2154,7 +2805,9 @@ class staticGroups extends Model {
     return other is staticGroups &&
         id == other.id &&
         name == other.name &&
-        bar == other.bar;
+        bar == other.bar &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2167,27 +2820,55 @@ class staticGroups extends Model {
     buffer.write(\\"staticGroups {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"bar=\\" + \\"$bar\\");
+    buffer.write(\\"bar=\\" + \\"$bar\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  staticGroups copyWith({String id, String name, String bar}) {
+  staticGroups copyWith(
+      {String id,
+      String name,
+      String bar,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return staticGroups(
-        id: id ?? this.id, name: name ?? this.name, bar: bar ?? this.bar);
+        id: id ?? this.id,
+        name: name ?? this.name,
+        bar: bar ?? this.bar,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   staticGroups.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        bar = json['bar'];
+        bar = json['bar'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'bar': bar,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"staticGroups.id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"staticGroups\\";
@@ -2219,6 +2900,16 @@ class staticGroups extends Model {
         key: staticGroups.BAR,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: staticGroups.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: staticGroups.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2261,6 +2952,8 @@ class Post extends Model {
   final String id;
   final String title;
   final String author;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2271,11 +2964,24 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id, @required this.title, @required this.author});
+      {@required this.id,
+      @required this.title,
+      @required this.author,
+      this.createdAt,
+      this.updatedAt});
 
-  factory Post({String id, @required String title, @required String author}) {
+  factory Post(
+      {String id,
+      @required String title,
+      @required String author,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post._internal(
-        id: id == null ? UUID.getUUID() : id, title: title, author: author);
+        id: id == null ? UUID.getUUID() : id,
+        title: title,
+        author: author,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2288,7 +2994,9 @@ class Post extends Model {
     return other is Post &&
         id == other.id &&
         title == other.title &&
-        author == other.author;
+        author == other.author &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2301,29 +3009,55 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"author=\\" + \\"$author\\");
+    buffer.write(\\"author=\\" + \\"$author\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith({String id, String title, String author}) {
+  Post copyWith(
+      {String id,
+      String title,
+      String author,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
-        author: author ?? this.author);
+        author: author ?? this.author,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Post.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         title = json['title'],
-        author = json['author'];
+        author = json['author'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'title': title, 'author': author};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'author': author,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -2353,6 +3087,16 @@ class Post extends Model {
         key: Post.AUTHOR,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2395,6 +3139,8 @@ class Post extends Model {
   final String id;
   final String title;
   final String owner;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2405,11 +3151,24 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id, @required this.title, @required this.owner});
+      {@required this.id,
+      @required this.title,
+      @required this.owner,
+      this.createdAt,
+      this.updatedAt});
 
-  factory Post({String id, @required String title, @required String owner}) {
+  factory Post(
+      {String id,
+      @required String title,
+      @required String owner,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post._internal(
-        id: id == null ? UUID.getUUID() : id, title: title, owner: owner);
+        id: id == null ? UUID.getUUID() : id,
+        title: title,
+        owner: owner,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2422,7 +3181,9 @@ class Post extends Model {
     return other is Post &&
         id == other.id &&
         title == other.title &&
-        owner == other.owner;
+        owner == other.owner &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2435,29 +3196,55 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"owner=\\" + \\"$owner\\");
+    buffer.write(\\"owner=\\" + \\"$owner\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith({String id, String title, String owner}) {
+  Post copyWith(
+      {String id,
+      String title,
+      String owner,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
-        owner: owner ?? this.owner);
+        owner: owner ?? this.owner,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Post.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         title = json['title'],
-        owner = json['owner'];
+        owner = json['owner'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'title': title, 'owner': owner};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'owner': owner,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField OWNER = QueryField(fieldName: \\"owner\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -2500,6 +3287,16 @@ class Post extends Model {
         key: Post.OWNER,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2543,6 +3340,8 @@ class Todo extends Model {
   static const classType = const TodoType();
   final String id;
   final List<Task> tasks;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2552,12 +3351,19 @@ class Todo extends Model {
     return id;
   }
 
-  const Todo._internal({@required this.id, this.tasks});
+  const Todo._internal(
+      {@required this.id, this.tasks, this.createdAt, this.updatedAt});
 
-  factory Todo({String id, List<Task> tasks}) {
+  factory Todo(
+      {String id,
+      List<Task> tasks,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Todo._internal(
         id: id == null ? UUID.getUUID() : id,
-        tasks: tasks != null ? List.unmodifiable(tasks) : tasks);
+        tasks: tasks != null ? List.unmodifiable(tasks) : tasks,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2569,7 +3375,9 @@ class Todo extends Model {
     if (identical(other, this)) return true;
     return other is Todo &&
         id == other.id &&
-        DeepCollectionEquality().equals(tasks, other.tasks);
+        DeepCollectionEquality().equals(tasks, other.tasks) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2580,14 +3388,27 @@ class Todo extends Model {
     var buffer = new StringBuffer();
 
     buffer.write(\\"Todo {\\");
-    buffer.write(\\"id=\\" + \\"$id\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Todo copyWith({String id, List<Task> tasks}) {
-    return Todo(id: id ?? this.id, tasks: tasks ?? this.tasks);
+  Todo copyWith(
+      {String id,
+      List<Task> tasks,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return Todo(
+        id: id ?? this.id,
+        tasks: tasks ?? this.tasks,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Todo.fromJson(Map<String, dynamic> json)
@@ -2596,16 +3417,28 @@ class Todo extends Model {
             ? (json['tasks'] as List)
                 .map((e) => Task.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
+            : null,
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
-  Map<String, dynamic> toJson() =>
-      {'id': id, 'tasks': tasks?.map((e) => e?.toJson())?.toList()};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'tasks': tasks?.map((e) => e?.toJson())?.toList(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"todo.id\\");
   static final QueryField TASKS = QueryField(
       fieldName: \\"tasks\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Task).toString()));
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Todo\\";
@@ -2618,6 +3451,16 @@ class Todo extends Model {
         isRequired: false,
         ofModelName: (Task).toString(),
         associatedKey: Task.TODO));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Todo.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Todo.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2660,6 +3503,8 @@ class Task extends Model {
   static const classType = const TaskType();
   final String id;
   final Todo todo;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2669,10 +3514,19 @@ class Task extends Model {
     return id;
   }
 
-  const Task._internal({@required this.id, this.todo});
+  const Task._internal(
+      {@required this.id, this.todo, this.createdAt, this.updatedAt});
 
-  factory Task({String id, Todo todo}) {
-    return Task._internal(id: id == null ? UUID.getUUID() : id, todo: todo);
+  factory Task(
+      {String id,
+      Todo todo,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return Task._internal(
+        id: id == null ? UUID.getUUID() : id,
+        todo: todo,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2682,7 +3536,11 @@ class Task extends Model {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is Task && id == other.id && todo == other.todo;
+    return other is Task &&
+        id == other.id &&
+        todo == other.todo &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2694,29 +3552,55 @@ class Task extends Model {
 
     buffer.write(\\"Task {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"todo=\\" + (todo != null ? todo.toString() : \\"null\\"));
+    buffer.write(\\"todo=\\" + (todo != null ? todo.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Task copyWith({String id, Todo todo}) {
-    return Task(id: id ?? this.id, todo: todo ?? this.todo);
+  Task copyWith(
+      {String id,
+      Todo todo,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return Task(
+        id: id ?? this.id,
+        todo: todo ?? this.todo,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Task.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         todo = json['todo'] != null
             ? Todo.fromJson(new Map<String, dynamic>.from(json['todo']))
+            : null,
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
-  Map<String, dynamic> toJson() => {'id': id, 'todo': todo?.toJson()};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'todo': todo?.toJson(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"task.id\\");
   static final QueryField TODO = QueryField(
       fieldName: \\"todo\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Todo).toString()));
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Task\\";
@@ -2729,6 +3613,16 @@ class Task extends Model {
         isRequired: false,
         targetName: \\"taskTodoId\\",
         ofModelName: (Todo).toString()));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Task.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Task.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2774,6 +3668,8 @@ class Blog extends Model {
   final String name;
   final List<Post> posts;
   final List<String> test;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2784,15 +3680,27 @@ class Blog extends Model {
   }
 
   const Blog._internal(
-      {@required this.id, @required this.name, this.posts, this.test});
+      {@required this.id,
+      @required this.name,
+      this.posts,
+      this.test,
+      this.createdAt,
+      this.updatedAt});
 
   factory Blog(
-      {String id, @required String name, List<Post> posts, List<String> test}) {
+      {String id,
+      @required String name,
+      List<Post> posts,
+      List<String> test,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Blog._internal(
         id: id == null ? UUID.getUUID() : id,
         name: name,
         posts: posts != null ? List.unmodifiable(posts) : posts,
-        test: test != null ? List.unmodifiable(test) : test);
+        test: test != null ? List.unmodifiable(test) : test,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2806,7 +3714,9 @@ class Blog extends Model {
         id == other.id &&
         name == other.name &&
         DeepCollectionEquality().equals(posts, other.posts) &&
-        DeepCollectionEquality().equals(test, other.test);
+        DeepCollectionEquality().equals(test, other.test) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2819,18 +3729,31 @@ class Blog extends Model {
     buffer.write(\\"Blog {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
-    buffer.write(\\"test=\\" + (test != null ? test.toString() : \\"null\\"));
+    buffer.write(\\"test=\\" + (test != null ? test.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Blog copyWith({String id, String name, List<Post> posts, List<String> test}) {
+  Blog copyWith(
+      {String id,
+      String name,
+      List<Post> posts,
+      List<String> test,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Blog(
         id: id ?? this.id,
         name: name ?? this.name,
         posts: posts ?? this.posts,
-        test: test ?? this.test);
+        test: test ?? this.test,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Blog.fromJson(Map<String, dynamic> json)
@@ -2841,13 +3764,21 @@ class Blog extends Model {
                 .map((e) => Post.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
             : null,
-        test = json['test']?.cast<String>();
+        test = json['test']?.cast<String>(),
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
         'posts': posts?.map((e) => e?.toJson())?.toList(),
-        'test': test
+        'test': test,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"blog.id\\");
@@ -2857,6 +3788,8 @@ class Blog extends Model {
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Post).toString()));
   static final QueryField TEST = QueryField(fieldName: \\"test\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Blog\\";
@@ -2881,6 +3814,16 @@ class Blog extends Model {
         isArray: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.collection,
             ofModelName: describeEnum(ModelFieldTypeEnum.string))));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Blog.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Blog.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -2924,6 +3867,8 @@ class Comment extends Model {
   final String id;
   final Post post;
   final String content;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -2934,11 +3879,24 @@ class Comment extends Model {
   }
 
   const Comment._internal(
-      {@required this.id, this.post, @required this.content});
+      {@required this.id,
+      this.post,
+      @required this.content,
+      this.createdAt,
+      this.updatedAt});
 
-  factory Comment({String id, Post post, @required String content}) {
+  factory Comment(
+      {String id,
+      Post post,
+      @required String content,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Comment._internal(
-        id: id == null ? UUID.getUUID() : id, post: post, content: content);
+        id: id == null ? UUID.getUUID() : id,
+        post: post,
+        content: content,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -2951,7 +3909,9 @@ class Comment extends Model {
     return other is Comment &&
         id == other.id &&
         post == other.post &&
-        content == other.content;
+        content == other.content &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -2964,17 +3924,29 @@ class Comment extends Model {
     buffer.write(\\"Comment {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"post=\\" + (post != null ? post.toString() : \\"null\\") + \\", \\");
-    buffer.write(\\"content=\\" + \\"$content\\");
+    buffer.write(\\"content=\\" + \\"$content\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Comment copyWith({String id, Post post, String content}) {
+  Comment copyWith(
+      {String id,
+      Post post,
+      String content,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Comment(
         id: id ?? this.id,
         post: post ?? this.post,
-        content: content ?? this.content);
+        content: content ?? this.content,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Comment.fromJson(Map<String, dynamic> json)
@@ -2982,10 +3954,21 @@ class Comment extends Model {
         post = json['post'] != null
             ? Post.fromJson(new Map<String, dynamic>.from(json['post']))
             : null,
-        content = json['content'];
+        content = json['content'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
-  Map<String, dynamic> toJson() =>
-      {'id': id, 'post': post?.toJson(), 'content': content};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'post': post?.toJson(),
+        'content': content,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
   static final QueryField POST = QueryField(
@@ -2993,6 +3976,8 @@ class Comment extends Model {
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Post).toString()));
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Comment\\";
@@ -3010,6 +3995,16 @@ class Comment extends Model {
         key: Comment.CONTENT,
         isRequired: true,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Comment.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Comment.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3055,6 +4050,8 @@ class Post extends Model {
   final String title;
   final Blog blog;
   final List<Comment> comments;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3065,15 +4062,27 @@ class Post extends Model {
   }
 
   const Post._internal(
-      {@required this.id, @required this.title, this.blog, this.comments});
+      {@required this.id,
+      @required this.title,
+      this.blog,
+      this.comments,
+      this.createdAt,
+      this.updatedAt});
 
   factory Post(
-      {String id, @required String title, Blog blog, List<Comment> comments}) {
+      {String id,
+      @required String title,
+      Blog blog,
+      List<Comment> comments,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post._internal(
         id: id == null ? UUID.getUUID() : id,
         title: title,
         blog: blog,
-        comments: comments != null ? List.unmodifiable(comments) : comments);
+        comments: comments != null ? List.unmodifiable(comments) : comments,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -3087,7 +4096,9 @@ class Post extends Model {
         id == other.id &&
         title == other.title &&
         blog == other.blog &&
-        DeepCollectionEquality().equals(comments, other.comments);
+        DeepCollectionEquality().equals(comments, other.comments) &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -3100,18 +4111,31 @@ class Post extends Model {
     buffer.write(\\"Post {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"title=\\" + \\"$title\\" + \\", \\");
-    buffer.write(\\"blog=\\" + (blog != null ? blog.toString() : \\"null\\"));
+    buffer.write(\\"blog=\\" + (blog != null ? blog.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
   }
 
-  Post copyWith({String id, String title, Blog blog, List<Comment> comments}) {
+  Post copyWith(
+      {String id,
+      String title,
+      Blog blog,
+      List<Comment> comments,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return Post(
         id: id ?? this.id,
         title: title ?? this.title,
         blog: blog ?? this.blog,
-        comments: comments ?? this.comments);
+        comments: comments ?? this.comments,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   Post.fromJson(Map<String, dynamic> json)
@@ -3124,13 +4148,21 @@ class Post extends Model {
             ? (json['comments'] as List)
                 .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e)))
                 .toList()
+            : null,
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
             : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'blog': blog?.toJson(),
-        'comments': comments?.map((e) => e?.toJson())?.toList()
+        'comments': comments?.map((e) => e?.toJson())?.toList(),
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
@@ -3143,6 +4175,8 @@ class Post extends Model {
       fieldName: \\"comments\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
           ofModelName: (Comment).toString()));
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
@@ -3166,6 +4200,16 @@ class Post extends Model {
         isRequired: false,
         ofModelName: (Comment).toString(),
         associatedKey: Comment.POST));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: Post.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 
@@ -3210,6 +4254,8 @@ class authorBook extends Model {
   final String book_id;
   final String author;
   final String book;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
 
   @override
   getInstanceType() => classType;
@@ -3224,20 +4270,26 @@ class authorBook extends Model {
       @required this.author_id,
       @required this.book_id,
       this.author,
-      this.book});
+      this.book,
+      this.createdAt,
+      this.updatedAt});
 
   factory authorBook(
       {String id,
       @required String author_id,
       @required String book_id,
       String author,
-      String book}) {
+      String book,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return authorBook._internal(
         id: id == null ? UUID.getUUID() : id,
         author_id: author_id,
         book_id: book_id,
         author: author,
-        book: book);
+        book: book,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
   }
 
   bool equals(Object other) {
@@ -3252,7 +4304,9 @@ class authorBook extends Model {
         author_id == other.author_id &&
         book_id == other.book_id &&
         author == other.author &&
-        book == other.book;
+        book == other.book &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
   }
 
   @override
@@ -3267,7 +4321,12 @@ class authorBook extends Model {
     buffer.write(\\"author_id=\\" + \\"$author_id\\" + \\", \\");
     buffer.write(\\"book_id=\\" + \\"$book_id\\" + \\", \\");
     buffer.write(\\"author=\\" + \\"$author\\" + \\", \\");
-    buffer.write(\\"book=\\" + \\"$book\\");
+    buffer.write(\\"book=\\" + \\"$book\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
     buffer.write(\\"}\\");
 
     return buffer.toString();
@@ -3278,13 +4337,17 @@ class authorBook extends Model {
       String author_id,
       String book_id,
       String author,
-      String book}) {
+      String book,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
     return authorBook(
         id: id ?? this.id,
         author_id: author_id ?? this.author_id,
         book_id: book_id ?? this.book_id,
         author: author ?? this.author,
-        book: book ?? this.book);
+        book: book ?? this.book,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
   }
 
   authorBook.fromJson(Map<String, dynamic> json)
@@ -3292,14 +4355,22 @@ class authorBook extends Model {
         author_id = json['author_id'],
         book_id = json['book_id'],
         author = json['author'],
-        book = json['book'];
+        book = json['book'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'author_id': author_id,
         'book_id': book_id,
         'author': author,
-        'book': book
+        'book': book,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"authorBook.id\\");
@@ -3307,6 +4378,8 @@ class authorBook extends Model {
   static final QueryField BOOK_ID = QueryField(fieldName: \\"book_id\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
   static final QueryField BOOK = QueryField(fieldName: \\"book\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"authorBook\\";
@@ -3333,6 +4406,16 @@ class authorBook extends Model {
         key: authorBook.BOOK,
         isRequired: false,
         ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: authorBook.CREATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: authorBook.UPDATEDAT,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
   });
 }
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -34,8 +34,8 @@ public final class customClaim implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -250,8 +250,8 @@ public final class customClaim implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -471,8 +471,8 @@ public final class Employee implements Model {
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
   }) String ssn;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -722,8 +722,8 @@ public final class dynamicGroups implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -938,8 +938,8 @@ public final class simpleOwnerAuth implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1154,8 +1154,8 @@ public final class allowRead implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1370,8 +1370,8 @@ public final class privateType implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1588,8 +1588,8 @@ public final class privateType implements Model {
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.CREATE, ModelOperation.UPDATE })
   }) String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1804,8 +1804,8 @@ public final class publicType implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2020,8 +2020,8 @@ public final class staticGroups implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2235,8 +2235,8 @@ public final class Landmark implements Model {
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer rating;
   private final @ModelField(targetType=\\"Location\\", isRequired = true) Location location;
   private final @ModelField(targetType=\\"Location\\") Location parking;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2633,8 +2633,8 @@ public final class task implements Model {
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2867,8 +2867,8 @@ public final class Todo implements Model {
   public static final QueryField ID = field(\\"Todo\\", \\"id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3033,8 +3033,8 @@ public final class SimpleModel implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3244,8 +3244,8 @@ public final class SimpleModel implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3455,8 +3455,8 @@ public final class SimpleModel implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3673,8 +3673,8 @@ public final class task implements Model {
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3979,8 +3979,8 @@ public final class Todo implements Model {
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer version;
   private final @ModelField(targetType=\\"Float\\") Double value;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4313,7 +4313,7 @@ public final class TypeWithAWSDateScalars implements Model {
   private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSTimestamp\\") Temporal.Timestamp timestamp;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4583,8 +4583,8 @@ public final class authorBook implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String book_id;
   private final @ModelField(targetType=\\"String\\") String author;
   private final @ModelField(targetType=\\"String\\") String book;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4852,8 +4852,8 @@ public final class NonCamelCaseField implements Model {
   public static final QueryField EMPLOYEE_PID = field(\\"NonCamelCaseField\\", \\"employeePID\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String employeePID;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -5036,8 +5036,8 @@ public final class snake_case implements Model {
   public static final QueryField NAME = field(\\"snake_case\\", \\"name\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -5220,8 +5220,8 @@ public final class SnakeCaseField implements Model {
   public static final QueryField FIRST_NAME = field(\\"SnakeCaseField\\", \\"first_name\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String first_name;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
-  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`AppSyncModelVisitor Model with Auth should generate class with custom claims 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -30,9 +31,13 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
   public static final QueryField NAME = field(\\"customClaim\\", \\"name\\");
   public static final QueryField BAR = field(\\"customClaim\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"customClaim\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"customClaim\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -45,10 +50,20 @@ public final class customClaim implements Model {
       return bar;
   }
   
-  private customClaim(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private customClaim(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -61,7 +76,9 @@ public final class customClaim implements Model {
       customClaim customClaim = (customClaim) obj;
       return ObjectsCompat.equals(getId(), customClaim.getId()) &&
               ObjectsCompat.equals(getName(), customClaim.getName()) &&
-              ObjectsCompat.equals(getBar(), customClaim.getBar());
+              ObjectsCompat.equals(getBar(), customClaim.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), customClaim.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), customClaim.getUpdatedAt());
       }
   }
   
@@ -71,6 +88,8 @@ public final class customClaim implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -81,7 +100,9 @@ public final class customClaim implements Model {
       .append(\\"customClaim {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -112,6 +133,8 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -119,13 +142,17 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -133,6 +160,8 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -140,7 +169,9 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -152,6 +183,18 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -178,10 +221,12 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -193,6 +238,16 @@ public final class customClaim implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -202,6 +257,7 @@ public final class customClaim implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with custom group claims 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -229,9 +285,13 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
   public static final QueryField NAME = field(\\"customClaim\\", \\"name\\");
   public static final QueryField BAR = field(\\"customClaim\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"customClaim\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"customClaim\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -244,10 +304,20 @@ public final class customClaim implements Model {
       return bar;
   }
   
-  private customClaim(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private customClaim(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -260,7 +330,9 @@ public final class customClaim implements Model {
       customClaim customClaim = (customClaim) obj;
       return ObjectsCompat.equals(getId(), customClaim.getId()) &&
               ObjectsCompat.equals(getName(), customClaim.getName()) &&
-              ObjectsCompat.equals(getBar(), customClaim.getBar());
+              ObjectsCompat.equals(getBar(), customClaim.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), customClaim.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), customClaim.getUpdatedAt());
       }
   }
   
@@ -270,6 +342,8 @@ public final class customClaim implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -280,7 +354,9 @@ public final class customClaim implements Model {
       .append(\\"customClaim {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -311,6 +387,8 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -318,13 +396,17 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -332,6 +414,8 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -339,7 +423,9 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -351,6 +437,18 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -377,10 +475,12 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -392,6 +492,16 @@ public final class customClaim implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -401,6 +511,7 @@ public final class customClaim implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with default field auth 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -430,12 +541,16 @@ public final class Employee implements Model {
   public static final QueryField NAME = field(\\"Employee\\", \\"name\\");
   public static final QueryField ADDRESS = field(\\"Employee\\", \\"address\\");
   public static final QueryField SSN = field(\\"Employee\\", \\"ssn\\");
+  public static final QueryField CREATED_AT = field(\\"Employee\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"Employee\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
   }) String ssn;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -452,11 +567,21 @@ public final class Employee implements Model {
       return ssn;
   }
   
-  private Employee(String id, String name, String address, String ssn) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Employee(String id, String name, String address, String ssn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.address = address;
     this.ssn = ssn;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -470,7 +595,9 @@ public final class Employee implements Model {
       return ObjectsCompat.equals(getId(), employee.getId()) &&
               ObjectsCompat.equals(getName(), employee.getName()) &&
               ObjectsCompat.equals(getAddress(), employee.getAddress()) &&
-              ObjectsCompat.equals(getSsn(), employee.getSsn());
+              ObjectsCompat.equals(getSsn(), employee.getSsn()) &&
+              ObjectsCompat.equals(getCreatedAt(), employee.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), employee.getUpdatedAt());
       }
   }
   
@@ -481,6 +608,8 @@ public final class Employee implements Model {
       .append(getName())
       .append(getAddress())
       .append(getSsn())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -492,7 +621,9 @@ public final class Employee implements Model {
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
       .append(\\"address=\\" + String.valueOf(getAddress()) + \\", \\")
-      .append(\\"ssn=\\" + String.valueOf(getSsn()))
+      .append(\\"ssn=\\" + String.valueOf(getSsn()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -524,6 +655,8 @@ public final class Employee implements Model {
       id,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -532,7 +665,9 @@ public final class Employee implements Model {
     return new CopyOfBuilder(id,
       name,
       address,
-      ssn);
+      ssn,
+      createdAt,
+      updatedAt);
   }
   public interface NameStep {
     AddressStep name(String name);
@@ -548,6 +683,8 @@ public final class Employee implements Model {
     Employee build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep ssn(String ssn);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -556,6 +693,8 @@ public final class Employee implements Model {
     private String name;
     private String address;
     private String ssn;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public Employee build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -564,7 +703,9 @@ public final class Employee implements Model {
           id,
           name,
           address,
-          ssn);
+          ssn,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -584,6 +725,18 @@ public final class Employee implements Model {
     @Override
      public BuildStep ssn(String ssn) {
         this.ssn = ssn;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -610,11 +763,13 @@ public final class Employee implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String address, String ssn) {
+    private CopyOfBuilder(String id, String name, String address, String ssn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
         .address(address)
-        .ssn(ssn);
+        .ssn(ssn)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -631,6 +786,16 @@ public final class Employee implements Model {
      public CopyOfBuilder ssn(String ssn) {
       return (CopyOfBuilder) super.ssn(ssn);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -640,6 +805,7 @@ public final class Employee implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with dynamic groups 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -667,9 +833,13 @@ public final class dynamicGroups implements Model {
   public static final QueryField ID = field(\\"dynamicGroups\\", \\"id\\");
   public static final QueryField NAME = field(\\"dynamicGroups\\", \\"name\\");
   public static final QueryField BAR = field(\\"dynamicGroups\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"dynamicGroups\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"dynamicGroups\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -682,10 +852,20 @@ public final class dynamicGroups implements Model {
       return bar;
   }
   
-  private dynamicGroups(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private dynamicGroups(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -698,7 +878,9 @@ public final class dynamicGroups implements Model {
       dynamicGroups dynamicGroups = (dynamicGroups) obj;
       return ObjectsCompat.equals(getId(), dynamicGroups.getId()) &&
               ObjectsCompat.equals(getName(), dynamicGroups.getName()) &&
-              ObjectsCompat.equals(getBar(), dynamicGroups.getBar());
+              ObjectsCompat.equals(getBar(), dynamicGroups.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), dynamicGroups.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), dynamicGroups.getUpdatedAt());
       }
   }
   
@@ -708,6 +890,8 @@ public final class dynamicGroups implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -718,7 +902,9 @@ public final class dynamicGroups implements Model {
       .append(\\"dynamicGroups {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -749,6 +935,8 @@ public final class dynamicGroups implements Model {
     return new dynamicGroups(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -756,13 +944,17 @@ public final class dynamicGroups implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     dynamicGroups build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -770,6 +962,8 @@ public final class dynamicGroups implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public dynamicGroups build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -777,7 +971,9 @@ public final class dynamicGroups implements Model {
         return new dynamicGroups(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -789,6 +985,18 @@ public final class dynamicGroups implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -815,10 +1023,12 @@ public final class dynamicGroups implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -830,6 +1040,16 @@ public final class dynamicGroups implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -839,6 +1059,7 @@ public final class dynamicGroups implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with owner auth 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -866,9 +1087,13 @@ public final class simpleOwnerAuth implements Model {
   public static final QueryField ID = field(\\"simpleOwnerAuth\\", \\"id\\");
   public static final QueryField NAME = field(\\"simpleOwnerAuth\\", \\"name\\");
   public static final QueryField BAR = field(\\"simpleOwnerAuth\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"simpleOwnerAuth\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"simpleOwnerAuth\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -881,10 +1106,20 @@ public final class simpleOwnerAuth implements Model {
       return bar;
   }
   
-  private simpleOwnerAuth(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private simpleOwnerAuth(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -897,7 +1132,9 @@ public final class simpleOwnerAuth implements Model {
       simpleOwnerAuth simpleOwnerAuth = (simpleOwnerAuth) obj;
       return ObjectsCompat.equals(getId(), simpleOwnerAuth.getId()) &&
               ObjectsCompat.equals(getName(), simpleOwnerAuth.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar());
+              ObjectsCompat.equals(getBar(), simpleOwnerAuth.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), simpleOwnerAuth.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), simpleOwnerAuth.getUpdatedAt());
       }
   }
   
@@ -907,6 +1144,8 @@ public final class simpleOwnerAuth implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -917,7 +1156,9 @@ public final class simpleOwnerAuth implements Model {
       .append(\\"simpleOwnerAuth {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -948,6 +1189,8 @@ public final class simpleOwnerAuth implements Model {
     return new simpleOwnerAuth(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -955,13 +1198,17 @@ public final class simpleOwnerAuth implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     simpleOwnerAuth build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -969,6 +1216,8 @@ public final class simpleOwnerAuth implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public simpleOwnerAuth build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -976,7 +1225,9 @@ public final class simpleOwnerAuth implements Model {
         return new simpleOwnerAuth(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -988,6 +1239,18 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1014,10 +1277,12 @@ public final class simpleOwnerAuth implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -1029,6 +1294,16 @@ public final class simpleOwnerAuth implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -1038,6 +1313,7 @@ public final class simpleOwnerAuth implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with owner auth allowing others to read 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -1065,9 +1341,13 @@ public final class allowRead implements Model {
   public static final QueryField ID = field(\\"allowRead\\", \\"id\\");
   public static final QueryField NAME = field(\\"allowRead\\", \\"name\\");
   public static final QueryField BAR = field(\\"allowRead\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"allowRead\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"allowRead\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1080,10 +1360,20 @@ public final class allowRead implements Model {
       return bar;
   }
   
-  private allowRead(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private allowRead(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1096,7 +1386,9 @@ public final class allowRead implements Model {
       allowRead allowRead = (allowRead) obj;
       return ObjectsCompat.equals(getId(), allowRead.getId()) &&
               ObjectsCompat.equals(getName(), allowRead.getName()) &&
-              ObjectsCompat.equals(getBar(), allowRead.getBar());
+              ObjectsCompat.equals(getBar(), allowRead.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), allowRead.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), allowRead.getUpdatedAt());
       }
   }
   
@@ -1106,6 +1398,8 @@ public final class allowRead implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -1116,7 +1410,9 @@ public final class allowRead implements Model {
       .append(\\"allowRead {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -1147,6 +1443,8 @@ public final class allowRead implements Model {
     return new allowRead(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -1154,13 +1452,17 @@ public final class allowRead implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     allowRead build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1168,6 +1470,8 @@ public final class allowRead implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public allowRead build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1175,7 +1479,9 @@ public final class allowRead implements Model {
         return new allowRead(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -1187,6 +1493,18 @@ public final class allowRead implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1213,10 +1531,12 @@ public final class allowRead implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -1227,6 +1547,16 @@ public final class allowRead implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1237,6 +1567,7 @@ public final class allowRead implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with private authorization 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -1264,9 +1595,13 @@ public final class privateType implements Model {
   public static final QueryField ID = field(\\"privateType\\", \\"id\\");
   public static final QueryField NAME = field(\\"privateType\\", \\"name\\");
   public static final QueryField BAR = field(\\"privateType\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"privateType\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"privateType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1279,10 +1614,20 @@ public final class privateType implements Model {
       return bar;
   }
   
-  private privateType(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private privateType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1295,7 +1640,9 @@ public final class privateType implements Model {
       privateType privateType = (privateType) obj;
       return ObjectsCompat.equals(getId(), privateType.getId()) &&
               ObjectsCompat.equals(getName(), privateType.getName()) &&
-              ObjectsCompat.equals(getBar(), privateType.getBar());
+              ObjectsCompat.equals(getBar(), privateType.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), privateType.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), privateType.getUpdatedAt());
       }
   }
   
@@ -1305,6 +1652,8 @@ public final class privateType implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -1315,7 +1664,9 @@ public final class privateType implements Model {
       .append(\\"privateType {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -1346,6 +1697,8 @@ public final class privateType implements Model {
     return new privateType(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -1353,13 +1706,17 @@ public final class privateType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     privateType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1367,6 +1724,8 @@ public final class privateType implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public privateType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1374,7 +1733,9 @@ public final class privateType implements Model {
         return new privateType(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -1386,6 +1747,18 @@ public final class privateType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1412,10 +1785,12 @@ public final class privateType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -1426,6 +1801,16 @@ public final class privateType implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1436,6 +1821,7 @@ public final class privateType implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with private authorization and field auth 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -1463,11 +1849,15 @@ public final class privateType implements Model {
   public static final QueryField ID = field(\\"privateType\\", \\"id\\");
   public static final QueryField NAME = field(\\"privateType\\", \\"name\\");
   public static final QueryField BAR = field(\\"privateType\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"privateType\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"privateType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.CREATE, ModelOperation.UPDATE })
   }) String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1480,10 +1870,20 @@ public final class privateType implements Model {
       return bar;
   }
   
-  private privateType(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private privateType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1496,7 +1896,9 @@ public final class privateType implements Model {
       privateType privateType = (privateType) obj;
       return ObjectsCompat.equals(getId(), privateType.getId()) &&
               ObjectsCompat.equals(getName(), privateType.getName()) &&
-              ObjectsCompat.equals(getBar(), privateType.getBar());
+              ObjectsCompat.equals(getBar(), privateType.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), privateType.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), privateType.getUpdatedAt());
       }
   }
   
@@ -1506,6 +1908,8 @@ public final class privateType implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -1516,7 +1920,9 @@ public final class privateType implements Model {
       .append(\\"privateType {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -1547,6 +1953,8 @@ public final class privateType implements Model {
     return new privateType(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -1554,13 +1962,17 @@ public final class privateType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     privateType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1568,6 +1980,8 @@ public final class privateType implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public privateType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1575,7 +1989,9 @@ public final class privateType implements Model {
         return new privateType(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -1587,6 +2003,18 @@ public final class privateType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1613,10 +2041,12 @@ public final class privateType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -1628,6 +2058,16 @@ public final class privateType implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -1637,6 +2077,7 @@ public final class privateType implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with public authorization 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -1664,9 +2105,13 @@ public final class publicType implements Model {
   public static final QueryField ID = field(\\"publicType\\", \\"id\\");
   public static final QueryField NAME = field(\\"publicType\\", \\"name\\");
   public static final QueryField BAR = field(\\"publicType\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"publicType\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"publicType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1679,10 +2124,20 @@ public final class publicType implements Model {
       return bar;
   }
   
-  private publicType(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private publicType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1695,7 +2150,9 @@ public final class publicType implements Model {
       publicType publicType = (publicType) obj;
       return ObjectsCompat.equals(getId(), publicType.getId()) &&
               ObjectsCompat.equals(getName(), publicType.getName()) &&
-              ObjectsCompat.equals(getBar(), publicType.getBar());
+              ObjectsCompat.equals(getBar(), publicType.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), publicType.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), publicType.getUpdatedAt());
       }
   }
   
@@ -1705,6 +2162,8 @@ public final class publicType implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -1715,7 +2174,9 @@ public final class publicType implements Model {
       .append(\\"publicType {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -1746,6 +2207,8 @@ public final class publicType implements Model {
     return new publicType(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -1753,13 +2216,17 @@ public final class publicType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     publicType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1767,6 +2234,8 @@ public final class publicType implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public publicType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1774,7 +2243,9 @@ public final class publicType implements Model {
         return new publicType(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -1786,6 +2257,18 @@ public final class publicType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1812,10 +2295,12 @@ public final class publicType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -1827,6 +2312,16 @@ public final class publicType implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -1836,6 +2331,7 @@ public final class publicType implements Model {
 exports[`AppSyncModelVisitor Model with Auth should generate class with static groups 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -1863,9 +2359,13 @@ public final class staticGroups implements Model {
   public static final QueryField ID = field(\\"staticGroups\\", \\"id\\");
   public static final QueryField NAME = field(\\"staticGroups\\", \\"name\\");
   public static final QueryField BAR = field(\\"staticGroups\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"staticGroups\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"staticGroups\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -1878,10 +2378,20 @@ public final class staticGroups implements Model {
       return bar;
   }
   
-  private staticGroups(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private staticGroups(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1894,7 +2404,9 @@ public final class staticGroups implements Model {
       staticGroups staticGroups = (staticGroups) obj;
       return ObjectsCompat.equals(getId(), staticGroups.getId()) &&
               ObjectsCompat.equals(getName(), staticGroups.getName()) &&
-              ObjectsCompat.equals(getBar(), staticGroups.getBar());
+              ObjectsCompat.equals(getBar(), staticGroups.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), staticGroups.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), staticGroups.getUpdatedAt());
       }
   }
   
@@ -1904,6 +2416,8 @@ public final class staticGroups implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -1914,7 +2428,9 @@ public final class staticGroups implements Model {
       .append(\\"staticGroups {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -1945,6 +2461,8 @@ public final class staticGroups implements Model {
     return new staticGroups(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -1952,13 +2470,17 @@ public final class staticGroups implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     staticGroups build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1966,6 +2488,8 @@ public final class staticGroups implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public staticGroups build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1973,7 +2497,9 @@ public final class staticGroups implements Model {
         return new staticGroups(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -1985,6 +2511,18 @@ public final class staticGroups implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2011,10 +2549,12 @@ public final class staticGroups implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -2026,6 +2566,16 @@ public final class staticGroups implements Model {
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -2035,6 +2585,7 @@ public final class staticGroups implements Model {
 exports[`AppSyncModelVisitor Non model type should generate class for model types with non model fields 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -2059,11 +2610,15 @@ public final class Landmark implements Model {
   public static final QueryField RATING = field(\\"Landmark\\", \\"rating\\");
   public static final QueryField LOCATION = field(\\"Landmark\\", \\"location\\");
   public static final QueryField PARKING = field(\\"Landmark\\", \\"parking\\");
+  public static final QueryField CREATED_AT = field(\\"Landmark\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"Landmark\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer rating;
   private final @ModelField(targetType=\\"Location\\", isRequired = true) Location location;
   private final @ModelField(targetType=\\"Location\\") Location parking;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2084,12 +2639,22 @@ public final class Landmark implements Model {
       return parking;
   }
   
-  private Landmark(String id, String name, Integer rating, Location location, Location parking) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Landmark(String id, String name, Integer rating, Location location, Location parking, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.rating = rating;
     this.location = location;
     this.parking = parking;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2104,7 +2669,9 @@ public final class Landmark implements Model {
               ObjectsCompat.equals(getName(), landmark.getName()) &&
               ObjectsCompat.equals(getRating(), landmark.getRating()) &&
               ObjectsCompat.equals(getLocation(), landmark.getLocation()) &&
-              ObjectsCompat.equals(getParking(), landmark.getParking());
+              ObjectsCompat.equals(getParking(), landmark.getParking()) &&
+              ObjectsCompat.equals(getCreatedAt(), landmark.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), landmark.getUpdatedAt());
       }
   }
   
@@ -2116,6 +2683,8 @@ public final class Landmark implements Model {
       .append(getRating())
       .append(getLocation())
       .append(getParking())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -2128,7 +2697,9 @@ public final class Landmark implements Model {
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
       .append(\\"rating=\\" + String.valueOf(getRating()) + \\", \\")
       .append(\\"location=\\" + String.valueOf(getLocation()) + \\", \\")
-      .append(\\"parking=\\" + String.valueOf(getParking()))
+      .append(\\"parking=\\" + String.valueOf(getParking()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -2161,6 +2732,8 @@ public final class Landmark implements Model {
       null,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -2170,7 +2743,9 @@ public final class Landmark implements Model {
       name,
       rating,
       location,
-      parking);
+      parking,
+      createdAt,
+      updatedAt);
   }
   public interface NameStep {
     RatingStep name(String name);
@@ -2191,6 +2766,8 @@ public final class Landmark implements Model {
     Landmark build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep parking(Location parking);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2200,6 +2777,8 @@ public final class Landmark implements Model {
     private Integer rating;
     private Location location;
     private Location parking;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public Landmark build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2209,7 +2788,9 @@ public final class Landmark implements Model {
           name,
           rating,
           location,
-          parking);
+          parking,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -2239,6 +2820,18 @@ public final class Landmark implements Model {
         return this;
     }
     
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -2262,12 +2855,14 @@ public final class Landmark implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, Integer rating, Location location, Location parking) {
+    private CopyOfBuilder(String id, String name, Integer rating, Location location, Location parking, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
         .rating(rating)
         .location(location)
-        .parking(parking);
+        .parking(parking)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -2288,6 +2883,16 @@ public final class Landmark implements Model {
     @Override
      public CopyOfBuilder parking(Location parking) {
       return (CopyOfBuilder) super.parking(parking);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2442,10 +3047,14 @@ public final class task implements Model {
   public static final QueryField TODO = field(\\"task\\", \\"taskTodoId\\");
   public static final QueryField TIME = field(\\"task\\", \\"time\\");
   public static final QueryField CREATED_ON = field(\\"task\\", \\"createdOn\\");
+  public static final QueryField CREATED_AT = field(\\"task\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"task\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2462,11 +3071,21 @@ public final class task implements Model {
       return createdOn;
   }
   
-  private task(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private task(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.todo = todo;
     this.time = time;
     this.createdOn = createdOn;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2480,7 +3099,9 @@ public final class task implements Model {
       return ObjectsCompat.equals(getId(), task.getId()) &&
               ObjectsCompat.equals(getTodo(), task.getTodo()) &&
               ObjectsCompat.equals(getTime(), task.getTime()) &&
-              ObjectsCompat.equals(getCreatedOn(), task.getCreatedOn());
+              ObjectsCompat.equals(getCreatedOn(), task.getCreatedOn()) &&
+              ObjectsCompat.equals(getCreatedAt(), task.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), task.getUpdatedAt());
       }
   }
   
@@ -2491,6 +3112,8 @@ public final class task implements Model {
       .append(getTodo())
       .append(getTime())
       .append(getCreatedOn())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -2502,7 +3125,9 @@ public final class task implements Model {
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"todo=\\" + String.valueOf(getTodo()) + \\", \\")
       .append(\\"time=\\" + String.valueOf(getTime()) + \\", \\")
-      .append(\\"createdOn=\\" + String.valueOf(getCreatedOn()))
+      .append(\\"createdOn=\\" + String.valueOf(getCreatedOn()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -2534,6 +3159,8 @@ public final class task implements Model {
       id,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -2542,7 +3169,9 @@ public final class task implements Model {
     return new CopyOfBuilder(id,
       todo,
       time,
-      createdOn);
+      createdOn,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     task build();
@@ -2550,6 +3179,8 @@ public final class task implements Model {
     BuildStep todo(Todo todo);
     BuildStep time(Temporal.Time time);
     BuildStep createdOn(Temporal.Date createdOn);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2558,6 +3189,8 @@ public final class task implements Model {
     private Todo todo;
     private Temporal.Time time;
     private Temporal.Date createdOn;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public task build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2566,7 +3199,9 @@ public final class task implements Model {
           id,
           todo,
           time,
-          createdOn);
+          createdOn,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -2584,6 +3219,18 @@ public final class task implements Model {
     @Override
      public BuildStep createdOn(Temporal.Date createdOn) {
         this.createdOn = createdOn;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2610,11 +3257,13 @@ public final class task implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
+    private CopyOfBuilder(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.todo(todo)
         .time(time)
-        .createdOn(createdOn);
+        .createdOn(createdOn)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -2631,6 +3280,16 @@ public final class task implements Model {
      public CopyOfBuilder createdOn(Temporal.Date createdOn) {
       return (CopyOfBuilder) super.createdOn(createdOn);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -2641,6 +3300,7 @@ exports[`AppSyncModelVisitor One to Many connection with no nullable and non nul
 "package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -2661,8 +3321,12 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @ModelConfig(pluralName = \\"Todos\\")
 public final class Todo implements Model {
   public static final QueryField ID = field(\\"Todo\\", \\"id\\");
+  public static final QueryField CREATED_AT = field(\\"Todo\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"Todo\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2671,8 +3335,18 @@ public final class Todo implements Model {
       return tasks;
   }
   
-  private Todo(String id) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Todo(String id, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2683,7 +3357,9 @@ public final class Todo implements Model {
         return false;
       } else {
       Todo todo = (Todo) obj;
-      return ObjectsCompat.equals(getId(), todo.getId());
+      return ObjectsCompat.equals(getId(), todo.getId()) &&
+              ObjectsCompat.equals(getCreatedAt(), todo.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), todo.getUpdatedAt());
       }
   }
   
@@ -2691,6 +3367,8 @@ public final class Todo implements Model {
    public int hashCode() {
     return new StringBuilder()
       .append(getId())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -2699,7 +3377,9 @@ public final class Todo implements Model {
    public String toString() {
     return new StringBuilder()
       .append(\\"Todo {\\")
-      .append(\\"id=\\" + String.valueOf(getId()))
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -2728,27 +3408,49 @@ public final class Todo implements Model {
       );
     }
     return new Todo(
-      id
+      id,
+      null,
+      null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id);
+    return new CopyOfBuilder(id,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     Todo build();
     BuildStep id(String id) throws IllegalArgumentException;
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public Todo build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new Todo(
-          id);
+          id,
+          createdAt,
+          updatedAt);
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
     }
     
     /** 
@@ -2774,9 +3476,20 @@ public final class Todo implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id) {
+    private CopyOfBuilder(String id, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
-      
+      super.createdAt(createdAt)
+        .updatedAt(updatedAt);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2787,6 +3500,7 @@ public final class Todo implements Model {
 exports[`AppSyncModelVisitor Should generate a class a model with all optional fields 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -2809,9 +3523,13 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -2824,10 +3542,20 @@ public final class SimpleModel implements Model {
       return bar;
   }
   
-  private SimpleModel(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2840,7 +3568,9 @@ public final class SimpleModel implements Model {
       SimpleModel simpleModel = (SimpleModel) obj;
       return ObjectsCompat.equals(getId(), simpleModel.getId()) &&
               ObjectsCompat.equals(getName(), simpleModel.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleModel.getBar());
+              ObjectsCompat.equals(getBar(), simpleModel.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), simpleModel.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), simpleModel.getUpdatedAt());
       }
   }
   
@@ -2850,6 +3580,8 @@ public final class SimpleModel implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -2860,7 +3592,9 @@ public final class SimpleModel implements Model {
       .append(\\"SimpleModel {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -2891,6 +3625,8 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -2898,13 +3634,17 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2912,6 +3652,8 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2919,7 +3661,9 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -2931,6 +3675,18 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2957,10 +3713,12 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -2971,6 +3729,16 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2981,6 +3749,7 @@ public final class SimpleModel implements Model {
 exports[`AppSyncModelVisitor Should generate a class for a Model 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -3003,9 +3772,13 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3018,10 +3791,20 @@ public final class SimpleModel implements Model {
       return bar;
   }
   
-  private SimpleModel(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3034,7 +3817,9 @@ public final class SimpleModel implements Model {
       SimpleModel simpleModel = (SimpleModel) obj;
       return ObjectsCompat.equals(getId(), simpleModel.getId()) &&
               ObjectsCompat.equals(getName(), simpleModel.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleModel.getBar());
+              ObjectsCompat.equals(getBar(), simpleModel.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), simpleModel.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), simpleModel.getUpdatedAt());
       }
   }
   
@@ -3044,6 +3829,8 @@ public final class SimpleModel implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -3054,7 +3841,9 @@ public final class SimpleModel implements Model {
       .append(\\"SimpleModel {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -3085,6 +3874,8 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -3092,13 +3883,17 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3106,6 +3901,8 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3113,7 +3910,9 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -3125,6 +3924,18 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -3151,10 +3962,12 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -3165,6 +3978,16 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -3175,6 +3998,7 @@ public final class SimpleModel implements Model {
 exports[`AppSyncModelVisitor Should generate a class for a Model 2`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -3197,9 +4021,13 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
+  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3212,10 +4040,20 @@ public final class SimpleModel implements Model {
       return bar;
   }
   
-  private SimpleModel(String id, String name, String bar) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
     this.bar = bar;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3228,7 +4066,9 @@ public final class SimpleModel implements Model {
       SimpleModel simpleModel = (SimpleModel) obj;
       return ObjectsCompat.equals(getId(), simpleModel.getId()) &&
               ObjectsCompat.equals(getName(), simpleModel.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleModel.getBar());
+              ObjectsCompat.equals(getBar(), simpleModel.getBar()) &&
+              ObjectsCompat.equals(getCreatedAt(), simpleModel.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), simpleModel.getUpdatedAt());
       }
   }
   
@@ -3238,6 +4078,8 @@ public final class SimpleModel implements Model {
       .append(getId())
       .append(getName())
       .append(getBar())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -3248,7 +4090,9 @@ public final class SimpleModel implements Model {
       .append(\\"SimpleModel {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()))
+      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -3279,6 +4123,8 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
+      null,
+      null,
       null
     );
   }
@@ -3286,13 +4132,17 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      bar,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3300,6 +4150,8 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3307,7 +4159,9 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar);
+          bar,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -3319,6 +4173,18 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -3345,10 +4211,12 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.name(name)
-        .bar(bar);
+        .bar(bar)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -3359,6 +4227,16 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -3396,12 +4274,16 @@ public final class task implements Model {
   public static final QueryField TODO = field(\\"task\\", \\"taskTodoId\\");
   public static final QueryField TIME = field(\\"task\\", \\"time\\");
   public static final QueryField CREATED_ON = field(\\"task\\", \\"createdOn\\");
+  public static final QueryField CREATED_AT = field(\\"task\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"task\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
   private final @ModelField(targetType=\\"Boolean\\", isRequired = true) Boolean done;
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3426,13 +4308,23 @@ public final class task implements Model {
       return createdOn;
   }
   
-  private task(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private task(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.title = title;
     this.done = done;
     this.todo = todo;
     this.time = time;
     this.createdOn = createdOn;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3448,7 +4340,9 @@ public final class task implements Model {
               ObjectsCompat.equals(getDone(), task.getDone()) &&
               ObjectsCompat.equals(getTodo(), task.getTodo()) &&
               ObjectsCompat.equals(getTime(), task.getTime()) &&
-              ObjectsCompat.equals(getCreatedOn(), task.getCreatedOn());
+              ObjectsCompat.equals(getCreatedOn(), task.getCreatedOn()) &&
+              ObjectsCompat.equals(getCreatedAt(), task.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), task.getUpdatedAt());
       }
   }
   
@@ -3461,6 +4355,8 @@ public final class task implements Model {
       .append(getTodo())
       .append(getTime())
       .append(getCreatedOn())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -3474,7 +4370,9 @@ public final class task implements Model {
       .append(\\"done=\\" + String.valueOf(getDone()) + \\", \\")
       .append(\\"todo=\\" + String.valueOf(getTodo()) + \\", \\")
       .append(\\"time=\\" + String.valueOf(getTime()) + \\", \\")
-      .append(\\"createdOn=\\" + String.valueOf(getCreatedOn()))
+      .append(\\"createdOn=\\" + String.valueOf(getCreatedOn()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -3508,6 +4406,8 @@ public final class task implements Model {
       null,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -3518,7 +4418,9 @@ public final class task implements Model {
       done,
       todo,
       time,
-      createdOn);
+      createdOn,
+      createdAt,
+      updatedAt);
   }
   public interface TitleStep {
     DoneStep title(String title);
@@ -3536,6 +4438,8 @@ public final class task implements Model {
     BuildStep todo(Todo todo);
     BuildStep time(Temporal.Time time);
     BuildStep createdOn(Temporal.Date createdOn);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3546,6 +4450,8 @@ public final class task implements Model {
     private Todo todo;
     private Temporal.Time time;
     private Temporal.Date createdOn;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public task build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3556,7 +4462,9 @@ public final class task implements Model {
           done,
           todo,
           time,
-          createdOn);
+          createdOn,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -3591,6 +4499,18 @@ public final class task implements Model {
         return this;
     }
     
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -3614,13 +4534,15 @@ public final class task implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
+    private CopyOfBuilder(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.title(title)
         .done(done)
         .todo(todo)
         .time(time)
-        .createdOn(createdOn);
+        .createdOn(createdOn)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -3647,6 +4569,16 @@ public final class task implements Model {
      public CopyOfBuilder createdOn(Temporal.Date createdOn) {
       return (CopyOfBuilder) super.createdOn(createdOn);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -3657,6 +4589,7 @@ exports[`AppSyncModelVisitor connection One to Many connection should generate o
 "package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.annotations.HasMany;
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -3683,6 +4616,8 @@ public final class Todo implements Model {
   public static final QueryField DUE_DATE = field(\\"Todo\\", \\"due_date\\");
   public static final QueryField VERSION = field(\\"Todo\\", \\"version\\");
   public static final QueryField VALUE = field(\\"Todo\\", \\"value\\");
+  public static final QueryField CREATED_AT = field(\\"Todo\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"Todo\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
   private final @ModelField(targetType=\\"Boolean\\", isRequired = true) Boolean done;
@@ -3691,6 +4626,8 @@ public final class Todo implements Model {
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer version;
   private final @ModelField(targetType=\\"Float\\") Double value;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -3723,7 +4660,15 @@ public final class Todo implements Model {
       return tasks;
   }
   
-  private Todo(String id, String title, Boolean done, String description, String due_date, Integer version, Double value) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Todo(String id, String title, Boolean done, String description, String due_date, Integer version, Double value, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.title = title;
     this.done = done;
@@ -3731,6 +4676,8 @@ public final class Todo implements Model {
     this.due_date = due_date;
     this.version = version;
     this.value = value;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3747,7 +4694,9 @@ public final class Todo implements Model {
               ObjectsCompat.equals(getDescription(), todo.getDescription()) &&
               ObjectsCompat.equals(getDueDate(), todo.getDueDate()) &&
               ObjectsCompat.equals(getVersion(), todo.getVersion()) &&
-              ObjectsCompat.equals(getValue(), todo.getValue());
+              ObjectsCompat.equals(getValue(), todo.getValue()) &&
+              ObjectsCompat.equals(getCreatedAt(), todo.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), todo.getUpdatedAt());
       }
   }
   
@@ -3761,6 +4710,8 @@ public final class Todo implements Model {
       .append(getDueDate())
       .append(getVersion())
       .append(getValue())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -3775,7 +4726,9 @@ public final class Todo implements Model {
       .append(\\"description=\\" + String.valueOf(getDescription()) + \\", \\")
       .append(\\"due_date=\\" + String.valueOf(getDueDate()) + \\", \\")
       .append(\\"version=\\" + String.valueOf(getVersion()) + \\", \\")
-      .append(\\"value=\\" + String.valueOf(getValue()))
+      .append(\\"value=\\" + String.valueOf(getValue()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -3810,6 +4763,8 @@ public final class Todo implements Model {
       null,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -3821,7 +4776,9 @@ public final class Todo implements Model {
       description,
       due_date,
       version,
-      value);
+      value,
+      createdAt,
+      updatedAt);
   }
   public interface TitleStep {
     DoneStep title(String title);
@@ -3844,6 +4801,8 @@ public final class Todo implements Model {
     BuildStep description(String description);
     BuildStep dueDate(String dueDate);
     BuildStep value(Double value);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3855,6 +4814,8 @@ public final class Todo implements Model {
     private String description;
     private String due_date;
     private Double value;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public Todo build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3866,7 +4827,9 @@ public final class Todo implements Model {
           description,
           due_date,
           version,
-          value);
+          value,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -3908,6 +4871,18 @@ public final class Todo implements Model {
         return this;
     }
     
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -3931,14 +4906,16 @@ public final class Todo implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String title, Boolean done, String description, String dueDate, Integer version, Double value) {
+    private CopyOfBuilder(String id, String title, Boolean done, String description, String dueDate, Integer version, Double value, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.title(title)
         .done(done)
         .version(version)
         .description(description)
         .dueDate(dueDate)
-        .value(value);
+        .value(value)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -3969,6 +4946,16 @@ public final class Todo implements Model {
     @Override
      public CopyOfBuilder value(Double value) {
       return (CopyOfBuilder) super.value(value);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4004,11 +4991,13 @@ public final class TypeWithAWSDateScalars implements Model {
   public static final QueryField CREATED_AT = field(\\"TypeWithAWSDateScalars\\", \\"createdAt\\");
   public static final QueryField TIME = field(\\"TypeWithAWSDateScalars\\", \\"time\\");
   public static final QueryField TIMESTAMP = field(\\"TypeWithAWSDateScalars\\", \\"timestamp\\");
+  public static final QueryField UPDATED_AT = field(\\"TypeWithAWSDateScalars\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date date;
   private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSTimestamp\\") Temporal.Timestamp timestamp;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4029,12 +5018,17 @@ public final class TypeWithAWSDateScalars implements Model {
       return timestamp;
   }
   
-  private TypeWithAWSDateScalars(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp) {
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private TypeWithAWSDateScalars(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp, Temporal.DateTime updatedAt) {
     this.id = id;
     this.date = date;
     this.createdAt = createdAt;
     this.time = time;
     this.timestamp = timestamp;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4049,7 +5043,8 @@ public final class TypeWithAWSDateScalars implements Model {
               ObjectsCompat.equals(getDate(), typeWithAwsDateScalars.getDate()) &&
               ObjectsCompat.equals(getCreatedAt(), typeWithAwsDateScalars.getCreatedAt()) &&
               ObjectsCompat.equals(getTime(), typeWithAwsDateScalars.getTime()) &&
-              ObjectsCompat.equals(getTimestamp(), typeWithAwsDateScalars.getTimestamp());
+              ObjectsCompat.equals(getTimestamp(), typeWithAwsDateScalars.getTimestamp()) &&
+              ObjectsCompat.equals(getUpdatedAt(), typeWithAwsDateScalars.getUpdatedAt());
       }
   }
   
@@ -4061,6 +5056,7 @@ public final class TypeWithAWSDateScalars implements Model {
       .append(getCreatedAt())
       .append(getTime())
       .append(getTimestamp())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -4073,7 +5069,8 @@ public final class TypeWithAWSDateScalars implements Model {
       .append(\\"date=\\" + String.valueOf(getDate()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"time=\\" + String.valueOf(getTime()) + \\", \\")
-      .append(\\"timestamp=\\" + String.valueOf(getTimestamp()))
+      .append(\\"timestamp=\\" + String.valueOf(getTimestamp()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -4106,6 +5103,7 @@ public final class TypeWithAWSDateScalars implements Model {
       null,
       null,
       null,
+      null,
       null
     );
   }
@@ -4115,7 +5113,8 @@ public final class TypeWithAWSDateScalars implements Model {
       date,
       createdAt,
       time,
-      timestamp);
+      timestamp,
+      updatedAt);
   }
   public interface BuildStep {
     TypeWithAWSDateScalars build();
@@ -4124,6 +5123,7 @@ public final class TypeWithAWSDateScalars implements Model {
     BuildStep createdAt(Temporal.DateTime createdAt);
     BuildStep time(Temporal.Time time);
     BuildStep timestamp(Temporal.Timestamp timestamp);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -4133,6 +5133,7 @@ public final class TypeWithAWSDateScalars implements Model {
     private Temporal.DateTime createdAt;
     private Temporal.Time time;
     private Temporal.Timestamp timestamp;
+    private Temporal.DateTime updatedAt;
     @Override
      public TypeWithAWSDateScalars build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -4142,7 +5143,8 @@ public final class TypeWithAWSDateScalars implements Model {
           date,
           createdAt,
           time,
-          timestamp);
+          timestamp,
+          updatedAt);
     }
     
     @Override
@@ -4169,6 +5171,12 @@ public final class TypeWithAWSDateScalars implements Model {
         return this;
     }
     
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -4192,12 +5200,13 @@ public final class TypeWithAWSDateScalars implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp) {
+    private CopyOfBuilder(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp, Temporal.DateTime updatedAt) {
       super.id(id);
       super.date(date)
         .createdAt(createdAt)
         .time(time)
-        .timestamp(timestamp);
+        .timestamp(timestamp)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -4219,6 +5228,11 @@ public final class TypeWithAWSDateScalars implements Model {
      public CopyOfBuilder timestamp(Temporal.Timestamp timestamp) {
       return (CopyOfBuilder) super.timestamp(timestamp);
     }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -4239,6 +5253,7 @@ public enum Status {
 exports[`AppSyncModelVisitor should generate model with key directive 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -4265,11 +5280,15 @@ public final class authorBook implements Model {
   public static final QueryField BOOK_ID = field(\\"authorBook\\", \\"book_id\\");
   public static final QueryField AUTHOR = field(\\"authorBook\\", \\"author\\");
   public static final QueryField BOOK = field(\\"authorBook\\", \\"book\\");
+  public static final QueryField CREATED_AT = field(\\"authorBook\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"authorBook\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String author_id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String book_id;
   private final @ModelField(targetType=\\"String\\") String author;
   private final @ModelField(targetType=\\"String\\") String book;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4290,12 +5309,22 @@ public final class authorBook implements Model {
       return book;
   }
   
-  private authorBook(String id, String author_id, String book_id, String author, String book) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private authorBook(String id, String author_id, String book_id, String author, String book, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.author_id = author_id;
     this.book_id = book_id;
     this.author = author;
     this.book = book;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4310,7 +5339,9 @@ public final class authorBook implements Model {
               ObjectsCompat.equals(getAuthorId(), authorBook.getAuthorId()) &&
               ObjectsCompat.equals(getBookId(), authorBook.getBookId()) &&
               ObjectsCompat.equals(getAuthor(), authorBook.getAuthor()) &&
-              ObjectsCompat.equals(getBook(), authorBook.getBook());
+              ObjectsCompat.equals(getBook(), authorBook.getBook()) &&
+              ObjectsCompat.equals(getCreatedAt(), authorBook.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), authorBook.getUpdatedAt());
       }
   }
   
@@ -4322,6 +5353,8 @@ public final class authorBook implements Model {
       .append(getBookId())
       .append(getAuthor())
       .append(getBook())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -4334,7 +5367,9 @@ public final class authorBook implements Model {
       .append(\\"author_id=\\" + String.valueOf(getAuthorId()) + \\", \\")
       .append(\\"book_id=\\" + String.valueOf(getBookId()) + \\", \\")
       .append(\\"author=\\" + String.valueOf(getAuthor()) + \\", \\")
-      .append(\\"book=\\" + String.valueOf(getBook()))
+      .append(\\"book=\\" + String.valueOf(getBook()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -4367,6 +5402,8 @@ public final class authorBook implements Model {
       null,
       null,
       null,
+      null,
+      null,
       null
     );
   }
@@ -4376,7 +5413,9 @@ public final class authorBook implements Model {
       author_id,
       book_id,
       author,
-      book);
+      book,
+      createdAt,
+      updatedAt);
   }
   public interface AuthorIdStep {
     BookIdStep authorId(String authorId);
@@ -4393,6 +5432,8 @@ public final class authorBook implements Model {
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep author(String author);
     BuildStep book(String book);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -4402,6 +5443,8 @@ public final class authorBook implements Model {
     private String book_id;
     private String author;
     private String book;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public authorBook build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -4411,7 +5454,9 @@ public final class authorBook implements Model {
           author_id,
           book_id,
           author,
-          book);
+          book,
+          createdAt,
+          updatedAt);
     }
     
     @Override
@@ -4440,6 +5485,18 @@ public final class authorBook implements Model {
         return this;
     }
     
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
+        return this;
+    }
+    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -4463,12 +5520,14 @@ public final class authorBook implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String authorId, String bookId, String author, String book) {
+    private CopyOfBuilder(String id, String authorId, String bookId, String author, String book, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
       super.authorId(authorId)
         .bookId(bookId)
         .author(author)
-        .book(book);
+        .book(book)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
@@ -4490,6 +5549,16 @@ public final class authorBook implements Model {
      public CopyOfBuilder book(String book) {
       return (CopyOfBuilder) super.book(book);
     }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
+    }
   }
   
 }
@@ -4499,6 +5568,7 @@ public final class authorBook implements Model {
 exports[`AppSyncModelVisitor should generate model with non-camel case field 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -4520,8 +5590,12 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class NonCamelCaseField implements Model {
   public static final QueryField ID = field(\\"NonCamelCaseField\\", \\"id\\");
   public static final QueryField EMPLOYEE_PID = field(\\"NonCamelCaseField\\", \\"employeePID\\");
+  public static final QueryField CREATED_AT = field(\\"NonCamelCaseField\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"NonCamelCaseField\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String employeePID;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4530,9 +5604,19 @@ public final class NonCamelCaseField implements Model {
       return employeePID;
   }
   
-  private NonCamelCaseField(String id, String employeePID) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private NonCamelCaseField(String id, String employeePID, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.employeePID = employeePID;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4544,7 +5628,9 @@ public final class NonCamelCaseField implements Model {
       } else {
       NonCamelCaseField nonCamelCaseField = (NonCamelCaseField) obj;
       return ObjectsCompat.equals(getId(), nonCamelCaseField.getId()) &&
-              ObjectsCompat.equals(getEmployeePid(), nonCamelCaseField.getEmployeePid());
+              ObjectsCompat.equals(getEmployeePid(), nonCamelCaseField.getEmployeePid()) &&
+              ObjectsCompat.equals(getCreatedAt(), nonCamelCaseField.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), nonCamelCaseField.getUpdatedAt());
       }
   }
   
@@ -4553,6 +5639,8 @@ public final class NonCamelCaseField implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getEmployeePid())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -4562,7 +5650,9 @@ public final class NonCamelCaseField implements Model {
     return new StringBuilder()
       .append(\\"NonCamelCaseField {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"employeePID=\\" + String.valueOf(getEmployeePid()))
+      .append(\\"employeePID=\\" + String.valueOf(getEmployeePid()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -4592,36 +5682,58 @@ public final class NonCamelCaseField implements Model {
     }
     return new NonCamelCaseField(
       id,
+      null,
+      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      employeePID);
+      employeePID,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     NonCamelCaseField build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep employeePid(String employeePid);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String employeePID;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public NonCamelCaseField build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new NonCamelCaseField(
           id,
-          employeePID);
+          employeePID,
+          createdAt,
+          updatedAt);
     }
     
     @Override
      public BuildStep employeePid(String employeePid) {
         this.employeePID = employeePid;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -4648,14 +5760,26 @@ public final class NonCamelCaseField implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String employeePid) {
+    private CopyOfBuilder(String id, String employeePid, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
-      super.employeePid(employeePid);
+      super.employeePid(employeePid)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
      public CopyOfBuilder employeePid(String employeePid) {
       return (CopyOfBuilder) super.employeePid(employeePid);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4666,6 +5790,7 @@ public final class NonCamelCaseField implements Model {
 exports[`AppSyncModelVisitor should generate model with snake case 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -4687,8 +5812,12 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class snake_case implements Model {
   public static final QueryField ID = field(\\"snake_case\\", \\"id\\");
   public static final QueryField NAME = field(\\"snake_case\\", \\"name\\");
+  public static final QueryField CREATED_AT = field(\\"snake_case\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"snake_case\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4697,9 +5826,19 @@ public final class snake_case implements Model {
       return name;
   }
   
-  private snake_case(String id, String name) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private snake_case(String id, String name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.name = name;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4711,7 +5850,9 @@ public final class snake_case implements Model {
       } else {
       snake_case snakeCase = (snake_case) obj;
       return ObjectsCompat.equals(getId(), snakeCase.getId()) &&
-              ObjectsCompat.equals(getName(), snakeCase.getName());
+              ObjectsCompat.equals(getName(), snakeCase.getName()) &&
+              ObjectsCompat.equals(getCreatedAt(), snakeCase.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), snakeCase.getUpdatedAt());
       }
   }
   
@@ -4720,6 +5861,8 @@ public final class snake_case implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getName())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -4729,7 +5872,9 @@ public final class snake_case implements Model {
     return new StringBuilder()
       .append(\\"snake_case {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"name=\\" + String.valueOf(getName()))
+      .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -4759,36 +5904,58 @@ public final class snake_case implements Model {
     }
     return new snake_case(
       id,
+      null,
+      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      name);
+      name,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     snake_case build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String name;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public snake_case build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new snake_case(
           id,
-          name);
+          name,
+          createdAt,
+          updatedAt);
     }
     
     @Override
      public BuildStep name(String name) {
         this.name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -4815,14 +5982,26 @@ public final class snake_case implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name) {
+    private CopyOfBuilder(String id, String name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
-      super.name(name);
+      super.name(name)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
      public CopyOfBuilder name(String name) {
       return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4833,6 +6012,7 @@ public final class snake_case implements Model {
 exports[`AppSyncModelVisitor should generate model with with snake_case field 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
+import com.amplifyframework.core.model.temporal.Temporal;
 
 import java.util.List;
 import java.util.UUID;
@@ -4854,8 +6034,12 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class SnakeCaseField implements Model {
   public static final QueryField ID = field(\\"SnakeCaseField\\", \\"id\\");
   public static final QueryField FIRST_NAME = field(\\"SnakeCaseField\\", \\"first_name\\");
+  public static final QueryField CREATED_AT = field(\\"SnakeCaseField\\", \\"createdAt\\");
+  public static final QueryField UPDATED_AT = field(\\"SnakeCaseField\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String first_name;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
   public String getId() {
       return id;
   }
@@ -4864,9 +6048,19 @@ public final class SnakeCaseField implements Model {
       return first_name;
   }
   
-  private SnakeCaseField(String id, String first_name) {
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private SnakeCaseField(String id, String first_name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
     this.id = id;
     this.first_name = first_name;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4878,7 +6072,9 @@ public final class SnakeCaseField implements Model {
       } else {
       SnakeCaseField snakeCaseField = (SnakeCaseField) obj;
       return ObjectsCompat.equals(getId(), snakeCaseField.getId()) &&
-              ObjectsCompat.equals(getFirstName(), snakeCaseField.getFirstName());
+              ObjectsCompat.equals(getFirstName(), snakeCaseField.getFirstName()) &&
+              ObjectsCompat.equals(getCreatedAt(), snakeCaseField.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), snakeCaseField.getUpdatedAt());
       }
   }
   
@@ -4887,6 +6083,8 @@ public final class SnakeCaseField implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getFirstName())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
       .toString()
       .hashCode();
   }
@@ -4896,7 +6094,9 @@ public final class SnakeCaseField implements Model {
     return new StringBuilder()
       .append(\\"SnakeCaseField {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"first_name=\\" + String.valueOf(getFirstName()))
+      .append(\\"first_name=\\" + String.valueOf(getFirstName()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -4926,36 +6126,58 @@ public final class SnakeCaseField implements Model {
     }
     return new SnakeCaseField(
       id,
+      null,
+      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      first_name);
+      first_name,
+      createdAt,
+      updatedAt);
   }
   public interface BuildStep {
     SnakeCaseField build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep firstName(String firstName);
+    BuildStep createdAt(Temporal.DateTime createdAt);
+    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String first_name;
+    private Temporal.DateTime createdAt;
+    private Temporal.DateTime updatedAt;
     @Override
      public SnakeCaseField build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new SnakeCaseField(
           id,
-          first_name);
+          first_name,
+          createdAt,
+          updatedAt);
     }
     
     @Override
      public BuildStep firstName(String firstName) {
         this.first_name = firstName;
+        return this;
+    }
+    
+    @Override
+     public BuildStep createdAt(Temporal.DateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+    
+    @Override
+     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
+        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -4982,14 +6204,26 @@ public final class SnakeCaseField implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String firstName) {
+    private CopyOfBuilder(String id, String firstName, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
       super.id(id);
-      super.firstName(firstName);
+      super.firstName(firstName)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt);
     }
     
     @Override
      public CopyOfBuilder firstName(String firstName) {
       return (CopyOfBuilder) super.firstName(firstName);
+    }
+    
+    @Override
+     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
+      return (CopyOfBuilder) super.createdAt(createdAt);
+    }
+    
+    @Override
+     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
+      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -31,13 +31,11 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
   public static final QueryField NAME = field(\\"customClaim\\", \\"name\\");
   public static final QueryField BAR = field(\\"customClaim\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"customClaim\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"customClaim\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -58,12 +56,10 @@ public final class customClaim implements Model {
       return updatedAt;
   }
   
-  private customClaim(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private customClaim(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -133,8 +129,6 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -142,17 +136,13 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -160,8 +150,6 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -169,9 +157,7 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -183,18 +169,6 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -221,12 +195,10 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -237,16 +209,6 @@ public final class customClaim implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -285,13 +247,11 @@ public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
   public static final QueryField NAME = field(\\"customClaim\\", \\"name\\");
   public static final QueryField BAR = field(\\"customClaim\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"customClaim\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"customClaim\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -312,12 +272,10 @@ public final class customClaim implements Model {
       return updatedAt;
   }
   
-  private customClaim(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private customClaim(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -387,8 +345,6 @@ public final class customClaim implements Model {
     return new customClaim(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -396,17 +352,13 @@ public final class customClaim implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     customClaim build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -414,8 +366,6 @@ public final class customClaim implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public customClaim build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -423,9 +373,7 @@ public final class customClaim implements Model {
         return new customClaim(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -437,18 +385,6 @@ public final class customClaim implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -475,12 +411,10 @@ public final class customClaim implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -491,16 +425,6 @@ public final class customClaim implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -541,16 +465,14 @@ public final class Employee implements Model {
   public static final QueryField NAME = field(\\"Employee\\", \\"name\\");
   public static final QueryField ADDRESS = field(\\"Employee\\", \\"address\\");
   public static final QueryField SSN = field(\\"Employee\\", \\"ssn\\");
-  public static final QueryField CREATED_AT = field(\\"Employee\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"Employee\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
   }) String ssn;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -575,13 +497,11 @@ public final class Employee implements Model {
       return updatedAt;
   }
   
-  private Employee(String id, String name, String address, String ssn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private Employee(String id, String name, String address, String ssn) {
     this.id = id;
     this.name = name;
     this.address = address;
     this.ssn = ssn;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -655,8 +575,6 @@ public final class Employee implements Model {
       id,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -665,9 +583,7 @@ public final class Employee implements Model {
     return new CopyOfBuilder(id,
       name,
       address,
-      ssn,
-      createdAt,
-      updatedAt);
+      ssn);
   }
   public interface NameStep {
     AddressStep name(String name);
@@ -683,8 +599,6 @@ public final class Employee implements Model {
     Employee build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep ssn(String ssn);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -693,8 +607,6 @@ public final class Employee implements Model {
     private String name;
     private String address;
     private String ssn;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public Employee build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -703,9 +615,7 @@ public final class Employee implements Model {
           id,
           name,
           address,
-          ssn,
-          createdAt,
-          updatedAt);
+          ssn);
     }
     
     @Override
@@ -725,18 +635,6 @@ public final class Employee implements Model {
     @Override
      public BuildStep ssn(String ssn) {
         this.ssn = ssn;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -763,13 +661,11 @@ public final class Employee implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String address, String ssn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String address, String ssn) {
       super.id(id);
       super.name(name)
         .address(address)
-        .ssn(ssn)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .ssn(ssn);
     }
     
     @Override
@@ -785,16 +681,6 @@ public final class Employee implements Model {
     @Override
      public CopyOfBuilder ssn(String ssn) {
       return (CopyOfBuilder) super.ssn(ssn);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -833,13 +719,11 @@ public final class dynamicGroups implements Model {
   public static final QueryField ID = field(\\"dynamicGroups\\", \\"id\\");
   public static final QueryField NAME = field(\\"dynamicGroups\\", \\"name\\");
   public static final QueryField BAR = field(\\"dynamicGroups\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"dynamicGroups\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"dynamicGroups\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -860,12 +744,10 @@ public final class dynamicGroups implements Model {
       return updatedAt;
   }
   
-  private dynamicGroups(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private dynamicGroups(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -935,8 +817,6 @@ public final class dynamicGroups implements Model {
     return new dynamicGroups(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -944,17 +824,13 @@ public final class dynamicGroups implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     dynamicGroups build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -962,8 +838,6 @@ public final class dynamicGroups implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public dynamicGroups build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -971,9 +845,7 @@ public final class dynamicGroups implements Model {
         return new dynamicGroups(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -985,18 +857,6 @@ public final class dynamicGroups implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1023,12 +883,10 @@ public final class dynamicGroups implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -1039,16 +897,6 @@ public final class dynamicGroups implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1087,13 +935,11 @@ public final class simpleOwnerAuth implements Model {
   public static final QueryField ID = field(\\"simpleOwnerAuth\\", \\"id\\");
   public static final QueryField NAME = field(\\"simpleOwnerAuth\\", \\"name\\");
   public static final QueryField BAR = field(\\"simpleOwnerAuth\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"simpleOwnerAuth\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"simpleOwnerAuth\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -1114,12 +960,10 @@ public final class simpleOwnerAuth implements Model {
       return updatedAt;
   }
   
-  private simpleOwnerAuth(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private simpleOwnerAuth(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1189,8 +1033,6 @@ public final class simpleOwnerAuth implements Model {
     return new simpleOwnerAuth(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -1198,17 +1040,13 @@ public final class simpleOwnerAuth implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     simpleOwnerAuth build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1216,8 +1054,6 @@ public final class simpleOwnerAuth implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public simpleOwnerAuth build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1225,9 +1061,7 @@ public final class simpleOwnerAuth implements Model {
         return new simpleOwnerAuth(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -1239,18 +1073,6 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1277,12 +1099,10 @@ public final class simpleOwnerAuth implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -1293,16 +1113,6 @@ public final class simpleOwnerAuth implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1341,13 +1151,11 @@ public final class allowRead implements Model {
   public static final QueryField ID = field(\\"allowRead\\", \\"id\\");
   public static final QueryField NAME = field(\\"allowRead\\", \\"name\\");
   public static final QueryField BAR = field(\\"allowRead\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"allowRead\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"allowRead\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -1368,12 +1176,10 @@ public final class allowRead implements Model {
       return updatedAt;
   }
   
-  private allowRead(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private allowRead(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1443,8 +1249,6 @@ public final class allowRead implements Model {
     return new allowRead(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -1452,17 +1256,13 @@ public final class allowRead implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     allowRead build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1470,8 +1270,6 @@ public final class allowRead implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public allowRead build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1479,9 +1277,7 @@ public final class allowRead implements Model {
         return new allowRead(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -1493,18 +1289,6 @@ public final class allowRead implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1531,12 +1315,10 @@ public final class allowRead implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -1547,16 +1329,6 @@ public final class allowRead implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1595,13 +1367,11 @@ public final class privateType implements Model {
   public static final QueryField ID = field(\\"privateType\\", \\"id\\");
   public static final QueryField NAME = field(\\"privateType\\", \\"name\\");
   public static final QueryField BAR = field(\\"privateType\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"privateType\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"privateType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -1622,12 +1392,10 @@ public final class privateType implements Model {
       return updatedAt;
   }
   
-  private privateType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private privateType(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1697,8 +1465,6 @@ public final class privateType implements Model {
     return new privateType(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -1706,17 +1472,13 @@ public final class privateType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     privateType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1724,8 +1486,6 @@ public final class privateType implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public privateType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1733,9 +1493,7 @@ public final class privateType implements Model {
         return new privateType(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -1747,18 +1505,6 @@ public final class privateType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -1785,12 +1531,10 @@ public final class privateType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -1801,16 +1545,6 @@ public final class privateType implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -1849,15 +1583,13 @@ public final class privateType implements Model {
   public static final QueryField ID = field(\\"privateType\\", \\"id\\");
   public static final QueryField NAME = field(\\"privateType\\", \\"name\\");
   public static final QueryField BAR = field(\\"privateType\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"privateType\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"privateType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\", authRules = {
     @AuthRule(allow = AuthStrategy.PRIVATE, operations = { ModelOperation.CREATE, ModelOperation.UPDATE })
   }) String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -1878,12 +1610,10 @@ public final class privateType implements Model {
       return updatedAt;
   }
   
-  private privateType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private privateType(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -1953,8 +1683,6 @@ public final class privateType implements Model {
     return new privateType(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -1962,17 +1690,13 @@ public final class privateType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     privateType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -1980,8 +1704,6 @@ public final class privateType implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public privateType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -1989,9 +1711,7 @@ public final class privateType implements Model {
         return new privateType(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -2003,18 +1723,6 @@ public final class privateType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2041,12 +1749,10 @@ public final class privateType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -2057,16 +1763,6 @@ public final class privateType implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2105,13 +1801,11 @@ public final class publicType implements Model {
   public static final QueryField ID = field(\\"publicType\\", \\"id\\");
   public static final QueryField NAME = field(\\"publicType\\", \\"name\\");
   public static final QueryField BAR = field(\\"publicType\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"publicType\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"publicType\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -2132,12 +1826,10 @@ public final class publicType implements Model {
       return updatedAt;
   }
   
-  private publicType(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private publicType(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2207,8 +1899,6 @@ public final class publicType implements Model {
     return new publicType(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -2216,17 +1906,13 @@ public final class publicType implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     publicType build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2234,8 +1920,6 @@ public final class publicType implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public publicType build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2243,9 +1927,7 @@ public final class publicType implements Model {
         return new publicType(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -2257,18 +1939,6 @@ public final class publicType implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2295,12 +1965,10 @@ public final class publicType implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -2311,16 +1979,6 @@ public final class publicType implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2359,13 +2017,11 @@ public final class staticGroups implements Model {
   public static final QueryField ID = field(\\"staticGroups\\", \\"id\\");
   public static final QueryField NAME = field(\\"staticGroups\\", \\"name\\");
   public static final QueryField BAR = field(\\"staticGroups\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"staticGroups\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"staticGroups\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -2386,12 +2042,10 @@ public final class staticGroups implements Model {
       return updatedAt;
   }
   
-  private staticGroups(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private staticGroups(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2461,8 +2115,6 @@ public final class staticGroups implements Model {
     return new staticGroups(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -2470,17 +2122,13 @@ public final class staticGroups implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     staticGroups build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2488,8 +2136,6 @@ public final class staticGroups implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public staticGroups build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2497,9 +2143,7 @@ public final class staticGroups implements Model {
         return new staticGroups(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -2511,18 +2155,6 @@ public final class staticGroups implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -2549,12 +2181,10 @@ public final class staticGroups implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -2565,16 +2195,6 @@ public final class staticGroups implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -2610,15 +2230,13 @@ public final class Landmark implements Model {
   public static final QueryField RATING = field(\\"Landmark\\", \\"rating\\");
   public static final QueryField LOCATION = field(\\"Landmark\\", \\"location\\");
   public static final QueryField PARKING = field(\\"Landmark\\", \\"parking\\");
-  public static final QueryField CREATED_AT = field(\\"Landmark\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"Landmark\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer rating;
   private final @ModelField(targetType=\\"Location\\", isRequired = true) Location location;
   private final @ModelField(targetType=\\"Location\\") Location parking;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -2647,14 +2265,12 @@ public final class Landmark implements Model {
       return updatedAt;
   }
   
-  private Landmark(String id, String name, Integer rating, Location location, Location parking, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private Landmark(String id, String name, Integer rating, Location location, Location parking) {
     this.id = id;
     this.name = name;
     this.rating = rating;
     this.location = location;
     this.parking = parking;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -2732,8 +2348,6 @@ public final class Landmark implements Model {
       null,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -2743,9 +2357,7 @@ public final class Landmark implements Model {
       name,
       rating,
       location,
-      parking,
-      createdAt,
-      updatedAt);
+      parking);
   }
   public interface NameStep {
     RatingStep name(String name);
@@ -2766,8 +2378,6 @@ public final class Landmark implements Model {
     Landmark build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep parking(Location parking);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -2777,8 +2387,6 @@ public final class Landmark implements Model {
     private Integer rating;
     private Location location;
     private Location parking;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public Landmark build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -2788,9 +2396,7 @@ public final class Landmark implements Model {
           name,
           rating,
           location,
-          parking,
-          createdAt,
-          updatedAt);
+          parking);
     }
     
     @Override
@@ -2820,18 +2426,6 @@ public final class Landmark implements Model {
         return this;
     }
     
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -2855,14 +2449,12 @@ public final class Landmark implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, Integer rating, Location location, Location parking, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, Integer rating, Location location, Location parking) {
       super.id(id);
       super.name(name)
         .rating(rating)
         .location(location)
-        .parking(parking)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .parking(parking);
     }
     
     @Override
@@ -2883,16 +2475,6 @@ public final class Landmark implements Model {
     @Override
      public CopyOfBuilder parking(Location parking) {
       return (CopyOfBuilder) super.parking(parking);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -3047,14 +2629,12 @@ public final class task implements Model {
   public static final QueryField TODO = field(\\"task\\", \\"taskTodoId\\");
   public static final QueryField TIME = field(\\"task\\", \\"time\\");
   public static final QueryField CREATED_ON = field(\\"task\\", \\"createdOn\\");
-  public static final QueryField CREATED_AT = field(\\"task\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"task\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -3079,13 +2659,11 @@ public final class task implements Model {
       return updatedAt;
   }
   
-  private task(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private task(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
     this.id = id;
     this.todo = todo;
     this.time = time;
     this.createdOn = createdOn;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3159,8 +2737,6 @@ public final class task implements Model {
       id,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -3169,9 +2745,7 @@ public final class task implements Model {
     return new CopyOfBuilder(id,
       todo,
       time,
-      createdOn,
-      createdAt,
-      updatedAt);
+      createdOn);
   }
   public interface BuildStep {
     task build();
@@ -3179,8 +2753,6 @@ public final class task implements Model {
     BuildStep todo(Todo todo);
     BuildStep time(Temporal.Time time);
     BuildStep createdOn(Temporal.Date createdOn);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3189,8 +2761,6 @@ public final class task implements Model {
     private Todo todo;
     private Temporal.Time time;
     private Temporal.Date createdOn;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public task build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3199,9 +2769,7 @@ public final class task implements Model {
           id,
           todo,
           time,
-          createdOn,
-          createdAt,
-          updatedAt);
+          createdOn);
     }
     
     @Override
@@ -3219,18 +2787,6 @@ public final class task implements Model {
     @Override
      public BuildStep createdOn(Temporal.Date createdOn) {
         this.createdOn = createdOn;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -3257,13 +2813,11 @@ public final class task implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
       super.id(id);
       super.todo(todo)
         .time(time)
-        .createdOn(createdOn)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .createdOn(createdOn);
     }
     
     @Override
@@ -3279,16 +2833,6 @@ public final class task implements Model {
     @Override
      public CopyOfBuilder createdOn(Temporal.Date createdOn) {
       return (CopyOfBuilder) super.createdOn(createdOn);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -3321,12 +2865,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @ModelConfig(pluralName = \\"Todos\\")
 public final class Todo implements Model {
   public static final QueryField ID = field(\\"Todo\\", \\"id\\");
-  public static final QueryField CREATED_AT = field(\\"Todo\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"Todo\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -3343,10 +2885,8 @@ public final class Todo implements Model {
       return updatedAt;
   }
   
-  private Todo(String id, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private Todo(String id) {
     this.id = id;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3408,49 +2948,27 @@ public final class Todo implements Model {
       );
     }
     return new Todo(
-      id,
-      null,
-      null
+      id
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      createdAt,
-      updatedAt);
+    return new CopyOfBuilder(id);
   }
   public interface BuildStep {
     Todo build();
     BuildStep id(String id) throws IllegalArgumentException;
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public Todo build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new Todo(
-          id,
-          createdAt,
-          updatedAt);
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
+          id);
     }
     
     /** 
@@ -3476,20 +2994,9 @@ public final class Todo implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id) {
       super.id(id);
-      super.createdAt(createdAt)
-        .updatedAt(updatedAt);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
+      
     }
   }
   
@@ -3523,13 +3030,11 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -3550,12 +3055,10 @@ public final class SimpleModel implements Model {
       return updatedAt;
   }
   
-  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private SimpleModel(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3625,8 +3128,6 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -3634,17 +3135,13 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3652,8 +3149,6 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3661,9 +3156,7 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -3675,18 +3168,6 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -3713,12 +3194,10 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -3729,16 +3208,6 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -3772,13 +3241,11 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -3799,12 +3266,10 @@ public final class SimpleModel implements Model {
       return updatedAt;
   }
   
-  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private SimpleModel(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -3874,8 +3339,6 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -3883,17 +3346,13 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -3901,8 +3360,6 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -3910,9 +3367,7 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -3924,18 +3379,6 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -3962,12 +3405,10 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -3978,16 +3419,6 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4021,13 +3452,11 @@ public final class SimpleModel implements Model {
   public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
   public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
   public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
-  public static final QueryField CREATED_AT = field(\\"SimpleModel\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"SimpleModel\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -4048,12 +3477,10 @@ public final class SimpleModel implements Model {
       return updatedAt;
   }
   
-  private SimpleModel(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private SimpleModel(String id, String name, String bar) {
     this.id = id;
     this.name = name;
     this.bar = bar;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4123,8 +3550,6 @@ public final class SimpleModel implements Model {
     return new SimpleModel(
       id,
       null,
-      null,
-      null,
       null
     );
   }
@@ -4132,17 +3557,13 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar,
-      createdAt,
-      updatedAt);
+      bar);
   }
   public interface BuildStep {
     SimpleModel build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
     BuildStep bar(String bar);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -4150,8 +3571,6 @@ public final class SimpleModel implements Model {
     private String id;
     private String name;
     private String bar;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public SimpleModel build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -4159,9 +3578,7 @@ public final class SimpleModel implements Model {
         return new SimpleModel(
           id,
           name,
-          bar,
-          createdAt,
-          updatedAt);
+          bar);
     }
     
     @Override
@@ -4173,18 +3590,6 @@ public final class SimpleModel implements Model {
     @Override
      public BuildStep bar(String bar) {
         this.bar = bar;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -4211,12 +3616,10 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name, String bar) {
       super.id(id);
       super.name(name)
-        .bar(bar)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .bar(bar);
     }
     
     @Override
@@ -4227,16 +3630,6 @@ public final class SimpleModel implements Model {
     @Override
      public CopyOfBuilder bar(String bar) {
       return (CopyOfBuilder) super.bar(bar);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4274,16 +3667,14 @@ public final class task implements Model {
   public static final QueryField TODO = field(\\"task\\", \\"taskTodoId\\");
   public static final QueryField TIME = field(\\"task\\", \\"time\\");
   public static final QueryField CREATED_ON = field(\\"task\\", \\"createdOn\\");
-  public static final QueryField CREATED_AT = field(\\"task\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"task\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
   private final @ModelField(targetType=\\"Boolean\\", isRequired = true) Boolean done;
   private final @ModelField(targetType=\\"Todo\\") @BelongsTo(targetName = \\"taskTodoId\\", type = Todo.class) Todo todo;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date createdOn;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -4316,15 +3707,13 @@ public final class task implements Model {
       return updatedAt;
   }
   
-  private task(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private task(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
     this.id = id;
     this.title = title;
     this.done = done;
     this.todo = todo;
     this.time = time;
     this.createdOn = createdOn;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4406,8 +3795,6 @@ public final class task implements Model {
       null,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -4418,9 +3805,7 @@ public final class task implements Model {
       done,
       todo,
       time,
-      createdOn,
-      createdAt,
-      updatedAt);
+      createdOn);
   }
   public interface TitleStep {
     DoneStep title(String title);
@@ -4438,8 +3823,6 @@ public final class task implements Model {
     BuildStep todo(Todo todo);
     BuildStep time(Temporal.Time time);
     BuildStep createdOn(Temporal.Date createdOn);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -4450,8 +3833,6 @@ public final class task implements Model {
     private Todo todo;
     private Temporal.Time time;
     private Temporal.Date createdOn;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public task build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -4462,9 +3843,7 @@ public final class task implements Model {
           done,
           todo,
           time,
-          createdOn,
-          createdAt,
-          updatedAt);
+          createdOn);
     }
     
     @Override
@@ -4499,18 +3878,6 @@ public final class task implements Model {
         return this;
     }
     
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -4534,15 +3901,13 @@ public final class task implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String title, Boolean done, Todo todo, Temporal.Time time, Temporal.Date createdOn) {
       super.id(id);
       super.title(title)
         .done(done)
         .todo(todo)
         .time(time)
-        .createdOn(createdOn)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .createdOn(createdOn);
     }
     
     @Override
@@ -4568,16 +3933,6 @@ public final class task implements Model {
     @Override
      public CopyOfBuilder createdOn(Temporal.Date createdOn) {
       return (CopyOfBuilder) super.createdOn(createdOn);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4616,8 +3971,6 @@ public final class Todo implements Model {
   public static final QueryField DUE_DATE = field(\\"Todo\\", \\"due_date\\");
   public static final QueryField VERSION = field(\\"Todo\\", \\"version\\");
   public static final QueryField VALUE = field(\\"Todo\\", \\"value\\");
-  public static final QueryField CREATED_AT = field(\\"Todo\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"Todo\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
   private final @ModelField(targetType=\\"Boolean\\", isRequired = true) Boolean done;
@@ -4626,8 +3979,8 @@ public final class Todo implements Model {
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer version;
   private final @ModelField(targetType=\\"Float\\") Double value;
   private final @ModelField(targetType=\\"task\\") @HasMany(associatedWith = \\"todo\\", type = task.class) List<task> tasks = null;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -4668,7 +4021,7 @@ public final class Todo implements Model {
       return updatedAt;
   }
   
-  private Todo(String id, String title, Boolean done, String description, String due_date, Integer version, Double value, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private Todo(String id, String title, Boolean done, String description, String due_date, Integer version, Double value) {
     this.id = id;
     this.title = title;
     this.done = done;
@@ -4676,8 +4029,6 @@ public final class Todo implements Model {
     this.due_date = due_date;
     this.version = version;
     this.value = value;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -4763,8 +4114,6 @@ public final class Todo implements Model {
       null,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -4776,9 +4125,7 @@ public final class Todo implements Model {
       description,
       due_date,
       version,
-      value,
-      createdAt,
-      updatedAt);
+      value);
   }
   public interface TitleStep {
     DoneStep title(String title);
@@ -4801,8 +4148,6 @@ public final class Todo implements Model {
     BuildStep description(String description);
     BuildStep dueDate(String dueDate);
     BuildStep value(Double value);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -4814,8 +4159,6 @@ public final class Todo implements Model {
     private String description;
     private String due_date;
     private Double value;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public Todo build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -4827,9 +4170,7 @@ public final class Todo implements Model {
           description,
           due_date,
           version,
-          value,
-          createdAt,
-          updatedAt);
+          value);
     }
     
     @Override
@@ -4871,18 +4212,6 @@ public final class Todo implements Model {
         return this;
     }
     
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -4906,16 +4235,14 @@ public final class Todo implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String title, Boolean done, String description, String dueDate, Integer version, Double value, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String title, Boolean done, String description, String dueDate, Integer version, Double value) {
       super.id(id);
       super.title(title)
         .done(done)
         .version(version)
         .description(description)
         .dueDate(dueDate)
-        .value(value)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .value(value);
     }
     
     @Override
@@ -4946,16 +4273,6 @@ public final class Todo implements Model {
     @Override
      public CopyOfBuilder value(Double value) {
       return (CopyOfBuilder) super.value(value);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -4991,13 +4308,12 @@ public final class TypeWithAWSDateScalars implements Model {
   public static final QueryField CREATED_AT = field(\\"TypeWithAWSDateScalars\\", \\"createdAt\\");
   public static final QueryField TIME = field(\\"TypeWithAWSDateScalars\\", \\"time\\");
   public static final QueryField TIMESTAMP = field(\\"TypeWithAWSDateScalars\\", \\"timestamp\\");
-  public static final QueryField UPDATED_AT = field(\\"TypeWithAWSDateScalars\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date date;
   private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
   private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time time;
   private final @ModelField(targetType=\\"AWSTimestamp\\") Temporal.Timestamp timestamp;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -5022,13 +4338,12 @@ public final class TypeWithAWSDateScalars implements Model {
       return updatedAt;
   }
   
-  private TypeWithAWSDateScalars(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp, Temporal.DateTime updatedAt) {
+  private TypeWithAWSDateScalars(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp) {
     this.id = id;
     this.date = date;
     this.createdAt = createdAt;
     this.time = time;
     this.timestamp = timestamp;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -5103,7 +4418,6 @@ public final class TypeWithAWSDateScalars implements Model {
       null,
       null,
       null,
-      null,
       null
     );
   }
@@ -5113,8 +4427,7 @@ public final class TypeWithAWSDateScalars implements Model {
       date,
       createdAt,
       time,
-      timestamp,
-      updatedAt);
+      timestamp);
   }
   public interface BuildStep {
     TypeWithAWSDateScalars build();
@@ -5123,7 +4436,6 @@ public final class TypeWithAWSDateScalars implements Model {
     BuildStep createdAt(Temporal.DateTime createdAt);
     BuildStep time(Temporal.Time time);
     BuildStep timestamp(Temporal.Timestamp timestamp);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -5133,7 +4445,6 @@ public final class TypeWithAWSDateScalars implements Model {
     private Temporal.DateTime createdAt;
     private Temporal.Time time;
     private Temporal.Timestamp timestamp;
-    private Temporal.DateTime updatedAt;
     @Override
      public TypeWithAWSDateScalars build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -5143,8 +4454,7 @@ public final class TypeWithAWSDateScalars implements Model {
           date,
           createdAt,
           time,
-          timestamp,
-          updatedAt);
+          timestamp);
     }
     
     @Override
@@ -5171,12 +4481,6 @@ public final class TypeWithAWSDateScalars implements Model {
         return this;
     }
     
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -5200,13 +4504,12 @@ public final class TypeWithAWSDateScalars implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, Temporal.Date date, Temporal.DateTime createdAt, Temporal.Time time, Temporal.Timestamp timestamp) {
       super.id(id);
       super.date(date)
         .createdAt(createdAt)
         .time(time)
-        .timestamp(timestamp)
-        .updatedAt(updatedAt);
+        .timestamp(timestamp);
     }
     
     @Override
@@ -5227,11 +4530,6 @@ public final class TypeWithAWSDateScalars implements Model {
     @Override
      public CopyOfBuilder timestamp(Temporal.Timestamp timestamp) {
       return (CopyOfBuilder) super.timestamp(timestamp);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -5280,15 +4578,13 @@ public final class authorBook implements Model {
   public static final QueryField BOOK_ID = field(\\"authorBook\\", \\"book_id\\");
   public static final QueryField AUTHOR = field(\\"authorBook\\", \\"author\\");
   public static final QueryField BOOK = field(\\"authorBook\\", \\"book\\");
-  public static final QueryField CREATED_AT = field(\\"authorBook\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"authorBook\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String author_id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String book_id;
   private final @ModelField(targetType=\\"String\\") String author;
   private final @ModelField(targetType=\\"String\\") String book;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -5317,14 +4613,12 @@ public final class authorBook implements Model {
       return updatedAt;
   }
   
-  private authorBook(String id, String author_id, String book_id, String author, String book, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private authorBook(String id, String author_id, String book_id, String author, String book) {
     this.id = id;
     this.author_id = author_id;
     this.book_id = book_id;
     this.author = author;
     this.book = book;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -5402,8 +4696,6 @@ public final class authorBook implements Model {
       null,
       null,
       null,
-      null,
-      null,
       null
     );
   }
@@ -5413,9 +4705,7 @@ public final class authorBook implements Model {
       author_id,
       book_id,
       author,
-      book,
-      createdAt,
-      updatedAt);
+      book);
   }
   public interface AuthorIdStep {
     BookIdStep authorId(String authorId);
@@ -5432,8 +4722,6 @@ public final class authorBook implements Model {
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep author(String author);
     BuildStep book(String book);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
@@ -5443,8 +4731,6 @@ public final class authorBook implements Model {
     private String book_id;
     private String author;
     private String book;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public authorBook build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
@@ -5454,9 +4740,7 @@ public final class authorBook implements Model {
           author_id,
           book_id,
           author,
-          book,
-          createdAt,
-          updatedAt);
+          book);
     }
     
     @Override
@@ -5485,18 +4769,6 @@ public final class authorBook implements Model {
         return this;
     }
     
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
-        return this;
-    }
-    
     /** 
      * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
      * This should only be set when referring to an already existing object.
@@ -5520,14 +4792,12 @@ public final class authorBook implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String authorId, String bookId, String author, String book, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String authorId, String bookId, String author, String book) {
       super.id(id);
       super.authorId(authorId)
         .bookId(bookId)
         .author(author)
-        .book(book)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+        .book(book);
     }
     
     @Override
@@ -5548,16 +4818,6 @@ public final class authorBook implements Model {
     @Override
      public CopyOfBuilder book(String book) {
       return (CopyOfBuilder) super.book(book);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -5590,12 +4850,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class NonCamelCaseField implements Model {
   public static final QueryField ID = field(\\"NonCamelCaseField\\", \\"id\\");
   public static final QueryField EMPLOYEE_PID = field(\\"NonCamelCaseField\\", \\"employeePID\\");
-  public static final QueryField CREATED_AT = field(\\"NonCamelCaseField\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"NonCamelCaseField\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String employeePID;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -5612,11 +4870,9 @@ public final class NonCamelCaseField implements Model {
       return updatedAt;
   }
   
-  private NonCamelCaseField(String id, String employeePID, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private NonCamelCaseField(String id, String employeePID) {
     this.id = id;
     this.employeePID = employeePID;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -5682,58 +4938,36 @@ public final class NonCamelCaseField implements Model {
     }
     return new NonCamelCaseField(
       id,
-      null,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      employeePID,
-      createdAt,
-      updatedAt);
+      employeePID);
   }
   public interface BuildStep {
     NonCamelCaseField build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep employeePid(String employeePid);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String employeePID;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public NonCamelCaseField build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new NonCamelCaseField(
           id,
-          employeePID,
-          createdAt,
-          updatedAt);
+          employeePID);
     }
     
     @Override
      public BuildStep employeePid(String employeePid) {
         this.employeePID = employeePid;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -5760,26 +4994,14 @@ public final class NonCamelCaseField implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String employeePid, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String employeePid) {
       super.id(id);
-      super.employeePid(employeePid)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+      super.employeePid(employeePid);
     }
     
     @Override
      public CopyOfBuilder employeePid(String employeePid) {
       return (CopyOfBuilder) super.employeePid(employeePid);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -5812,12 +5034,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class snake_case implements Model {
   public static final QueryField ID = field(\\"snake_case\\", \\"id\\");
   public static final QueryField NAME = field(\\"snake_case\\", \\"name\\");
-  public static final QueryField CREATED_AT = field(\\"snake_case\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"snake_case\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -5834,11 +5054,9 @@ public final class snake_case implements Model {
       return updatedAt;
   }
   
-  private snake_case(String id, String name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private snake_case(String id, String name) {
     this.id = id;
     this.name = name;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -5904,58 +5122,36 @@ public final class snake_case implements Model {
     }
     return new snake_case(
       id,
-      null,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      name,
-      createdAt,
-      updatedAt);
+      name);
   }
   public interface BuildStep {
     snake_case build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep name(String name);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String name;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public snake_case build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new snake_case(
           id,
-          name,
-          createdAt,
-          updatedAt);
+          name);
     }
     
     @Override
      public BuildStep name(String name) {
         this.name = name;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -5982,26 +5178,14 @@ public final class snake_case implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String name) {
       super.id(id);
-      super.name(name)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+      super.name(name);
     }
     
     @Override
      public CopyOfBuilder name(String name) {
       return (CopyOfBuilder) super.name(name);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   
@@ -6034,12 +5218,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class SnakeCaseField implements Model {
   public static final QueryField ID = field(\\"SnakeCaseField\\", \\"id\\");
   public static final QueryField FIRST_NAME = field(\\"SnakeCaseField\\", \\"first_name\\");
-  public static final QueryField CREATED_AT = field(\\"SnakeCaseField\\", \\"createdAt\\");
-  public static final QueryField UPDATED_AT = field(\\"SnakeCaseField\\", \\"updatedAt\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String first_name;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime createdAt;
-  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime updatedAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt = null;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt = null;
   public String getId() {
       return id;
   }
@@ -6056,11 +5238,9 @@ public final class SnakeCaseField implements Model {
       return updatedAt;
   }
   
-  private SnakeCaseField(String id, String first_name, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+  private SnakeCaseField(String id, String first_name) {
     this.id = id;
     this.first_name = first_name;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
   
   @Override
@@ -6126,58 +5306,36 @@ public final class SnakeCaseField implements Model {
     }
     return new SnakeCaseField(
       id,
-      null,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      first_name,
-      createdAt,
-      updatedAt);
+      first_name);
   }
   public interface BuildStep {
     SnakeCaseField build();
     BuildStep id(String id) throws IllegalArgumentException;
     BuildStep firstName(String firstName);
-    BuildStep createdAt(Temporal.DateTime createdAt);
-    BuildStep updatedAt(Temporal.DateTime updatedAt);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
     private String first_name;
-    private Temporal.DateTime createdAt;
-    private Temporal.DateTime updatedAt;
     @Override
      public SnakeCaseField build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new SnakeCaseField(
           id,
-          first_name,
-          createdAt,
-          updatedAt);
+          first_name);
     }
     
     @Override
      public BuildStep firstName(String firstName) {
         this.first_name = firstName;
-        return this;
-    }
-    
-    @Override
-     public BuildStep createdAt(Temporal.DateTime createdAt) {
-        this.createdAt = createdAt;
-        return this;
-    }
-    
-    @Override
-     public BuildStep updatedAt(Temporal.DateTime updatedAt) {
-        this.updatedAt = updatedAt;
         return this;
     }
     
@@ -6204,26 +5362,14 @@ public final class SnakeCaseField implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String firstName, Temporal.DateTime createdAt, Temporal.DateTime updatedAt) {
+    private CopyOfBuilder(String id, String firstName) {
       super.id(id);
-      super.firstName(firstName)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt);
+      super.firstName(firstName);
     }
     
     @Override
      public CopyOfBuilder firstName(String firstName) {
       return (CopyOfBuilder) super.firstName(firstName);
-    }
-    
-    @Override
-     public CopyOfBuilder createdAt(Temporal.DateTime createdAt) {
-      return (CopyOfBuilder) super.createdAt(createdAt);
-    }
-    
-    @Override
-     public CopyOfBuilder updatedAt(Temporal.DateTime updatedAt) {
-      return (CopyOfBuilder) super.updatedAt(updatedAt);
     }
   }
   

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -14,7 +14,7 @@ const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGene
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncModelJavaVisitor(
     builtSchema,
-    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP },
+    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP, isTimestampFieldsAdded: true },
     { selectedType },
   );
   visit(ast, { leave: visitor });
@@ -276,15 +276,11 @@ describe('AppSyncModelVisitor', () => {
 
     it('should generate class with default field auth', () => {
       const schema = /* GraphQL */ `
-        type Employee @model
-        @auth(rules: [
-            { allow: owner },
-            { allow: groups, groups: ["Admins"] }
-        ]) {
+        type Employee @model @auth(rules: [{ allow: owner }, { allow: groups, groups: ["Admins"] }]) {
           id: ID!
           name: String!
           address: String!
-          ssn: String @auth(rules: [{allow: owner}])
+          ssn: String @auth(rules: [{ allow: owner }])
         }
       `;
       const visitor = getVisitor(schema, 'Employee');

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -114,12 +114,16 @@ describe('Javascript visitor', () => {
           readonly name?: string;
           readonly bar?: string;
           readonly foo?: Bar[];
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }
 
         export declare class Bar {
           readonly id: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           readonly simpleModelFooId?: string;
           constructor(init: ModelInit<Bar>);
           static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
@@ -233,6 +237,8 @@ describe('Javascript visitor with default owner auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -302,6 +308,8 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -373,6 +381,8 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -428,6 +438,8 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly name: string;
           readonly address: string;
           readonly ssn?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<Employee>);
           static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
         }"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -13,7 +13,7 @@ const getVisitor = (schema: string, isDeclaration: boolean = false): AppSyncMode
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncModelJavascriptVisitor(
     builtSchema,
-    { directives, target: 'javascript', scalars: TYPESCRIPT_SCALAR_MAP, isDeclaration },
+    { directives, target: 'javascript', scalars: TYPESCRIPT_SCALAR_MAP, isDeclaration, isTimestampFieldsAdded: true },
     {},
   );
   visit(ast, { leave: visitor });
@@ -114,12 +114,16 @@ describe('Javascript visitor', () => {
           readonly name?: string;
           readonly bar?: string;
           readonly foo?: Bar[];
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }
 
         export declare class Bar {
           readonly id: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           readonly simpleModelFooId?: string;
           constructor(init: ModelInit<Bar>);
           static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
@@ -233,6 +237,8 @@ describe('Javascript visitor with default owner auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -302,6 +308,8 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -373,6 +381,8 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -428,6 +438,8 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly name: string;
           readonly address: string;
           readonly ssn?: string;
+          readonly createdAt?: string;
+          readonly updatedAt?: string;
           constructor(init: ModelInit<Employee>);
           static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
         }"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -114,16 +114,12 @@ describe('Javascript visitor', () => {
           readonly name?: string;
           readonly bar?: string;
           readonly foo?: Bar[];
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }
 
         export declare class Bar {
           readonly id: string;
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           readonly simpleModelFooId?: string;
           constructor(init: ModelInit<Bar>);
           static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
@@ -237,8 +233,6 @@ describe('Javascript visitor with default owner auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -308,8 +302,6 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -381,8 +373,6 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           constructor(init: ModelInit<SimpleModel>);
           static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
         }"
@@ -438,8 +428,6 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly name: string;
           readonly address: string;
           readonly ssn?: string;
-          readonly createdAt?: string;
-          readonly updatedAt?: string;
           constructor(init: ModelInit<Employee>);
           static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
         }"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -296,13 +296,6 @@ describe('Metadata visitor', () => {
                     "name": "bar",
                     "type": "String",
                   },
-                  "createdAt": Object {
-                    "attributes": Array [],
-                    "isArray": false,
-                    "isRequired": false,
-                    "name": "createdAt",
-                    "type": "AWSDateTime",
-                  },
                   "id": Object {
                     "attributes": Array [],
                     "isArray": false,
@@ -316,13 +309,6 @@ describe('Metadata visitor', () => {
                     "isRequired": false,
                     "name": "name",
                     "type": "String",
-                  },
-                  "updatedAt": Object {
-                    "attributes": Array [],
-                    "isArray": false,
-                    "isRequired": false,
-                    "name": "updatedAt",
-                    "type": "AWSDateTime",
                   },
                 },
                 "name": "SimpleModel",
@@ -352,7 +338,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "5eb36909e822fd40c657cc69b22c919a",
+            "version": "bc1b6d35e990f16a49dbb447a8876025",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -393,20 +379,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -450,7 +422,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -484,20 +456,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -541,7 +499,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -610,20 +568,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -698,7 +642,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -732,20 +676,6 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -820,7 +750,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
+            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
         };"
       `);
     });
@@ -877,20 +807,6 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -938,7 +854,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
+            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
         };"
       `);
     });
@@ -980,20 +896,6 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        },
-                        \\"createdAt\\": {
-                            \\"name\\": \\"createdAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
-                        },
-                        \\"updatedAt\\": {
-                            \\"name\\": \\"updatedAt\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"AWSDateTime\\",
-                            \\"isRequired\\": false,
-                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -1041,7 +943,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
+            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
         };"
       `);
     });
@@ -1108,20 +1010,6 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
-                      },
-                      \\"createdAt\\": {
-                          \\"name\\": \\"createdAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
-                      },
-                      \\"updatedAt\\": {
-                          \\"name\\": \\"updatedAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1149,20 +1037,6 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
-                      },
-                      \\"createdAt\\": {
-                          \\"name\\": \\"createdAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
-                      },
-                      \\"updatedAt\\": {
-                          \\"name\\": \\"updatedAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1177,7 +1051,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
+          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
       };"
     `);
   });
@@ -1226,20 +1100,6 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
-                      },
-                      \\"createdAt\\": {
-                          \\"name\\": \\"createdAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
-                      },
-                      \\"updatedAt\\": {
-                          \\"name\\": \\"updatedAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1267,20 +1127,6 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
-                      },
-                      \\"createdAt\\": {
-                          \\"name\\": \\"createdAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
-                      },
-                      \\"updatedAt\\": {
-                          \\"name\\": \\"updatedAt\\",
-                          \\"isArray\\": false,
-                          \\"type\\": \\"AWSDateTime\\",
-                          \\"isRequired\\": false,
-                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1295,7 +1141,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
+          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
       };"
     `);
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -296,6 +296,13 @@ describe('Metadata visitor', () => {
                     "name": "bar",
                     "type": "String",
                   },
+                  "createdAt": Object {
+                    "attributes": Array [],
+                    "isArray": false,
+                    "isRequired": false,
+                    "name": "createdAt",
+                    "type": "AWSDateTime",
+                  },
                   "id": Object {
                     "attributes": Array [],
                     "isArray": false,
@@ -309,6 +316,13 @@ describe('Metadata visitor', () => {
                     "isRequired": false,
                     "name": "name",
                     "type": "String",
+                  },
+                  "updatedAt": Object {
+                    "attributes": Array [],
+                    "isArray": false,
+                    "isRequired": false,
+                    "name": "updatedAt",
+                    "type": "AWSDateTime",
                   },
                 },
                 "name": "SimpleModel",
@@ -338,7 +352,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "bc1b6d35e990f16a49dbb447a8876025",
+            "version": "5eb36909e822fd40c657cc69b22c919a",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -379,6 +393,20 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -422,7 +450,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -456,6 +484,20 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -499,7 +541,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -568,6 +610,20 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -642,7 +698,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -676,6 +732,20 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
                         }
                     },
                     \\"syncable\\": true,
@@ -750,7 +820,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -807,93 +877,18 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
-                        }
-                    },
-                    \\"syncable\\": true,
-                    \\"pluralName\\": \\"Employees\\",
-                    \\"attributes\\": [
-                        {
-                            \\"type\\": \\"model\\",
-                            \\"properties\\": {}
                         },
-                        {
-                            \\"type\\": \\"auth\\",
-                            \\"properties\\": {
-                                \\"rules\\": [
-                                    {
-                                        \\"provider\\": \\"userPools\\",
-                                        \\"ownerField\\": \\"owner\\",
-                                        \\"allow\\": \\"owner\\",
-                                        \\"identityClaim\\": \\"cognito:username\\",
-                                        \\"operations\\": [
-                                            \\"create\\",
-                                            \\"update\\",
-                                            \\"delete\\",
-                                            \\"read\\"
-                                        ]
-                                    },
-                                    {
-                                        \\"groupClaim\\": \\"cognito:groups\\",
-                                        \\"provider\\": \\"userPools\\",
-                                        \\"allow\\": \\"groups\\",
-                                        \\"groups\\": [
-                                            \\"Admins\\"
-                                        ],
-                                        \\"operations\\": [
-                                            \\"create\\",
-                                            \\"update\\",
-                                            \\"delete\\",
-                                            \\"read\\"
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            \\"enums\\": {},
-            \\"nonModels\\": {},
-            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
-        };"
-      `);
-    });
-
-    it('should generate for typescript', () => {
-      const tsVisitor = getVisitor(schema, 'typescript');
-      expect(tsVisitor.generate()).toMatchInlineSnapshot(`
-        "import { Schema } from \\"@aws-amplify/datastore\\";
-
-        export const schema: Schema = {
-            \\"models\\": {
-                \\"Employee\\": {
-                    \\"name\\": \\"Employee\\",
-                    \\"fields\\": {
-                        \\"id\\": {
-                            \\"name\\": \\"id\\",
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
                             \\"isArray\\": false,
-                            \\"type\\": \\"ID\\",
-                            \\"isRequired\\": true,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
                             \\"attributes\\": []
                         },
-                        \\"name\\": {
-                            \\"name\\": \\"name\\",
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
                             \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": true,
-                            \\"attributes\\": []
-                        },
-                        \\"address\\": {
-                            \\"name\\": \\"address\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
-                            \\"isRequired\\": true,
-                            \\"attributes\\": []
-                        },
-                        \\"ssn\\": {
-                            \\"name\\": \\"ssn\\",
-                            \\"isArray\\": false,
-                            \\"type\\": \\"String\\",
+                            \\"type\\": \\"AWSDateTime\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
                         }
@@ -943,7 +938,110 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
+            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
+        };"
+      `);
+    });
+
+    it('should generate for typescript', () => {
+      const tsVisitor = getVisitor(schema, 'typescript');
+      expect(tsVisitor.generate()).toMatchInlineSnapshot(`
+        "import { Schema } from \\"@aws-amplify/datastore\\";
+
+        export const schema: Schema = {
+            \\"models\\": {
+                \\"Employee\\": {
+                    \\"name\\": \\"Employee\\",
+                    \\"fields\\": {
+                        \\"id\\": {
+                            \\"name\\": \\"id\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"ID\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"name\\": {
+                            \\"name\\": \\"name\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"address\\": {
+                            \\"name\\": \\"address\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": true,
+                            \\"attributes\\": []
+                        },
+                        \\"ssn\\": {
+                            \\"name\\": \\"ssn\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"String\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": []
+                        }
+                    },
+                    \\"syncable\\": true,
+                    \\"pluralName\\": \\"Employees\\",
+                    \\"attributes\\": [
+                        {
+                            \\"type\\": \\"model\\",
+                            \\"properties\\": {}
+                        },
+                        {
+                            \\"type\\": \\"auth\\",
+                            \\"properties\\": {
+                                \\"rules\\": [
+                                    {
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"ownerField\\": \\"owner\\",
+                                        \\"allow\\": \\"owner\\",
+                                        \\"identityClaim\\": \\"cognito:username\\",
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    },
+                                    {
+                                        \\"groupClaim\\": \\"cognito:groups\\",
+                                        \\"provider\\": \\"userPools\\",
+                                        \\"allow\\": \\"groups\\",
+                                        \\"groups\\": [
+                                            \\"Admins\\"
+                                        ],
+                                        \\"operations\\": [
+                                            \\"create\\",
+                                            \\"update\\",
+                                            \\"delete\\",
+                                            \\"read\\"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            \\"enums\\": {},
+            \\"nonModels\\": {},
+            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
         };"
       `);
     });
@@ -1010,6 +1108,20 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1037,6 +1149,20 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1051,7 +1177,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
   });
@@ -1100,6 +1226,20 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1127,6 +1267,20 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": []
                       }
                   },
                   \\"syncable\\": true,
@@ -1141,7 +1295,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -19,7 +19,7 @@ const getVisitor = (schema: string, target: 'typescript' | 'javascript' | 'typeD
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncJSONVisitor(
     builtSchema,
-    { directives, target: 'metadata', scalars: TYPESCRIPT_SCALAR_MAP, metadataTarget: target },
+    { directives, target: 'metadata', scalars: TYPESCRIPT_SCALAR_MAP, metadataTarget: target, isTimestampFieldsAdded: true },
     {},
   );
   visit(ast, { leave: visitor });
@@ -296,6 +296,14 @@ describe('Metadata visitor', () => {
                     "name": "bar",
                     "type": "String",
                   },
+                  "createdAt": Object {
+                    "attributes": Array [],
+                    "isArray": false,
+                    "isReadOnly": true,
+                    "isRequired": false,
+                    "name": "createdAt",
+                    "type": "AWSDateTime",
+                  },
                   "id": Object {
                     "attributes": Array [],
                     "isArray": false,
@@ -309,6 +317,14 @@ describe('Metadata visitor', () => {
                     "isRequired": false,
                     "name": "name",
                     "type": "String",
+                  },
+                  "updatedAt": Object {
+                    "attributes": Array [],
+                    "isArray": false,
+                    "isReadOnly": true,
+                    "isRequired": false,
+                    "name": "updatedAt",
+                    "type": "AWSDateTime",
                   },
                 },
                 "name": "SimpleModel",
@@ -338,7 +354,7 @@ describe('Metadata visitor', () => {
                 "name": "SimpleNonModelType",
               },
             },
-            "version": "bc1b6d35e990f16a49dbb447a8876025",
+            "version": "5eb36909e822fd40c657cc69b22c919a",
           }
         `);
         expect(generateModelSpy).toHaveBeenCalledTimes(1);
@@ -379,6 +395,22 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -422,7 +454,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -456,6 +488,22 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -499,7 +547,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -568,6 +616,22 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -642,7 +706,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -676,6 +740,22 @@ describe('Metadata visitor', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -750,7 +830,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"version\\": \\"bc1b6d35e990f16a49dbb447a8876025\\"
+            \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
     });
@@ -807,6 +887,22 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -854,7 +950,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
+            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
         };"
       `);
     });
@@ -896,6 +992,22 @@ describe('Metadata visitor for auth process in field level', () => {
                             \\"type\\": \\"String\\",
                             \\"isRequired\\": false,
                             \\"attributes\\": []
+                        },
+                        \\"createdAt\\": {
+                            \\"name\\": \\"createdAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
+                        },
+                        \\"updatedAt\\": {
+                            \\"name\\": \\"updatedAt\\",
+                            \\"isArray\\": false,
+                            \\"type\\": \\"AWSDateTime\\",
+                            \\"isRequired\\": false,
+                            \\"attributes\\": [],
+                            \\"isReadOnly\\": true
                         }
                     },
                     \\"syncable\\": true,
@@ -943,7 +1055,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"version\\": \\"95acbb25bafac9a5339620c322ea25c7\\"
+            \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
         };"
       `);
     });
@@ -1010,6 +1122,22 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
                       }
                   },
                   \\"syncable\\": true,
@@ -1037,6 +1165,22 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
                       }
                   },
                   \\"syncable\\": true,
@@ -1051,7 +1195,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
   });
@@ -1100,6 +1244,22 @@ describe('Metadata visitor has one relation', () => {
                               \\"associatedWith\\": \\"id\\",
                               \\"targetName\\": \\"teamID\\"
                           }
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
                       }
                   },
                   \\"syncable\\": true,
@@ -1127,6 +1287,22 @@ describe('Metadata visitor has one relation', () => {
                           \\"type\\": \\"String\\",
                           \\"isRequired\\": true,
                           \\"attributes\\": []
+                      },
+                      \\"createdAt\\": {
+                          \\"name\\": \\"createdAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
+                      },
+                      \\"updatedAt\\": {
+                          \\"name\\": \\"updatedAt\\",
+                          \\"isArray\\": false,
+                          \\"type\\": \\"AWSDateTime\\",
+                          \\"isRequired\\": false,
+                          \\"attributes\\": [],
+                          \\"isReadOnly\\": true
                       }
                   },
                   \\"syncable\\": true,
@@ -1141,7 +1317,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"version\\": \\"4de4b90e612a2203db7d8911d9f41f36\\"
+          \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -46,7 +46,8 @@ describe('AppSyncSwiftVisitor', () => {
         
         public init(name: String? = nil,
             bar: String? = nil) {
-          self.init(name: name,
+          self.init(id: id,
+            name: name,
             bar: bar,
             createdAt: nil,
             updatedAt: nil)
@@ -153,7 +154,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(name: String? = nil) {
-          self.init(name: name,
+          self.init(id: id,
+            name: name,
             createdAt: nil,
             updatedAt: nil)
         }
@@ -226,7 +228,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(first_name: String? = nil) {
-          self.init(first_name: first_name,
+          self.init(id: id,
+            first_name: first_name,
             createdAt: nil,
             updatedAt: nil)
         }
@@ -273,7 +276,8 @@ describe('AppSyncSwiftVisitor', () => {
             book_id: String,
             author: String? = nil,
             book: String? = nil) {
-          self.init(author_id: author_id,
+          self.init(id: id,
+            author_id: author_id,
             book_id: book_id,
             author: author,
             book: book,
@@ -389,7 +393,8 @@ describe('AppSyncSwiftVisitor', () => {
                 version: Int,
                 value: Double? = nil,
                 tasks: List<task>? = []) {
-              self.init(title: title,
+              self.init(id: id,
+                title: title,
                 done: done,
                 description: description,
                 due_date: due_date,
@@ -493,7 +498,8 @@ describe('AppSyncSwiftVisitor', () => {
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
                 createdOn: Temporal.Date? = nil) {
-              self.init(title: title,
+              self.init(id: id,
+                title: title,
                 done: done,
                 todo: todo,
                 time: time,
@@ -640,7 +646,8 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(title: String,
                 editors: List<PostEditor>? = []) {
-              self.init(title: title,
+              self.init(id: id,
+                title: title,
                 editors: editors,
                 createdAt: nil,
                 updatedAt: nil)
@@ -709,7 +716,8 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(title: String,
                 editors: List<PostEditor>? = []) {
-              self.init(title: title,
+              self.init(id: id,
+                title: title,
                 editors: editors,
                 createdAt: nil,
                 updatedAt: nil)
@@ -805,7 +813,8 @@ describe('AppSyncSwiftVisitor', () => {
             boolArr: [Bool]? = [],
             dateArr: [Temporal.Date]? = [],
             enumArr: [EnumType]? = []) {
-          self.init(intArr: intArr,
+          self.init(id: id,
+            intArr: intArr,
             strArr: strArr,
             floatArr: floatArr,
             boolArr: boolArr,
@@ -926,7 +935,8 @@ describe('AppSyncSwiftVisitor', () => {
             status: Status,
             statusHistory: [Status]? = [],
             tags: [String]? = []) {
-          self.init(name: name,
+          self.init(id: id,
+            name: name,
             location: location,
             nearByLocations: nearByLocations,
             status: status,
@@ -1166,7 +1176,8 @@ describe('AppSyncSwiftVisitor', () => {
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
               nonNullClasses: [\`Class\`] = []) {
-            self.init(\`Class\`: \`Class\`,
+            self.init(id: id,
+              \`Class\`: \`Class\`,
               nonNullClass: nonNullClass,
               classes: classes,
               nonNullClasses: nonNullClasses,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -44,12 +44,24 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            name: String? = nil,
+        public init(name: String? = nil,
             bar: String? = nil) {
+          self.init(,
+          name: name,
+          bar: bar,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            name: String? = nil,
+            bar: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
             self.bar = bar
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -82,8 +94,8 @@ describe('AppSyncSwiftVisitor', () => {
             .id(),
             .field(simpleModel.name, is: .optional, ofType: .string),
             .field(simpleModel.bar, is: .optional, ofType: .string),
-            .field(simpleModel.createdAt, is: .optional, ofType: .dateTime),
-            .field(simpleModel.updatedAt, is: .optional, ofType: .dateTime)
+            .field(simpleModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(simpleModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"
@@ -141,10 +153,20 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            name: String? = nil) {
+        public init(name: String? = nil) {
+          self.init(,
+          name: name,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            name: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -176,8 +198,8 @@ describe('AppSyncSwiftVisitor', () => {
           model.fields(
             .id(),
             .field(snake_case.name, is: .optional, ofType: .string),
-            .field(snake_case.createdAt, is: .optional, ofType: .dateTime),
-            .field(snake_case.updatedAt, is: .optional, ofType: .dateTime)
+            .field(snake_case.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(snake_case.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"
@@ -205,10 +227,20 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            first_name: String? = nil) {
+        public init(first_name: String? = nil) {
+          self.init(,
+          first_name: first_name,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            first_name: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.first_name = first_name
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -240,16 +272,32 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            author_id: String,
+        public init(author_id: String,
             book_id: String,
             author: String? = nil,
             book: String? = nil) {
+          self.init(,
+          author_id: author_id,
+          book_id: book_id,
+          author: author,
+          book: book,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            author_id: String,
+            book_id: String,
+            author: String? = nil,
+            book: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.author_id = author_id
             self.book_id = book_id
             self.author = author
             self.book = book
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -287,8 +335,8 @@ describe('AppSyncSwiftVisitor', () => {
             .field(authorBook.book_id, is: .required, ofType: .string),
             .field(authorBook.author, is: .optional, ofType: .string),
             .field(authorBook.book, is: .optional, ofType: .string),
-            .field(authorBook.createdAt, is: .optional, ofType: .dateTime),
-            .field(authorBook.updatedAt, is: .optional, ofType: .dateTime)
+            .field(authorBook.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(authorBook.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"
@@ -338,14 +386,34 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(id: String = UUID().uuidString,
-                title: String,
+            public init(title: String,
                 done: Bool,
                 description: String? = nil,
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
                 tasks: List<task>? = []) {
+              self.init(,
+              title: title,
+              done: done,
+              description: description,
+              due_date: due_date,
+              version: version,
+              value: value,
+              tasks: tasks,
+              createdAt: nil,
+              updatedAt: nil)
+            }
+            internal init(id: String = UUID().uuidString,
+                title: String,
+                done: Bool,
+                description: String? = nil,
+                due_date: String? = nil,
+                version: Int,
+                value: Double? = nil,
+                tasks: List<task>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.done = done
@@ -354,6 +422,8 @@ describe('AppSyncSwiftVisitor', () => {
                 self.version = version
                 self.value = value
                 self.tasks = tasks
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -397,8 +467,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(todo.version, is: .required, ofType: .int),
                 .field(todo.value, is: .optional, ofType: .double),
                 .hasMany(todo.tasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
-                .field(todo.createdAt, is: .optional, ofType: .dateTime),
-                .field(todo.updatedAt, is: .optional, ofType: .dateTime)
+                .field(todo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -423,18 +493,36 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(id: String = UUID().uuidString,
-                title: String,
+            public init(title: String,
                 done: Bool,
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
                 createdOn: Temporal.Date? = nil) {
+              self.init(,
+              title: title,
+              done: done,
+              todo: todo,
+              time: time,
+              createdOn: createdOn,
+              createdAt: nil,
+              updatedAt: nil)
+            }
+            internal init(id: String = UUID().uuidString,
+                title: String,
+                done: Bool,
+                todo: Todo? = nil,
+                time: Temporal.Time? = nil,
+                createdOn: Temporal.Date? = nil,
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.done = done
                 self.todo = todo
                 self.time = time
                 self.createdOn = createdOn
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -474,8 +562,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
                 .field(task.time, is: .optional, ofType: .time),
                 .field(task.createdOn, is: .optional, ofType: .date),
-                .field(task.createdAt, is: .optional, ofType: .dateTime),
-                .field(task.updatedAt, is: .optional, ofType: .dateTime)
+                .field(task.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -556,12 +644,24 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(id: String = UUID().uuidString,
-                title: String,
+            public init(title: String,
                 editors: List<PostEditor>? = []) {
+              self.init(,
+              title: title,
+              editors: editors,
+              createdAt: nil,
+              updatedAt: nil)
+            }
+            internal init(id: String = UUID().uuidString,
+                title: String,
+                editors: List<PostEditor>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.editors = editors
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -594,8 +694,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -614,12 +714,24 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(id: String = UUID().uuidString,
-                title: String,
+            public init(title: String,
                 editors: List<PostEditor>? = []) {
+              self.init(,
+              title: title,
+              editors: editors,
+              createdAt: nil,
+              updatedAt: nil)
+            }
+            internal init(id: String = UUID().uuidString,
+                title: String,
+                editors: List<PostEditor>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.editors = editors
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -652,8 +764,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -695,13 +807,31 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            intArr: [Int]? = [],
+        public init(intArr: [Int]? = [],
             strArr: [String]? = [],
             floatArr: [Double]? = [],
             boolArr: [Bool]? = [],
             dateArr: [Temporal.Date]? = [],
             enumArr: [EnumType]? = []) {
+          self.init(,
+          intArr: intArr,
+          strArr: strArr,
+          floatArr: floatArr,
+          boolArr: boolArr,
+          dateArr: dateArr,
+          enumArr: enumArr,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            intArr: [Int]? = [],
+            strArr: [String]? = [],
+            floatArr: [Double]? = [],
+            boolArr: [Bool]? = [],
+            dateArr: [Temporal.Date]? = [],
+            enumArr: [EnumType]? = [],
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.intArr = intArr
             self.strArr = strArr
@@ -709,6 +839,8 @@ describe('AppSyncSwiftVisitor', () => {
             self.boolArr = boolArr
             self.dateArr = dateArr
             self.enumArr = enumArr
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -750,8 +882,8 @@ describe('AppSyncSwiftVisitor', () => {
             .field(objectWithNativeTypes.boolArr, is: .optional, ofType: .embeddedCollection(of: Bool.self)),
             .field(objectWithNativeTypes.dateArr, is: .optional, ofType: .embeddedCollection(of: Temporal.Date.self)),
             .field(objectWithNativeTypes.enumArr, is: .optional, ofType: .embeddedCollection(of: EnumType.self)),
-            .field(objectWithNativeTypes.createdAt, is: .optional, ofType: .dateTime),
-            .field(objectWithNativeTypes.updatedAt, is: .optional, ofType: .dateTime)
+            .field(objectWithNativeTypes.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(objectWithNativeTypes.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"
@@ -797,13 +929,31 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(id: String = UUID().uuidString,
-            name: String,
+        public init(name: String,
             location: Location,
             nearByLocations: [Location]? = [],
             status: Status,
             statusHistory: [Status]? = [],
             tags: [String]? = []) {
+          self.init(,
+          name: name,
+          location: location,
+          nearByLocations: nearByLocations,
+          status: status,
+          statusHistory: statusHistory,
+          tags: tags,
+          createdAt: nil,
+          updatedAt: nil)
+        }
+        internal init(id: String = UUID().uuidString,
+            name: String,
+            location: Location,
+            nearByLocations: [Location]? = [],
+            status: Status,
+            statusHistory: [Status]? = [],
+            tags: [String]? = [],
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
             self.location = location
@@ -811,6 +961,8 @@ describe('AppSyncSwiftVisitor', () => {
             self.status = status
             self.statusHistory = statusHistory
             self.tags = tags
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -851,8 +1003,8 @@ describe('AppSyncSwiftVisitor', () => {
             .field(attraction.status, is: .required, ofType: .enum(type: Status.self)),
             .field(attraction.statusHistory, is: .optional, ofType: .embeddedCollection(of: Status.self)),
             .field(attraction.tags, is: .optional, ofType: .embeddedCollection(of: String.self)),
-            .field(attraction.createdAt, is: .optional, ofType: .dateTime),
-            .field(attraction.updatedAt, is: .optional, ofType: .dateTime)
+            .field(attraction.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(attraction.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"
@@ -1020,16 +1172,32 @@ describe('AppSyncSwiftVisitor', () => {
           public var createdAt: Temporal.DateTime?
           public var updatedAt: Temporal.DateTime?
           
-          public init(id: String = UUID().uuidString,
-              \`Class\`: \`Class\`? = nil,
+          public init(\`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
               nonNullClasses: [\`Class\`] = []) {
+            self.init(,
+            Class: Class,
+            nonNullClass: nonNullClass,
+            classes: classes,
+            nonNullClasses: nonNullClasses,
+            createdAt: nil,
+            updatedAt: nil)
+          }
+          internal init(id: String = UUID().uuidString,
+              \`Class\`: \`Class\`? = nil,
+              nonNullClass: \`Class\`,
+              classes: [\`Class\`]? = [],
+              nonNullClasses: [\`Class\`] = [],
+              createdAt: Temporal.DateTime? = nil,
+              updatedAt: Temporal.DateTime? = nil) {
               self.id = id
               self.\`Class\` = \`Class\`
               self.nonNullClass = nonNullClass
               self.classes = classes
               self.nonNullClasses = nonNullClasses
+              self.createdAt = createdAt
+              self.updatedAt = updatedAt
           }
         }"
       `);
@@ -1078,8 +1246,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.owner, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1127,8 +1295,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1177,8 +1345,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1227,8 +1395,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1273,8 +1441,8 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1319,8 +1487,8 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1374,8 +1542,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self)),
-                .field(post.createdAt, is: .optional, ofType: .dateTime),
-                .field(post.updatedAt, is: .optional, ofType: .dateTime)
+                .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1427,8 +1595,8 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(employee.name, is: .required, ofType: .string),
                 .field(employee.address, is: .required, ofType: .string),
                 .field(employee.ssn, is: .optional, ofType: .string),
-                .field(employee.createdAt, is: .optional, ofType: .dateTime),
-                .field(employee.updatedAt, is: .optional, ofType: .dateTime)
+                .field(employee.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+                .field(employee.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
           }"
@@ -1476,8 +1644,8 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.createdAt, is: .optional, ofType: .dateTime),
-              .field(post.updatedAt, is: .optional, ofType: .dateTime)
+              .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
         }"
@@ -1525,8 +1693,8 @@ describe('AppSyncSwiftVisitor', () => {
               .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self)),
-              .field(post.createdAt, is: .optional, ofType: .dateTime),
-              .field(post.updatedAt, is: .optional, ofType: .dateTime)
+              .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
         }"
@@ -1572,8 +1740,8 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.createdAt, is: .optional, ofType: .dateTime),
-              .field(post.updatedAt, is: .optional, ofType: .dateTime)
+              .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
         }"
@@ -1619,8 +1787,8 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.createdAt, is: .optional, ofType: .dateTime),
-              .field(post.updatedAt, is: .optional, ofType: .dateTime)
+              .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
         }"
@@ -1678,8 +1846,8 @@ describe('AppSyncSwiftVisitor', () => {
             .id(),
             .field(post.title, is: .required, ofType: .string),
             .field(post.owner, is: .required, ofType: .string),
-            .field(post.createdAt, is: .optional, ofType: .dateTime),
-            .field(post.updatedAt, is: .optional, ofType: .dateTime)
+            .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+            .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
       }"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -13,7 +13,7 @@ const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGene
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncSwiftVisitor(
     builtSchema,
-    { directives, target: 'swift', scalars: SWIFT_SCALAR_MAP },
+    { directives, target: 'swift', scalars: SWIFT_SCALAR_MAP, isTimestampFieldsAdded: true },
     { selectedType, generate },
   );
   visit(ast, { leave: visitor });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -41,13 +41,19 @@ describe('AppSyncSwiftVisitor', () => {
         public let id: String
         public var name: String?
         public var bar: String?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
             name: String? = nil,
-            bar: String? = nil) {
+            bar: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
             self.bar = bar
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -64,6 +70,8 @@ describe('AppSyncSwiftVisitor', () => {
           case id
           case name
           case bar
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -77,7 +85,9 @@ describe('AppSyncSwiftVisitor', () => {
           model.fields(
             .id(),
             .field(simpleModel.name, is: .optional, ofType: .string),
-            .field(simpleModel.bar, is: .optional, ofType: .string)
+            .field(simpleModel.bar, is: .optional, ofType: .string),
+            .field(simpleModel.createdAt, is: .optional, ofType: .dateTime),
+            .field(simpleModel.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"
@@ -132,11 +142,17 @@ describe('AppSyncSwiftVisitor', () => {
       public struct snake_case: Model {
         public let id: String
         public var name: String?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
-            name: String? = nil) {
+            name: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -153,6 +169,8 @@ describe('AppSyncSwiftVisitor', () => {
          public enum CodingKeys: String, ModelKey {
           case id
           case name
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -165,7 +183,9 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.fields(
             .id(),
-            .field(snake_case.name, is: .optional, ofType: .string)
+            .field(snake_case.name, is: .optional, ofType: .string),
+            .field(snake_case.createdAt, is: .optional, ofType: .dateTime),
+            .field(snake_case.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"
@@ -190,11 +210,17 @@ describe('AppSyncSwiftVisitor', () => {
       public struct SnakeCaseField: Model {
         public let id: String
         public var first_name: String?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
-            first_name: String? = nil) {
+            first_name: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.first_name = first_name
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -223,17 +249,23 @@ describe('AppSyncSwiftVisitor', () => {
         public var book_id: String
         public var author: String?
         public var book: String?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
             author_id: String,
             book_id: String,
             author: String? = nil,
-            book: String? = nil) {
+            book: String? = nil,
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.author_id = author_id
             self.book_id = book_id
             self.author = author
             self.book = book
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -253,6 +285,8 @@ describe('AppSyncSwiftVisitor', () => {
           case book_id
           case author
           case book
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -268,7 +302,9 @@ describe('AppSyncSwiftVisitor', () => {
             .field(authorBook.author_id, is: .required, ofType: .string),
             .field(authorBook.book_id, is: .required, ofType: .string),
             .field(authorBook.author, is: .optional, ofType: .string),
-            .field(authorBook.book, is: .optional, ofType: .string)
+            .field(authorBook.book, is: .optional, ofType: .string),
+            .field(authorBook.createdAt, is: .optional, ofType: .dateTime),
+            .field(authorBook.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"
@@ -315,6 +351,8 @@ describe('AppSyncSwiftVisitor', () => {
             public var version: Int
             public var value: Double?
             public var tasks: List<task>?
+            public var createdAt: Temporal.DateTime?
+            public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
@@ -323,7 +361,9 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task>? = []) {
+                tasks: List<task>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.done = done
@@ -332,6 +372,8 @@ describe('AppSyncSwiftVisitor', () => {
                 self.version = version
                 self.value = value
                 self.tasks = tasks
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -354,6 +396,8 @@ describe('AppSyncSwiftVisitor', () => {
               case version
               case value
               case tasks
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -372,7 +416,9 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(todo.due_date, is: .optional, ofType: .string),
                 .field(todo.version, is: .required, ofType: .int),
                 .field(todo.value, is: .optional, ofType: .double),
-                .hasMany(todo.tasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo)
+                .hasMany(todo.tasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
+                .field(todo.createdAt, is: .optional, ofType: .dateTime),
+                .field(todo.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -394,19 +440,25 @@ describe('AppSyncSwiftVisitor', () => {
             public var todo: Todo?
             public var time: Temporal.Time?
             public var createdOn: Temporal.Date?
+            public var createdAt: Temporal.DateTime?
+            public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
                 done: Bool,
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
-                createdOn: Temporal.Date? = nil) {
+                createdOn: Temporal.Date? = nil,
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.done = done
                 self.todo = todo
                 self.time = time
                 self.createdOn = createdOn
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -427,6 +479,8 @@ describe('AppSyncSwiftVisitor', () => {
               case todo
               case time
               case createdOn
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -443,7 +497,9 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(task.done, is: .required, ofType: .bool),
                 .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
                 .field(task.time, is: .optional, ofType: .time),
-                .field(task.createdOn, is: .optional, ofType: .date)
+                .field(task.createdOn, is: .optional, ofType: .date),
+                .field(task.createdAt, is: .optional, ofType: .dateTime),
+                .field(task.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -521,13 +577,19 @@ describe('AppSyncSwiftVisitor', () => {
             public let id: String
             public var title: String
             public var editors: List<PostEditor>?
+            public var createdAt: Temporal.DateTime?
+            public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.editors = editors
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -544,6 +606,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case editors
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -557,7 +621,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id)
+                .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -573,13 +639,19 @@ describe('AppSyncSwiftVisitor', () => {
             public let id: String
             public var title: String
             public var editors: List<PostEditor>?
+            public var createdAt: Temporal.DateTime?
+            public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor>? = [],
+                createdAt: Temporal.DateTime? = nil,
+                updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
                 self.title = title
                 self.editors = editors
+                self.createdAt = createdAt
+                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -596,6 +668,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case editors
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -609,7 +683,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id)
+                .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -648,6 +724,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var boolArr: [Bool]?
         public var dateArr: [Temporal.Date]?
         public var enumArr: [EnumType]?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
             intArr: [Int]? = [],
@@ -655,7 +733,9 @@ describe('AppSyncSwiftVisitor', () => {
             floatArr: [Double]? = [],
             boolArr: [Bool]? = [],
             dateArr: [Temporal.Date]? = [],
-            enumArr: [EnumType]? = []) {
+            enumArr: [EnumType]? = [],
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.intArr = intArr
             self.strArr = strArr
@@ -663,6 +743,8 @@ describe('AppSyncSwiftVisitor', () => {
             self.boolArr = boolArr
             self.dateArr = dateArr
             self.enumArr = enumArr
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -684,6 +766,8 @@ describe('AppSyncSwiftVisitor', () => {
           case boolArr
           case dateArr
           case enumArr
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -701,7 +785,9 @@ describe('AppSyncSwiftVisitor', () => {
             .field(objectWithNativeTypes.floatArr, is: .optional, ofType: .embeddedCollection(of: Double.self)),
             .field(objectWithNativeTypes.boolArr, is: .optional, ofType: .embeddedCollection(of: Bool.self)),
             .field(objectWithNativeTypes.dateArr, is: .optional, ofType: .embeddedCollection(of: Temporal.Date.self)),
-            .field(objectWithNativeTypes.enumArr, is: .optional, ofType: .embeddedCollection(of: EnumType.self))
+            .field(objectWithNativeTypes.enumArr, is: .optional, ofType: .embeddedCollection(of: EnumType.self)),
+            .field(objectWithNativeTypes.createdAt, is: .optional, ofType: .dateTime),
+            .field(objectWithNativeTypes.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"
@@ -744,6 +830,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var status: Status
         public var statusHistory: [Status]?
         public var tags: [String]?
+        public var createdAt: Temporal.DateTime?
+        public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
             name: String,
@@ -751,7 +839,9 @@ describe('AppSyncSwiftVisitor', () => {
             nearByLocations: [Location]? = [],
             status: Status,
             statusHistory: [Status]? = [],
-            tags: [String]? = []) {
+            tags: [String]? = [],
+            createdAt: Temporal.DateTime? = nil,
+            updatedAt: Temporal.DateTime? = nil) {
             self.id = id
             self.name = name
             self.location = location
@@ -759,6 +849,8 @@ describe('AppSyncSwiftVisitor', () => {
             self.status = status
             self.statusHistory = statusHistory
             self.tags = tags
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -779,6 +871,8 @@ describe('AppSyncSwiftVisitor', () => {
           case status
           case statusHistory
           case tags
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -796,7 +890,9 @@ describe('AppSyncSwiftVisitor', () => {
             .field(attraction.nearByLocations, is: .optional, ofType: .embeddedCollection(of: Location.self)),
             .field(attraction.status, is: .required, ofType: .enum(type: Status.self)),
             .field(attraction.statusHistory, is: .optional, ofType: .embeddedCollection(of: Status.self)),
-            .field(attraction.tags, is: .optional, ofType: .embeddedCollection(of: String.self))
+            .field(attraction.tags, is: .optional, ofType: .embeddedCollection(of: String.self)),
+            .field(attraction.createdAt, is: .optional, ofType: .dateTime),
+            .field(attraction.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"
@@ -867,7 +963,7 @@ describe('AppSyncSwiftVisitor', () => {
       // Contains the set of classes that conforms to the \`Model\` protocol. 
 
       final public class AmplifyModels: AmplifyModelRegistration {
-        public let version: String = \\"11dddb282be1f7ba4eabda5ee4c56430\\"
+        public let version: String = \\"fcfad0bb5cf954c935899c0102689995\\"
         
         public func registerModels(registry: ModelRegistry.Type) {
           ModelRegistry.register(modelType: Attraction.self)
@@ -961,17 +1057,23 @@ describe('AppSyncSwiftVisitor', () => {
           public var nonNullClass: Class
           public var classes: [\`Class\`]?
           public var nonNullClasses: [\`Class\`]
+          public var createdAt: Temporal.DateTime?
+          public var updatedAt: Temporal.DateTime?
           
           public init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
-              nonNullClasses: [\`Class\`] = []) {
+              nonNullClasses: [\`Class\`] = [],
+              createdAt: Temporal.DateTime? = nil,
+              updatedAt: Temporal.DateTime? = nil) {
               self.id = id
               self.\`Class\` = \`Class\`
               self.nonNullClass = nonNullClass
               self.classes = classes
               self.nonNullClasses = nonNullClasses
+              self.createdAt = createdAt
+              self.updatedAt = updatedAt
           }
         }"
       `);
@@ -1000,6 +1102,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case owner
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1017,7 +1121,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.owner, is: .required, ofType: .string)
+                .field(post.owner, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1045,6 +1151,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case author
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1062,7 +1170,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.author, is: .required, ofType: .string)
+                .field(post.author, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1091,6 +1201,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case author
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1108,7 +1220,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.author, is: .required, ofType: .string)
+                .field(post.author, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1137,6 +1251,8 @@ describe('AppSyncSwiftVisitor', () => {
               case id
               case title
               case author
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1154,7 +1270,9 @@ describe('AppSyncSwiftVisitor', () => {
               model.fields(
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
-                .field(post.author, is: .required, ofType: .string)
+                .field(post.author, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1180,6 +1298,8 @@ describe('AppSyncSwiftVisitor', () => {
              public enum CodingKeys: String, ModelKey {
               case id
               case title
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1196,7 +1316,9 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.fields(
                 .id(),
-                .field(post.title, is: .required, ofType: .string)
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1222,6 +1344,8 @@ describe('AppSyncSwiftVisitor', () => {
              public enum CodingKeys: String, ModelKey {
               case id
               case title
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1238,7 +1362,9 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.fields(
                 .id(),
-                .field(post.title, is: .required, ofType: .string)
+                .field(post.title, is: .required, ofType: .string),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1270,6 +1396,8 @@ describe('AppSyncSwiftVisitor', () => {
               case title
               case author
               case editors
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1289,7 +1417,9 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self))
+                .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self)),
+                .field(post.createdAt, is: .optional, ofType: .dateTime),
+                .field(post.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1319,6 +1449,8 @@ describe('AppSyncSwiftVisitor', () => {
               case name
               case address
               case ssn
+              case createdAt
+              case updatedAt
             }
             
             public static let keys = CodingKeys.self
@@ -1338,7 +1470,9 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(employee.name, is: .required, ofType: .string),
                 .field(employee.address, is: .required, ofType: .string),
-                .field(employee.ssn, is: .optional, ofType: .string)
+                .field(employee.ssn, is: .optional, ofType: .string),
+                .field(employee.createdAt, is: .optional, ofType: .dateTime),
+                .field(employee.updatedAt, is: .optional, ofType: .dateTime)
               )
               }
           }"
@@ -1367,6 +1501,8 @@ describe('AppSyncSwiftVisitor', () => {
            public enum CodingKeys: String, ModelKey {
             case id
             case title
+            case createdAt
+            case updatedAt
           }
           
           public static let keys = CodingKeys.self
@@ -1383,7 +1519,9 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.fields(
               .id(),
-              .field(post.title, is: .required, ofType: .string)
+              .field(post.title, is: .required, ofType: .string),
+              .field(post.createdAt, is: .optional, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, ofType: .dateTime)
             )
             }
         }"
@@ -1411,6 +1549,8 @@ describe('AppSyncSwiftVisitor', () => {
             case id
             case title
             case groups
+            case createdAt
+            case updatedAt
           }
           
           public static let keys = CodingKeys.self
@@ -1428,7 +1568,9 @@ describe('AppSyncSwiftVisitor', () => {
             model.fields(
               .id(),
               .field(post.title, is: .required, ofType: .string),
-              .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self))
+              .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self)),
+              .field(post.createdAt, is: .optional, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, ofType: .dateTime)
             )
             }
         }"
@@ -1455,6 +1597,8 @@ describe('AppSyncSwiftVisitor', () => {
            public enum CodingKeys: String, ModelKey {
             case id
             case title
+            case createdAt
+            case updatedAt
           }
           
           public static let keys = CodingKeys.self
@@ -1471,7 +1615,9 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.fields(
               .id(),
-              .field(post.title, is: .required, ofType: .string)
+              .field(post.title, is: .required, ofType: .string),
+              .field(post.createdAt, is: .optional, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, ofType: .dateTime)
             )
             }
         }"
@@ -1498,6 +1644,8 @@ describe('AppSyncSwiftVisitor', () => {
            public enum CodingKeys: String, ModelKey {
             case id
             case title
+            case createdAt
+            case updatedAt
           }
           
           public static let keys = CodingKeys.self
@@ -1514,7 +1662,9 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.fields(
               .id(),
-              .field(post.title, is: .required, ofType: .string)
+              .field(post.title, is: .required, ofType: .string),
+              .field(post.createdAt, is: .optional, ofType: .dateTime),
+              .field(post.updatedAt, is: .optional, ofType: .dateTime)
             )
             }
         }"
@@ -1551,6 +1701,8 @@ describe('AppSyncSwiftVisitor', () => {
           case id
           case title
           case owner
+          case createdAt
+          case updatedAt
         }
         
         public static let keys = CodingKeys.self
@@ -1569,7 +1721,9 @@ describe('AppSyncSwiftVisitor', () => {
           model.fields(
             .id(),
             .field(post.title, is: .required, ofType: .string),
-            .field(post.owner, is: .required, ofType: .string)
+            .field(post.owner, is: .required, ofType: .string),
+            .field(post.createdAt, is: .optional, ofType: .dateTime),
+            .field(post.updatedAt, is: .optional, ofType: .dateTime)
           )
           }
       }"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -46,14 +46,10 @@ describe('AppSyncSwiftVisitor', () => {
         
         public init(id: String = UUID().uuidString,
             name: String? = nil,
-            bar: String? = nil,
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            bar: String? = nil) {
             self.id = id
             self.name = name
             self.bar = bar
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -146,13 +142,9 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
-            name: String? = nil,
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            name: String? = nil) {
             self.id = id
             self.name = name
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -214,13 +206,9 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
-            first_name: String? = nil,
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            first_name: String? = nil) {
             self.id = id
             self.first_name = first_name
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -256,16 +244,12 @@ describe('AppSyncSwiftVisitor', () => {
             author_id: String,
             book_id: String,
             author: String? = nil,
-            book: String? = nil,
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            book: String? = nil) {
             self.id = id
             self.author_id = author_id
             self.book_id = book_id
             self.author = author
             self.book = book
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -361,9 +345,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task>? = [],
-                createdAt: Temporal.DateTime? = nil,
-                updatedAt: Temporal.DateTime? = nil) {
+                tasks: List<task>? = []) {
                 self.id = id
                 self.title = title
                 self.done = done
@@ -372,8 +354,6 @@ describe('AppSyncSwiftVisitor', () => {
                 self.version = version
                 self.value = value
                 self.tasks = tasks
-                self.createdAt = createdAt
-                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -448,17 +428,13 @@ describe('AppSyncSwiftVisitor', () => {
                 done: Bool,
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
-                createdOn: Temporal.Date? = nil,
-                createdAt: Temporal.DateTime? = nil,
-                updatedAt: Temporal.DateTime? = nil) {
+                createdOn: Temporal.Date? = nil) {
                 self.id = id
                 self.title = title
                 self.done = done
                 self.todo = todo
                 self.time = time
                 self.createdOn = createdOn
-                self.createdAt = createdAt
-                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -582,14 +558,10 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = [],
-                createdAt: Temporal.DateTime? = nil,
-                updatedAt: Temporal.DateTime? = nil) {
+                editors: List<PostEditor>? = []) {
                 self.id = id
                 self.title = title
                 self.editors = editors
-                self.createdAt = createdAt
-                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -644,14 +616,10 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = [],
-                createdAt: Temporal.DateTime? = nil,
-                updatedAt: Temporal.DateTime? = nil) {
+                editors: List<PostEditor>? = []) {
                 self.id = id
                 self.title = title
                 self.editors = editors
-                self.createdAt = createdAt
-                self.updatedAt = updatedAt
             }
           }"
         `);
@@ -733,9 +701,7 @@ describe('AppSyncSwiftVisitor', () => {
             floatArr: [Double]? = [],
             boolArr: [Bool]? = [],
             dateArr: [Temporal.Date]? = [],
-            enumArr: [EnumType]? = [],
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            enumArr: [EnumType]? = []) {
             self.id = id
             self.intArr = intArr
             self.strArr = strArr
@@ -743,8 +709,6 @@ describe('AppSyncSwiftVisitor', () => {
             self.boolArr = boolArr
             self.dateArr = dateArr
             self.enumArr = enumArr
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -839,9 +803,7 @@ describe('AppSyncSwiftVisitor', () => {
             nearByLocations: [Location]? = [],
             status: Status,
             statusHistory: [Status]? = [],
-            tags: [String]? = [],
-            createdAt: Temporal.DateTime? = nil,
-            updatedAt: Temporal.DateTime? = nil) {
+            tags: [String]? = []) {
             self.id = id
             self.name = name
             self.location = location
@@ -849,8 +811,6 @@ describe('AppSyncSwiftVisitor', () => {
             self.status = status
             self.statusHistory = statusHistory
             self.tags = tags
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
         }
       }"
     `);
@@ -1064,16 +1024,12 @@ describe('AppSyncSwiftVisitor', () => {
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
-              nonNullClasses: [\`Class\`] = [],
-              createdAt: Temporal.DateTime? = nil,
-              updatedAt: Temporal.DateTime? = nil) {
+              nonNullClasses: [\`Class\`] = []) {
               self.id = id
               self.\`Class\` = \`Class\`
               self.nonNullClass = nonNullClass
               self.classes = classes
               self.nonNullClasses = nonNullClasses
-              self.createdAt = createdAt
-              self.updatedAt = updatedAt
           }
         }"
       `);

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -46,11 +46,10 @@ describe('AppSyncSwiftVisitor', () => {
         
         public init(name: String? = nil,
             bar: String? = nil) {
-          self.init(,
-          name: name,
-          bar: bar,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(name: name,
+            bar: bar,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             name: String? = nil,
@@ -154,10 +153,9 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(name: String? = nil) {
-          self.init(,
-          name: name,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(name: name,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             name: String? = nil,
@@ -228,10 +226,9 @@ describe('AppSyncSwiftVisitor', () => {
         public var updatedAt: Temporal.DateTime?
         
         public init(first_name: String? = nil) {
-          self.init(,
-          first_name: first_name,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(first_name: first_name,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             first_name: String? = nil,
@@ -276,13 +273,12 @@ describe('AppSyncSwiftVisitor', () => {
             book_id: String,
             author: String? = nil,
             book: String? = nil) {
-          self.init(,
-          author_id: author_id,
-          book_id: book_id,
-          author: author,
-          book: book,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(author_id: author_id,
+            book_id: book_id,
+            author: author,
+            book: book,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             author_id: String,
@@ -393,16 +389,15 @@ describe('AppSyncSwiftVisitor', () => {
                 version: Int,
                 value: Double? = nil,
                 tasks: List<task>? = []) {
-              self.init(,
-              title: title,
-              done: done,
-              description: description,
-              due_date: due_date,
-              version: version,
-              value: value,
-              tasks: tasks,
-              createdAt: nil,
-              updatedAt: nil)
+              self.init(title: title,
+                done: done,
+                description: description,
+                due_date: due_date,
+                version: version,
+                value: value,
+                tasks: tasks,
+                createdAt: nil,
+                updatedAt: nil)
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
@@ -498,14 +493,13 @@ describe('AppSyncSwiftVisitor', () => {
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
                 createdOn: Temporal.Date? = nil) {
-              self.init(,
-              title: title,
-              done: done,
-              todo: todo,
-              time: time,
-              createdOn: createdOn,
-              createdAt: nil,
-              updatedAt: nil)
+              self.init(title: title,
+                done: done,
+                todo: todo,
+                time: time,
+                createdOn: createdOn,
+                createdAt: nil,
+                updatedAt: nil)
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
@@ -646,11 +640,10 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(title: String,
                 editors: List<PostEditor>? = []) {
-              self.init(,
-              title: title,
-              editors: editors,
-              createdAt: nil,
-              updatedAt: nil)
+              self.init(title: title,
+                editors: editors,
+                createdAt: nil,
+                updatedAt: nil)
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
@@ -716,11 +709,10 @@ describe('AppSyncSwiftVisitor', () => {
             
             public init(title: String,
                 editors: List<PostEditor>? = []) {
-              self.init(,
-              title: title,
-              editors: editors,
-              createdAt: nil,
-              updatedAt: nil)
+              self.init(title: title,
+                editors: editors,
+                createdAt: nil,
+                updatedAt: nil)
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
@@ -813,15 +805,14 @@ describe('AppSyncSwiftVisitor', () => {
             boolArr: [Bool]? = [],
             dateArr: [Temporal.Date]? = [],
             enumArr: [EnumType]? = []) {
-          self.init(,
-          intArr: intArr,
-          strArr: strArr,
-          floatArr: floatArr,
-          boolArr: boolArr,
-          dateArr: dateArr,
-          enumArr: enumArr,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(intArr: intArr,
+            strArr: strArr,
+            floatArr: floatArr,
+            boolArr: boolArr,
+            dateArr: dateArr,
+            enumArr: enumArr,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             intArr: [Int]? = [],
@@ -935,15 +926,14 @@ describe('AppSyncSwiftVisitor', () => {
             status: Status,
             statusHistory: [Status]? = [],
             tags: [String]? = []) {
-          self.init(,
-          name: name,
-          location: location,
-          nearByLocations: nearByLocations,
-          status: status,
-          statusHistory: statusHistory,
-          tags: tags,
-          createdAt: nil,
-          updatedAt: nil)
+          self.init(name: name,
+            location: location,
+            nearByLocations: nearByLocations,
+            status: status,
+            statusHistory: statusHistory,
+            tags: tags,
+            createdAt: nil,
+            updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
             name: String,
@@ -1176,13 +1166,12 @@ describe('AppSyncSwiftVisitor', () => {
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
               nonNullClasses: [\`Class\`] = []) {
-            self.init(,
-            Class: Class,
-            nonNullClass: nonNullClass,
-            classes: classes,
-            nonNullClasses: nonNullClasses,
-            createdAt: nil,
-            updatedAt: nil)
+            self.init(\`Class\`: \`Class\`,
+              nonNullClass: nonNullClass,
+              classes: classes,
+              nonNullClasses: nonNullClasses,
+              createdAt: nil,
+              updatedAt: nil)
           }
           internal init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -44,7 +44,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(name: String? = nil,
+        public init(id: String = UUID().uuidString,
+            name: String? = nil,
             bar: String? = nil) {
           self.init(id: id,
             name: name,
@@ -153,7 +154,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(name: String? = nil) {
+        public init(id: String = UUID().uuidString,
+            name: String? = nil) {
           self.init(id: id,
             name: name,
             createdAt: nil,
@@ -227,7 +229,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(first_name: String? = nil) {
+        public init(id: String = UUID().uuidString,
+            first_name: String? = nil) {
           self.init(id: id,
             first_name: first_name,
             createdAt: nil,
@@ -272,7 +275,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(author_id: String,
+        public init(id: String = UUID().uuidString,
+            author_id: String,
             book_id: String,
             author: String? = nil,
             book: String? = nil) {
@@ -386,7 +390,8 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(title: String,
+            public init(id: String = UUID().uuidString,
+                title: String,
                 done: Bool,
                 description: String? = nil,
                 due_date: String? = nil,
@@ -493,7 +498,8 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(title: String,
+            public init(id: String = UUID().uuidString,
+                title: String,
                 done: Bool,
                 todo: Todo? = nil,
                 time: Temporal.Time? = nil,
@@ -644,7 +650,8 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(title: String,
+            public init(id: String = UUID().uuidString,
+                title: String,
                 editors: List<PostEditor>? = []) {
               self.init(id: id,
                 title: title,
@@ -714,7 +721,8 @@ describe('AppSyncSwiftVisitor', () => {
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
-            public init(title: String,
+            public init(id: String = UUID().uuidString,
+                title: String,
                 editors: List<PostEditor>? = []) {
               self.init(id: id,
                 title: title,
@@ -807,7 +815,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(intArr: [Int]? = [],
+        public init(id: String = UUID().uuidString,
+            intArr: [Int]? = [],
             strArr: [String]? = [],
             floatArr: [Double]? = [],
             boolArr: [Bool]? = [],
@@ -929,7 +938,8 @@ describe('AppSyncSwiftVisitor', () => {
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
-        public init(name: String,
+        public init(id: String = UUID().uuidString,
+            name: String,
             location: Location,
             nearByLocations: [Location]? = [],
             status: Status,
@@ -1172,7 +1182,8 @@ describe('AppSyncSwiftVisitor', () => {
           public var createdAt: Temporal.DateTime?
           public var updatedAt: Temporal.DateTime?
           
-          public init(\`Class\`: \`Class\`? = nil,
+          public init(id: String = UUID().uuidString,
+              \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
               classes: [\`Class\`]? = [],
               nonNullClasses: [\`Class\`] = []) {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -10,7 +10,11 @@ const buildSchemaWithDirectives = (schema: String) => {
 const createAndGenerateVisitor = (schema: string) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
-  const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'general' }, { generate: CodeGenGenerateEnum.code });
+  const visitor = new AppSyncModelVisitor(
+    builtSchema,
+    { directives, target: 'general', isTimestampFieldsAdded: true },
+    { generate: CodeGenGenerateEnum.code },
+  );
   visit(ast, { leave: visitor });
   visitor.generate();
   return visitor;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -575,5 +575,36 @@ describe('AppSyncModelVisitor', () => {
       const updatedAtField = postFields.find(field => field.name === 'updatedAt');
       expect(updatedAtField).toMatchObject(updatedAtFieldObj);
     });
+    it('should not override original fields if users define them explicitly in schema and use timestamps params in @model', () => {
+      const schema = /* GraphQL */ `
+        type Post 
+          @model(timestamps: {createdAt: "createdOn", updatedAt: "updatedOn"})
+        {
+          id: ID!
+          createdOn: AWSDateTime!
+          updatedOn: AWSDateTime!
+        }
+      `;
+      const createdAtFieldObj = {
+        name: 'createdOn',
+        type: 'AWSDateTime',
+        isList: false,
+        isNullable: false,
+      };
+      const updatedAtFieldObj = {
+        name: 'updatedOn',
+        type: 'AWSDateTime',
+        isList: false,
+        isNullable: false,
+      };
+      const visitor = createAndGenerateVisitor(schema);
+      expect(visitor.models.Post).toBeDefined();
+
+      const postFields = visitor.models.Post.fields;
+      const createdAtField = postFields.find(field => field.name === 'createdOn');
+      expect(createdAtField).toMatchObject(createdAtFieldObj);
+      const updatedAtField = postFields.find(field => field.name === 'updatedOn');
+      expect(updatedAtField).toMatchObject(updatedAtFieldObj);
+    });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -546,7 +546,7 @@ describe('AppSyncModelVisitor', () => {
       const updatedAtField = postFields.find(field => field.name === 'updatedOn');
       expect(updatedAtField).toMatchObject(updatedAtFieldObj);
     });
-    it('should not override original fields if user define them explicitly in schema except for update', () => {
+    it('should not override original fields if user define them explicitly in schema', () => {
       const schema = /* GraphQL */ `
         type Post @model {
           id: ID!
@@ -564,8 +564,7 @@ describe('AppSyncModelVisitor', () => {
         name: 'updatedAt',
         type: 'AWSDateTime',
         isList: false,
-        isNullable: true,
-        isReadOnly: true,
+        isNullable: false,
       };
       const visitor = createAndGenerateVisitor(schema);
       expect(visitor.models.Post).toBeDefined();
@@ -595,8 +594,7 @@ describe('AppSyncModelVisitor', () => {
         name: 'updatedOn',
         type: 'AWSDateTime',
         isList: false,
-        isNullable: true,
-        isReadOnly: true,
+        isNullable: false,
       };
       const visitor = createAndGenerateVisitor(schema);
       expect(visitor.models.Post).toBeDefined();

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -115,7 +115,7 @@ export enum ListType {
   ARRAY = 'ARRAY',
   LIST = 'LIST',
 }
-export type Access = 'private' | 'public' | 'DEFAULT';
+export type Access = 'private' | 'public' | 'internal' | 'DEFAULT';
 export type VariableFlags = {
   isList?: boolean;
   listType?: ListType;

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -3,7 +3,12 @@
 // prettier-ignore
 export const directives = /* GraphQL */ `
   # model directive
-  directive @model(queries: ModelQueryMap, mutations: ModelMutationMap, subscriptions: ModelSubscriptionMap) on OBJECT
+  directive @model(
+    queries: ModelQueryMap
+    mutations: ModelMutationMap
+    subscriptions: ModelSubscriptionMap
+    timestamps: TimestampConfiguration
+  ) on OBJECT
   input ModelMutationMap {
     create: String
     update: String
@@ -23,6 +28,10 @@ export const directives = /* GraphQL */ `
     off
     public
     on
+  }
+  input TimestampConfiguration {
+    createdAt: String
+    updatedAt: String
   }
 
   # Key directive

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -182,8 +182,9 @@ export class AppSyncModelJavaVisitor<
 
     const queryFields = this.getWritableField(model);
     queryFields.forEach(field => this.generateQueryFields(model, field, classDeclarationBlock));
+    const nonConnectedFields = this.getNonConnectedField(model);
     model.fields.forEach(field => {
-      const value = queryFields.includes(field) ? '' : 'null';
+      const value = nonConnectedFields.includes(field) ? '' : 'null';
       this.generateModelField(field, value, classDeclarationBlock);
     });
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -180,7 +180,7 @@ export class AppSyncModelJavaVisitor<
     const annotations = this.generateModelAnnotations(model);
     classDeclarationBlock.annotate(annotations);
 
-    const queryFields = this.getWritableField(model);
+    const queryFields = this.getWritableFields(model);
     queryFields.forEach(field => this.generateQueryFields(model, field, classDeclarationBlock));
     const nonConnectedFields = this.getNonConnectedField(model);
     model.fields.forEach(field => {
@@ -337,8 +337,8 @@ export class AppSyncModelJavaVisitor<
    *
    */
   protected generateStepBuilderInterfaces(model: CodeGenModel, isModel: boolean = true): JavaDeclarationBlock[] {
-    const nonNullableFields = this.getWritableField(model).filter(field => !field.isNullable);
-    const nullableFields = this.getWritableField(model).filter(field => field.isNullable);
+    const nonNullableFields = this.getWritableFields(model).filter(field => !field.isNullable);
+    const nullableFields = this.getWritableFields(model).filter(field => field.isNullable);
     const requiredInterfaces = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const interfaces = requiredInterfaces.map((field, idx) => {
       const isLastField = requiredInterfaces.length - 1 === idx ? true : false;
@@ -385,8 +385,8 @@ export class AppSyncModelJavaVisitor<
    * @returns JavaDeclarationBlock
    */
   protected generateBuilderClass(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isModel: boolean = true): void {
-    const nonNullableFields = this.getWritableField(model).filter(field => !field.isNullable);
-    const nullableFields = this.getWritableField(model).filter(field => field.isNullable);
+    const nonNullableFields = this.getWritableFields(model).filter(field => !field.isNullable);
+    const nullableFields = this.getWritableFields(model).filter(field => field.isNullable);
     const stepFields = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const stepInterfaces = stepFields.map((field: CodeGenField) => this.getStepInterfaceName(field.name));
 
@@ -406,7 +406,7 @@ export class AppSyncModelJavaVisitor<
     // methods
     // build();
     const buildImplementation = isModel ? [`String id = this.id != null ? this.id : UUID.randomUUID().toString();`, ''] : [''];
-    const buildParams = this.getWritableField(model)
+    const buildParams = this.getWritableFields(model)
       .map(field => this.getFieldName(field))
       .join(',\n');
     buildImplementation.push(`return new ${this.getModelName(model)}(\n${indentMultiline(buildParams)});`);
@@ -513,13 +513,13 @@ export class AppSyncModelJavaVisitor<
       .withName(builderName)
       .extends(['Builder']);
 
-    const nonNullableFields = this.getWritableField(model)
+    const nonNullableFields = this.getWritableFields(model)
       .filter(field => !field.isNullable)
       .filter(f => (isModel ? f.name !== 'id' : true));
-    const nullableFields = this.getWritableField(model).filter(field => field.isNullable);
+    const nullableFields = this.getWritableFields(model).filter(field => field.isNullable);
 
     // constructor
-    const constructorArguments = this.getWritableField(model).map(field => ({ name: this.getStepFunctionArgumentName(field), type: this.getNativeType(field) }));
+    const constructorArguments = this.getWritableFields(model).map(field => ({ name: this.getStepFunctionArgumentName(field), type: this.getNativeType(field) }));
     const stepBuilderInvocation = [...nonNullableFields, ...nullableFields].map(field => {
       const methodName = this.getStepFunctionName(field);
       const argumentName = this.getStepFunctionArgumentName(field);
@@ -560,7 +560,7 @@ export class AppSyncModelJavaVisitor<
    */
   protected generateCopyOfBuilderMethod(model: CodeGenModel, classDeclaration: JavaDeclarationBlock): void {
     const args = indentMultiline(
-      this.getWritableField(model)
+      this.getWritableFields(model)
         .map(field => this.getFieldName(field))
         .join(',\n'),
     ).trim();
@@ -615,14 +615,14 @@ export class AppSyncModelJavaVisitor<
    */
   protected generateConstructor(model: CodeGenModel, declarationsBlock: JavaDeclarationBlock): void {
     const name = this.getModelName(model);
-    const body = this.getWritableField(model)
+    const body = this.getWritableFields(model)
       .map((field: CodeGenField) => {
         const fieldName = this.getFieldName(field);
         return `this.${fieldName} = ${fieldName};`;
       })
       .join('\n');
 
-    const constructorArguments = this.getWritableField(model).map(field => ({ name: this.getFieldName(field), type: this.getNativeType(field) }));
+    const constructorArguments = this.getWritableFields(model).map(field => ({ name: this.getFieldName(field), type: this.getNativeType(field) }));
     declarationsBlock.addClassMethod(name, null, body, constructorArguments, undefined, 'private');
   }
 
@@ -720,7 +720,7 @@ export class AppSyncModelJavaVisitor<
    * @param classDeclaration
    */
   protected generateBuilderMethod(model: CodeGenModel, classDeclaration: JavaDeclarationBlock): void {
-    const requiredFields = this.getWritableField(model).filter(
+    const requiredFields = this.getWritableFields(model).filter(
       field => !field.isNullable && !this.READ_ONLY_FIELDS.includes(field.name),
     );
     const returnType = requiredFields.length ? this.getStepInterfaceName(requiredFields[0].name) : this.getStepInterfaceName('Build');
@@ -886,7 +886,7 @@ export class AppSyncModelJavaVisitor<
               "creating a new object, use the standard builder method and leave the ID field blank."
       );
     }`;
-    const initArgs = indentMultiline(['id', ...new Array(this.getWritableField(model).length - 1).fill('null')].join(',\n'));
+    const initArgs = indentMultiline(['id', ...new Array(this.getWritableFields(model).length - 1).fill('null')].join(',\n'));
     const initBlock = `return new ${returnType}(\n${initArgs}\n);`;
     classDeclaration.addClassMethod(
       'justId',
@@ -915,7 +915,7 @@ export class AppSyncModelJavaVisitor<
     });
   }
 
-  protected getWritableField(model: CodeGenModel): CodeGenField[] {
+  protected getWritableFields(model: CodeGenModel): CodeGenField[] {
     return this.getNonConnectedField(model).filter(f => !f.isReadOnly);
   }
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -64,6 +64,7 @@ type JSONModelField = {
   isArray: boolean;
   isRequired?: boolean;
   isArrayNullable?: boolean;
+  isReadOnly?: boolean;
   attributes?: JSONModelFieldAttributes;
   association?: AssociationType;
 };
@@ -210,6 +211,10 @@ export class AppSyncJSONVisitor<
 
         if (field.isListNullable !== undefined) {
           fieldMeta.isArrayNullable = field.isListNullable;
+        }
+
+        if (field.isReadOnly !== undefined) {
+          fieldMeta.isReadOnly = field.isReadOnly;
         }
 
         const association: AssociationType | void = this.getFieldAssociation(field);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -49,7 +49,6 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
       const initParams: CodeGenField[] = this.getWritableFields(obj);
       const initImpl: string = `self.init(${indentMultiline(
         obj.fields
-          .filter(f => f.name !== 'id')
           .map(field => {
             const fieldName = escapeKeywords(this.getFieldName(field));
             return field.isReadOnly ? `${fieldName}: nil` : `${fieldName}: ${fieldName}`;
@@ -66,7 +65,7 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
           return {
             name: this.getFieldName(field),
             type: this.getNativeType(field),
-            value: undefined,
+            value: field.name === 'id' ? 'UUID().uuidString' : undefined,
             flags: {
               optional: field.isNullable,
               isList: field.isList,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -47,14 +47,15 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
         });
       });
       const initParams: CodeGenField[] = this.getWritableFields(obj);
-      const initImpl: string = `self.init(${obj.fields
-        .map(field => {
-          const fieldName = this.getFieldName(field);
-          if (field.name !== 'id') {
+      const initImpl: string = `self.init(${indentMultiline(
+        obj.fields
+          .filter(f => f.name !== 'id')
+          .map(field => {
+            const fieldName = escapeKeywords(this.getFieldName(field));
             return field.isReadOnly ? `${fieldName}: nil` : `${fieldName}: ${fieldName}`;
-          }
-        })
-        .join(',\n')})`;
+          })
+          .join(',\n'),
+      ).trim()})`;
       //public constructor
       structBlock.addClassMethod(
         'init',

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -384,6 +384,6 @@ export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
   }
 
   protected getWritableFields(model: CodeGenModel): CodeGenField[] {
-    return model.fields.filter(f => f.name !== 'id' && !f.isReadOnly);
+    return model.fields.filter(f => !f.isReadOnly);
   }
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -4,11 +4,21 @@ import { lowerCaseFirst } from 'lower-case-first';
 import { schemaTypeMap } from '../configs/swift-config';
 import { SwiftDeclarationBlock, escapeKeywords, ListType } from '../languages/swift-declaration-block';
 import { CodeGenConnectionType } from '../utils/process-connections';
-import { AppSyncModelVisitor, CodeGenField, CodeGenGenerateEnum, CodeGenModel } from './appsync-visitor';
+import {
+  AppSyncModelVisitor,
+  CodeGenField,
+  CodeGenGenerateEnum,
+  CodeGenModel,
+  RawAppSyncModelConfig,
+  ParsedAppSyncModelConfig,
+} from './appsync-visitor';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 
-export class AppSyncSwiftVisitor extends AppSyncModelVisitor {
+export class AppSyncSwiftVisitor<
+  TRawConfig extends RawAppSyncModelConfig = RawAppSyncModelConfig,
+  TPluginConfig extends ParsedAppSyncModelConfig = ParsedAppSyncModelConfig
+> extends AppSyncModelVisitor<TRawConfig, TPluginConfig> {
   protected modelExtensionImports: string[] = ['import Amplify', 'import Foundation'];
   protected imports: string[] = ['import Amplify', 'import Foundation'];
   generate(): string {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -102,6 +102,7 @@ export interface RawAppSyncModelConfig extends RawConfig {
 export interface ParsedAppSyncModelConfig extends ParsedConfig {
   selectedType?: string;
   generate?: CodeGenGenerateEnum;
+  target?: string;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -166,6 +167,7 @@ export class AppSyncModelVisitor<
     super(rawConfig, {
       ...additionalConfig,
       scalars: buildScalars(_schema, rawConfig.scalars || '', defaultScalars),
+      target: rawConfig.target,
     });
 
     const typesUsedInDirectives: string[] = [];
@@ -510,6 +512,10 @@ export class AppSyncModelVisitor<
    * @param model
    */
   protected addTimestampFields(model: CodeGenModel, directive: CodeGenDirective): void {
+    const target = this.config.target;
+    if (target === 'javascript' || target === 'dart') {
+      return;
+    }
     if (directive.name !== 'model') {
       return;
     }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -115,7 +115,7 @@ export type CodeGenField = TypeInfo & {
   name: string;
   directives: CodeGenDirectives;
   connectionInfo?: CodeGenFieldConnection;
-  isReadOnly?: boolean
+  isReadOnly?: boolean;
 };
 export type TypeInfo = {
   type: string;
@@ -505,7 +505,7 @@ export class AppSyncModelVisitor<
     return plural(model.name);
   }
 
-    /**
+  /**
    * Add timestamp fields createdAt, updatedAt(or equivalent fields) to model fields
    * @param model
    */
@@ -520,7 +520,7 @@ export class AppSyncModelVisitor<
       type: 'AWSDateTime',
       isList: false,
       isNullable: true,
-      isReadOnly: true
+      isReadOnly: true,
     };
     const updatedAtField: CodeGenField = {
       name: timestamps?.updatedAt || DEFAULT_UPDATED_TIME,
@@ -528,9 +528,11 @@ export class AppSyncModelVisitor<
       type: 'AWSDateTime',
       isList: false,
       isNullable: true,
-      isReadOnly: true
+      isReadOnly: true,
     };
     addFieldToModel(model, createdAtField);
+    //updated field will always be override
+    removeFieldFromModel(model, updatedAtField.name);
     addFieldToModel(model, updatedAtField);
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -96,6 +96,12 @@ export interface RawAppSyncModelConfig extends RawConfig {
    * @descriptions optional string which includes directive definition and types used by directives. The types defined in here won't make it to output
    */
   directives?: string;
+  /**
+   * @name directives
+   * @type boolean
+   * @descriptions optional boolean which adds the read-only timestamp fields or not
+   */
+  isTimestampFieldsAdded?: boolean;
 }
 
 // Todo: need to figure out how to share config
@@ -103,6 +109,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   selectedType?: string;
   generate?: CodeGenGenerateEnum;
   target?: string;
+  isTimestampFieldsAdded?: boolean;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -168,6 +175,7 @@ export class AppSyncModelVisitor<
       ...additionalConfig,
       scalars: buildScalars(_schema, rawConfig.scalars || '', defaultScalars),
       target: rawConfig.target,
+      isTimestampFieldsAdded: rawConfig.isTimestampFieldsAdded,
     });
 
     const typesUsedInDirectives: string[] = [];
@@ -512,6 +520,9 @@ export class AppSyncModelVisitor<
    * @param model
    */
   protected addTimestampFields(model: CodeGenModel, directive: CodeGenDirective): void {
+    if (!this.config.isTimestampFieldsAdded) {
+      return;
+    }
     const target = this.config.target;
     if (target === 'javascript' || target === 'dart' || target === 'metadata') {
       return;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -216,32 +216,7 @@ export class AppSyncModelVisitor<
       this.nonModelMap[node.name.value] = nonModel;
     }
   }
-  /**
-   * Add timestamp fields createdAt, updatedAt(or equivalent fields) to model fields
-   * @param model
-   */
-  protected addTimestampFields(model: CodeGenModel, directive: CodeGenDirective): void {
-    if (directive.name !== 'model') {
-      return;
-    }
-    const timestamps = directive.arguments.timestamps;
-    const createdAtField: CodeGenField = {
-      name: timestamps?.createdAt || DEFAULT_CREATED_TIME,
-      directives: [],
-      type: 'AWSDateTime',
-      isList: false,
-      isNullable: true,
-    };
-    const updatedAtField: CodeGenField = {
-      name: timestamps?.updatedAt || DEFAULT_UPDATED_TIME,
-      directives: [],
-      type: 'AWSDateTime',
-      isList: false,
-      isNullable: true
-    };
-    addFieldToModel(model, createdAtField);
-    addFieldToModel(model, updatedAtField);
-  }
+
   FieldDefinition(node: FieldDefinitionNode): CodeGenField {
     const directive = this.getDirectives(node.directives);
     return {
@@ -527,6 +502,33 @@ export class AppSyncModelVisitor<
 
   protected pluralizeModelName(model: CodeGenModel): string {
     return plural(model.name);
+  }
+
+    /**
+   * Add timestamp fields createdAt, updatedAt(or equivalent fields) to model fields
+   * @param model
+   */
+  protected addTimestampFields(model: CodeGenModel, directive: CodeGenDirective): void {
+    if (directive.name !== 'model') {
+      return;
+    }
+    const timestamps = directive.arguments.timestamps;
+    const createdAtField: CodeGenField = {
+      name: timestamps?.createdAt || DEFAULT_CREATED_TIME,
+      directives: [],
+      type: 'AWSDateTime',
+      isList: false,
+      isNullable: true,
+    };
+    const updatedAtField: CodeGenField = {
+      name: timestamps?.updatedAt || DEFAULT_UPDATED_TIME,
+      directives: [],
+      type: 'AWSDateTime',
+      isList: false,
+      isNullable: true
+    };
+    addFieldToModel(model, createdAtField);
+    addFieldToModel(model, updatedAtField);
   }
 
   get models() {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -524,7 +524,7 @@ export class AppSyncModelVisitor<
       return;
     }
     const target = this.config.target;
-    if (target === 'javascript' || target === 'dart' || target === 'metadata') {
+    if (target === 'dart') {
       return;
     }
     if (directive.name !== 'model') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -513,7 +513,7 @@ export class AppSyncModelVisitor<
    */
   protected addTimestampFields(model: CodeGenModel, directive: CodeGenDirective): void {
     const target = this.config.target;
-    if (target === 'javascript' || target === 'dart') {
+    if (target === 'javascript' || target === 'dart' || target === 'metadata') {
       return;
     }
     if (directive.name !== 'model') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -115,6 +115,7 @@ export type CodeGenField = TypeInfo & {
   name: string;
   directives: CodeGenDirectives;
   connectionInfo?: CodeGenFieldConnection;
+  isReadOnly?: boolean
 };
 export type TypeInfo = {
   type: string;
@@ -519,13 +520,15 @@ export class AppSyncModelVisitor<
       type: 'AWSDateTime',
       isList: false,
       isNullable: true,
+      isReadOnly: true
     };
     const updatedAtField: CodeGenField = {
       name: timestamps?.updatedAt || DEFAULT_UPDATED_TIME,
       directives: [],
       type: 'AWSDateTime',
       isList: false,
-      isNullable: true
+      isNullable: true,
+      isReadOnly: true
     };
     addFieldToModel(model, createdAtField);
     addFieldToModel(model, updatedAtField);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -536,9 +536,8 @@ export class AppSyncModelVisitor<
       isNullable: true,
       isReadOnly: true,
     };
+    //If the field is defined explicitly, the default value will not override
     addFieldToModel(model, createdAtField);
-    //updated field will always be override
-    removeFieldFromModel(model, updatedAtField.name);
     addFieldToModel(model, updatedAtField);
   }
 


### PR DESCRIPTION
_Issue #, if available:_
fix #112 
_Description of changes:_
Add timestamps fields `createdAt` and `updatedAt` as read-only fields in codegen output for graphql types with `@model`. This is achieved by adding a new metadata `isReadOnly: boolean` in `CodeGenField`. This change is applied to all platforms except for flutter.

The feature will be released behind a feature flag of CLI. Refer https://github.com/aws-amplify/amplify-cli/pull/7273
```TypeScript
export type CodeGenField = TypeInfo & {
  name: string;
  directives: CodeGenDirectives;
  connectionInfo?: CodeGenFieldConnection;
  isReadOnly?: boolean // ---> new metadata
};
```
Related PR from libraries:
Android : https://github.com/aws-amplify/amplify-android/pull/1249
iOS: https://github.com/aws-amplify/amplify-ios/pull/1133

### Implicit schema
Since they are read-only and auto-generated, we suggest to use implicit schema. The timestamp fields are automatically added to modelgen output as an optional type.
1. Simple @model
```GraphQL
type Post @model {
  id: ID!
}
```
2. Use `timestamps` field in @model for implicit schema
You can also use `timestamps` field in @model to change the default timestamp field name. This will add the desired name as optional `AWSDateTime` fields.
```GraphQL
type Post @model(timestamps:{createdAt: "createdOn", updatedAt:"updatedOn"} {
  id: ID!
}
```
### Explicit schema (read-only disabled)
You can also include `createdAt`, `updatedAt`  in the schema field explicitly. However, the timestamp field will be **no longer read-only**. 
```GraphQL
type Post @model {
  id: ID!
  createdAt: AWSDateTime
  updatedAt: AWSDateTime
}
```
This behavior conforms to the fact that graphql transformer will include timestamp fields in input variables in explict schema. 

_How are these changes tested:_
`yarn test`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
