### PR TITLE
feat(amplify-codegen): Add Amplify CLI version as a comment for the Modelgen output files

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -58,7 +58,7 @@ async function generateModels(context) {
     schema,
     config: {
       target: platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend,
-      directives: directiveDefinitions,
+      directives: directiveDefinitions
     },
   });
 
@@ -87,7 +87,8 @@ async function generateModels(context) {
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;
     fs.ensureFileSync(outPutPath);
-    fs.writeFileSync(outPutPath, generatedCode[idx]);
+    const contentToWrite = [getAmplifyCLIVersionComment(context), generatedCode[idx]].join('\n\n');
+    fs.writeFileSync(outPutPath, contentToWrite);
   });
 
   generateEslintIgnore(context);
@@ -143,6 +144,13 @@ function getModelOutputPath(context) {
     default:
       return '.';
   }
+}
+
+function getAmplifyCLIVersionComment(context) {
+  if (context.usageData == null || !context.usageData.version) {
+    return null
+  }
+  return '// Generated using Amplify CLI version: ' + context.usageData.version;
 }
 
 function generateEslintIgnore(context) {

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -150,7 +150,7 @@ function getAmplifyCLIVersionComment(context) {
   if (context.usageData == null || !context.usageData.version) {
     return null
   }
-  return '// Generated using Amplify CLI version: ' + context.usageData.version;
+  return 'Generated using amplify-cli-version: ' + context.usageData.version;
 }
 
 function generateEslintIgnore(context) {

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -78,18 +78,10 @@ async function generateModels(context) {
 
   const generatedCode = await Promise.all(codeGenPromises);
 
-  // clean the output directory before re-generating models
-  // const cleanOutputPath = FeatureFlags.getBoolean('codegen.cleanGeneratedModelsDirectory');
-  // if (cleanOutputPath) {
-  //   await fs.emptyDir(outputPath);
-  // }
-
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;
     fs.ensureFileSync(outPutPath);
-    const contentsToWrite = [getVersionsMetadataComment(context), generatedCode[idx]].filter(function (content) {
-      return content != null;
-    });
+    const contentsToWrite = [getVersionsMetadataComment(context), generatedCode[idx]].filter(content => content);
     const contentToWrite = contentsToWrite.join('\n\n');
     fs.writeFileSync(outPutPath, contentToWrite);
   });
@@ -158,9 +150,7 @@ function getVersionsMetadataComment(context) {
 
   const codegenPluginsInfo = context?.pluginPlatform?.plugins?.codegen;
   if (codegenPluginsInfo && codegenPluginsInfo.length > 0) {
-    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(function(plugin) {
-      return plugin.packageName == 'amplify-codegen';
-    });
+    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(plugin => plugin.packageName == 'amplify-codegen');
     if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
       versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);
     }

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -138,7 +138,7 @@ describe('command-models adds Amplify CLI version comment', () => {
         fs.readdirSync(outputDirectory).forEach(filename => {
           const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
           // assert version is appended to each of the generated files
-          expect(data === '// Generated using Amplify CLI version: 0.0.0\n\nThis code is auto-generated!');
+          expect(data === '// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
         });
     });
 

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -5,24 +5,6 @@ const fs = require('fs');
 const path = require('path');
 
 jest.mock('@graphql-codegen/core');
-const MOCK_CONTEXT = {
-  print: {
-    info: jest.fn(),
-  },
-  amplify: {
-    getProjectMeta: jest.fn(),
-    getEnvInfo: jest.fn(),
-    getResourceStatus: jest.fn(),
-    executeProviderUtils: jest.fn(),
-    pathManager: {
-        getBackendDirPath: jest.fn()
-    },
-    getProjectConfig: jest.fn()
-  },
-  usageData: {
-    version: '0.0.0'
-  }
-};
 const OUTPUT_PATHS = {
     javascript: 'src/models',
     android: 'app/src/main/java/com/amplifyframework/datastore/generated/model',
@@ -54,7 +36,6 @@ jest.mock('amplify-cli-core', (MOCK_PROJECT_ROOT) => {
 describe('command-models-generates models in expected output path', () => {
     beforeEach(() => {
       jest.resetAllMocks();
-      addMocksToContext();
       graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
     });
 
@@ -68,13 +49,14 @@ describe('command-models-generates models in expected output path', () => {
                 'schema.graphql': ' type SimpleModel { id: ID! status: String } '
             };
             mockedFiles[outputDirectory] = {};
+            const context = createMockContext();
+            addMocksToContext(context, frontend);
             mockFs(mockedFiles);
-            MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
 
             // assert empty folder before generation
             expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-            await generateModels(MOCK_CONTEXT);
+            await generateModels(context);
 
             // assert model generation succeeds with a single schema file
             expect(graphqlCodegen.codegen).toBeCalled();
@@ -93,12 +75,13 @@ describe('command-models-generates models in expected output path', () => {
             };
             mockedFiles[outputDirectory] = {}
             mockFs(mockedFiles);
-            MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+            const context = createMockContext();
+            addMocksToContext(context, frontend);
 
             // assert empty folder before generation
             expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-            await generateModels(MOCK_CONTEXT);
+            await generateModels(context);
 
             // assert model generation succeeds with a single schema file
             expect(graphqlCodegen.codegen).toBeCalled();
@@ -114,20 +97,20 @@ describe('command-models-generates models in expected output path', () => {
 describe('command-models adds Amplify CLI version comment', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    addMocksToContext();
     graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
   });
 
   for (const frontend in OUTPUT_PATHS) {
-    it(frontend + ': Should append cli version comment to generated files', async () => {
+    it(frontend + ': Should append version metadata comment to generated files', async () => {
         const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
         createMockFS(outputDirectory);
-        MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-
+        const context = createMockContext();
+        addMocksToContext(context, frontend);
+        
         // assert empty folder before generation
         expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-        await generateModels(MOCK_CONTEXT);
+        await generateModels(context);
 
         // assert model generation succeeds with a single schema file
         expect(graphqlCodegen.codegen).toBeCalled();
@@ -138,20 +121,22 @@ describe('command-models adds Amplify CLI version comment', () => {
         fs.readdirSync(outputDirectory).forEach(filename => {
           const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
           // assert version is appended to each of the generated files
-          expect(data === '// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
+          expect(data).toEqual('// Generated using amplify-cli-version: 0.0.0, amplify-codegen-version: 100.100.100\n\nThis code is auto-generated!');
         });
     });
 
-    it(frontend + ': Should not break codegen if cli version is not available', async () => {
+    it(frontend + ': Should not break codegen if no version metadata is available', async () => {
       const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
       createMockFS(outputDirectory);
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-      MOCK_CONTEXT.usageData = null;
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.usageData = null;
+      context.pluginPlatform = null;
 
       // assert empty folder before generation
       expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-      await generateModels(MOCK_CONTEXT);
+      await generateModels(context);
 
       // assert model generation succeeds with a single schema file
       expect(graphqlCodegen.codegen).toBeCalled();
@@ -162,20 +147,21 @@ describe('command-models adds Amplify CLI version comment', () => {
       fs.readdirSync(outputDirectory).forEach(filename => {
         const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
         // assert version is not appended to any of the generated files
-        expect(data === 'This code is auto-generated!');
+        expect(data).toEqual('This code is auto-generated!');
       });
     });
 
     it(frontend + ': Handle empty cli version string', async () => {
       const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
       createMockFS(outputDirectory);
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-      MOCK_CONTEXT.usageData = {version: ''};
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.usageData = {version: ''};
 
       // assert empty folder before generation
       expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-      await generateModels(MOCK_CONTEXT);
+      await generateModels(context);
 
       // assert model generation succeeds with a single schema file
       expect(graphqlCodegen.codegen).toBeCalled();
@@ -186,20 +172,21 @@ describe('command-models adds Amplify CLI version comment', () => {
       fs.readdirSync(outputDirectory).forEach(filename => {
         const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
         // assert version is not appended to any of the generated files
-        expect(data === 'This code is auto-generated!');
+        expect(data).toEqual('// Generated using amplify-codegen-version: 100.100.100\n\nThis code is auto-generated!');
       });
     });
 
     it(frontend + ': Handle undefined cli version string', async () => {
       const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
       createMockFS(outputDirectory);
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-      MOCK_CONTEXT.usageData = {version: undefined};
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.usageData = {version: undefined};
 
       // assert empty folder before generation
       expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-      await generateModels(MOCK_CONTEXT);
+      await generateModels(context);
 
       // assert model generation succeeds with a single schema file
       expect(graphqlCodegen.codegen).toBeCalled();
@@ -210,7 +197,90 @@ describe('command-models adds Amplify CLI version comment', () => {
       fs.readdirSync(outputDirectory).forEach(filename => {
         const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
         // assert version is not appended to any of the generated files
-        expect(data === 'This code is auto-generated!');
+        expect(data).toEqual('// Generated using amplify-codegen-version: 100.100.100\n\nThis code is auto-generated!');
+      });
+    });
+
+    it(frontend + ': Handle empty codegen version string', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.pluginPlatform.plugins.codegen = {
+        packageName: 'amplify-codegen',
+        packageVersion: '',
+        packageLocation: '/path/to/global/node/modules'
+      };
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(context);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data).toEqual('// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
+      });
+    });
+
+    it(frontend + ': Handle undefined codegen version string', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.pluginPlatform.plugins.codegen = {
+        packageName: 'amplify-codegen',
+        packageVersion: undefined,
+        packageLocation: '/path/to/global/node/modules'
+      };
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(context);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data).toEqual('// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
+      });
+    });
+
+    it(frontend + ': Handle empty codegen plugins array in context', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
+      context.pluginPlatform.plugins.codegen = [];
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(context);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data).toEqual('// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
       });
     });
 
@@ -316,10 +386,9 @@ describe('codegen models respects cleanGeneratedModelsDirectory', () => {
 */
 
 // Add models generation specific mocks to Amplify Context
-
-function addMocksToContext() {
-  MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({projectPath: MOCK_PROJECT_ROOT});
-  MOCK_CONTEXT.amplify.getResourceStatus.mockReturnValue(
+function addMocksToContext(context, frontend) {
+  context.amplify.getEnvInfo.mockReturnValue({projectPath: MOCK_PROJECT_ROOT});
+  context.amplify.getResourceStatus.mockReturnValue(
         {
           allResources: [
               {
@@ -330,6 +399,41 @@ function addMocksToContext() {
             ]
         }
     );
-  MOCK_CONTEXT.amplify.executeProviderUtils.mockReturnValue([]);
-  MOCK_CONTEXT.amplify.pathManager.getBackendDirPath.mockReturnValue(MOCK_BACKEND_DIRECTORY);
+  context.amplify.executeProviderUtils.mockReturnValue([]);
+  context.amplify.pathManager.getBackendDirPath.mockReturnValue(MOCK_BACKEND_DIRECTORY);
+  context.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+}
+
+// Create a mock Amplify context which can be customized by each test
+function createMockContext() {
+  const MOCK_CONTEXT = {
+    print: {
+      info: jest.fn(),
+    },
+    amplify: {
+      getProjectMeta: jest.fn(),
+      getEnvInfo: jest.fn(),
+      getResourceStatus: jest.fn(),
+      executeProviderUtils: jest.fn(),
+      pathManager: {
+          getBackendDirPath: jest.fn()
+      },
+      getProjectConfig: jest.fn()
+    },
+    usageData: {
+      version: '0.0.0'
+    },
+    pluginPlatform: {
+      plugins: {
+        codegen: [
+          {
+            packageName: 'amplify-codegen',
+            packageVersion: '100.100.100',
+            packageLocation: '/path/to/global/node/modules'
+          }
+        ]
+      }
+    }
+  };
+  return MOCK_CONTEXT;
 }

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -15,7 +15,6 @@ const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PROJECT_NAME = 'myapp';
 const MOCK_BACKEND_DIRECTORY = 'backend';
 const MOCK_GENERATED_CODE = 'This code is auto-generated!';
-const MOCK_PRE_EXISTING_FILE = 'preexisting.txt';
 
 // Mock the Feature flag to use migrated moldegen
 jest.mock('amplify-cli-core', (MOCK_PROJECT_ROOT) => {
@@ -298,92 +297,6 @@ describe('command-models adds Amplify CLI version comment', () => {
 
   afterEach(mockFs.restore);
 });
-
-/*
-describe('codegen models respects cleanGeneratedModelsDirectory', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    addMocksToContext();
-    graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
-  });
- 
-  for (const frontend in OUTPUT_PATHS) {
-    it(frontend + ': Should clear the output directory before generation if cleanGeneratedModelsDirectory is true', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-          if (name === 'codegen.useappsyncmodelgenplugin' ||
-              name === 'codegen.cleanGeneratedModelsDirectory') {
-            return true;
-          }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
-
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
-
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
-
-      // assert that the pre-existing file is deleted
-      expect(fs.existsSync(preExistingFilePath)).toBeFalsy;
-    });
-
-    it(frontend + ': Should not clear the output directory before generation if cleanGeneratedModelsDirectory is false', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-          if (name === 'codegen.useappsyncmodelgenplugin') {
-            return true;
-          }
-          if (name === 'codegen.cleanGeneratedModelsDirectory') {
-              return false;
-          }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
- 
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
- 
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(1);
- 
-      // assert that the pre-existing file is retained
-      expect(fs.existsSync(preExistingFilePath)).toBeTruthy;
-    });
-  }
-
-  function createMockFS(outputDirectory) {
-    // mock the input and output file structure
-    const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
-    const mockedFiles = {};
-    mockedFiles[schemaFilePath] = {
-        'schema.graphql': ' type SimpleModel { id: ID! status: String } '
-    };
-    mockedFiles[outputDirectory] = {};
-    mockedFiles[outputDirectory][MOCK_PRE_EXISTING_FILE] = 'A pre-existing mock file';
-    mockFs(mockedFiles);
-  }
-  
-  afterEach(mockFs.restore);
-}); 
-*/
 
 // Add models generation specific mocks to Amplify Context
 function addMocksToContext(context, frontend) {


### PR DESCRIPTION
_Issue #, if available:
fix #90

_Description of changes:_
These changes add the Amplify CLI and Codegen versions used to generate the Datastore Model files as a comment. 
```
// Generated using amplify-cli-version: <version>, amplify-codegen-version: <version>
```
Since all the currently supported language targets (Swift, JS, TS, Java and Dart) use `//` for in-line comments, we did not have to customize the behavior for any specific visitor and handled the version generation in the top level `amplify-codegen` plugin package. 

Most popular programming languages support `//` for in-line comments. [Refer for overview](https://en.wikipedia.org/wiki/Comparison_of_programming_languages_(syntax)#Inline_comments).
The implementation might evolve in the future as we support languages which do not use `//` for in-line comments. 

This PR also comments out a test suite for `cleanGeneratedModels` flag which is not relevant for now. 
_How are these changes tested:_
Added relevant unit tests.
Tested manually using sample apps. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
