### PR TITLE
fix(modelgen): throw error when id field is not present on models

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1072,7 +1072,7 @@ class SimpleModelType extends ModelType<SimpleModel> {
 "
 `;
 
-exports[`AppSync Dart Visitor Model Directive should generate a class for a model with all optional fields 1`] = `
+exports[`AppSync Dart Visitor Model Directive should generate a class for a model with all optional fields except id field 1`] = `
 "/*
 * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -2784,7 +2784,7 @@ public final class Todo implements Model {
 "
 `;
 
-exports[`AppSyncModelVisitor Should generate a class a model with all optional fields 1`] = `
+exports[`AppSyncModelVisitor Should generate a class a model with all optional fields except id field 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -35,9 +35,10 @@ describe('AppSync Dart Visitor', () => {
       expect(generatedCode).toMatchSnapshot();
     });
 
-    it('should generate a class for a model with all optional fields', () => {
+    it('should generate a class for a model with all optional fields except id field', () => {
       const schema = /* GraphQL */ `
         type SimpleModel @model {
+          id: ID!,
           name: String
           bar: String
         }
@@ -357,6 +358,7 @@ describe('AppSync Dart Visitor', () => {
     it('should throw error when a reserved word of dart is used in graphql schema field name', () => {
       const schema = /* GraphQL */ `
         type ReservedWord @model {
+          id: ID!
           class: String!
         }
       `;
@@ -369,6 +371,7 @@ describe('AppSync Dart Visitor', () => {
     it('should throw error when a reserved word of dart is used in graphql schema type name', () => {
       const schema = /* GraphQL */ `
         type class @model {
+          id: ID!,
           name: String!
         }
       `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -92,9 +92,10 @@ describe('AppSyncModelVisitor', () => {
     expect(generatedCode).toMatchSnapshot();
   });
 
-  it('Should generate a class a model with all optional fields', () => {
+  it('Should generate a class a model with all optional fields except id field', () => {
     const schema = /* GraphQL */ `
       type SimpleModel @model {
+        id: ID!,
         name: String
         bar: String
       }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -625,6 +625,7 @@ describe('AppSyncSwiftVisitor', () => {
         val2
       }
       type ObjectWithNativeTypes @model {
+        id: ID!,
         intArr: [Int]
         strArr: [String]
         floatArr: [Float]
@@ -929,6 +930,7 @@ describe('AppSyncSwiftVisitor', () => {
         }
 
         type Foo @model {
+          id: ID!,
           Class: Class
           nonNullClass: Class!
           classes: [Class]

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -17,7 +17,7 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
-  it('should support schema without id', () => {
+  it('should throw error when model has no id field', () => {
     const schema = /* GraphQL */ `
       enum Status {
         draft
@@ -39,41 +39,7 @@ describe('AppSyncModelVisitor', () => {
     const ast = parse(schema);
     const builtSchema = buildSchemaWithDirectives(schema);
     const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
-    visit(ast, { leave: visitor });
-    expect(visitor.models.Post).toBeDefined();
-    const postFields = visitor.models.Post.fields;
-    // ID
-    expect(postFields[0].name).toEqual('id');
-    expect(postFields[0].type).toEqual('ID');
-    expect(postFields[0].isNullable).toEqual(false);
-    expect(postFields[0].isList).toEqual(false);
-
-    // title
-    expect(postFields[1].name).toEqual('title');
-    expect(postFields[1].type).toEqual('String');
-    expect(postFields[1].isNullable).toEqual(false);
-    expect(postFields[1].isList).toEqual(false);
-
-    // content
-    expect(postFields[2].name).toEqual('content');
-    expect(postFields[2].type).toEqual('String');
-    expect(postFields[2].isNullable).toEqual(true);
-    expect(postFields[2].isList).toEqual(false);
-    // comments
-    expect(postFields[3].name).toEqual('comments');
-    expect(postFields[3].type).toEqual('Comment');
-    expect(postFields[3].isNullable).toEqual(true);
-    expect(postFields[3].isList).toEqual(true);
-
-    // Status
-    expect(postFields[4].name).toEqual('status');
-    expect(postFields[4].type).toEqual('Status');
-    expect(postFields[4].isNullable).toEqual(false);
-    expect(postFields[4].isList).toEqual(false);
-
-    // Enums
-    expect(visitor.enums.Status).toBeDefined();
-    expect(visitor.enums.Status.values).toEqual({ DRAFT: 'draft', IN_REVIEW: 'inReview', PUBLISHED: 'published' });
+    expect(() => visit(ast, { leave: visitor })).toThrowError();
   });
 
   it('should support schema with id', () => {
@@ -225,12 +191,14 @@ describe('AppSyncModelVisitor', () => {
     describe('with connection name', () => {
       const schema = /* GraphQL */ `
         type Post @model {
+          id: ID!,
           title: String!
           content: String
           comments: [Comment] @connection(name: "PostComment")
         }
 
         type Comment @model {
+          id: ID!,
           comment: String!
           post: Post @connection(name: "PostComment")
         }
@@ -269,12 +237,14 @@ describe('AppSyncModelVisitor', () => {
     describe('connection with fields argument', () => {
       const schema = /* GraphQL */ `
         type Post @model {
+          id: ID!,
           title: String!
           content: String
           comments: [Comment] @connection(fields: ["id"])
         }
 
         type Comment @model {
+          id: ID!,
           comment: String!
           postId: ID!
           post: Post @connection(fields: ["postId"])
@@ -319,12 +289,14 @@ describe('AppSyncModelVisitor', () => {
     it('should not include a comments in Post when comments field does not have connection directive', () => {
       const schema = /* GraphQL */ `
         type Post @model {
+          id: ID!,
           title: String!
           content: String
           comments: [Comment]
         }
 
         type Comment @model {
+          id: ID!,
           comment: String!
           post: Post @connection
         }
@@ -341,12 +313,14 @@ describe('AppSyncModelVisitor', () => {
     it('should not include a post when post field in Comment when post does not have connection directive', () => {
       const schema = /* GraphQL */ `
         type Post @model {
+          id: ID!,
           title: String!
           content: String
           comments: [Comment] @connection
         }
 
         type Comment @model {
+          id: ID!,
           comment: String!
           post: Post
         }
@@ -365,6 +339,7 @@ describe('AppSyncModelVisitor', () => {
     it('should process auth with owner authorization', () => {
       const schema = /* GraphQL */ `
         type Post @searchable @model @auth(rules: [{ allow: owner }]) {
+          id: ID!,
           title: String!
           content: String
         }
@@ -392,6 +367,7 @@ describe('AppSyncModelVisitor', () => {
     it('should process group with owner authorization', () => {
       const schema = /* GraphQL */ `
         type Post @model @searchable @auth(rules: [{ allow: groups, groups: ["admin", "moderator"] }]) {
+          id: ID!,
           title: String!
           content: String
         }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -39,7 +39,7 @@ describe('AppSyncModelVisitor', () => {
     const ast = parse(schema);
     const builtSchema = buildSchemaWithDirectives(schema);
     const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
-    expect(() => visit(ast, { leave: visitor })).toThrowError();
+    expect(() => visit(ast, { leave: visitor })).toThrowErrorMatchingInlineSnapshot('"Post model does not have the required id field"');
   });
 
   it('should support schema with id', () => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -436,13 +436,14 @@ export class AppSyncModelVisitor<
       // Make id field required
       idField.isNullable = false;
     } else {
-      model.fields.splice(0, 0, {
-        name: 'id',
-        type: 'ID',
-        isNullable: false,
-        isList: false,
-        directives: [],
-      });
+      throw new Error(`${model.name} model does not have the required id field`);
+      // model.fields.splice(0, 0, {
+      //   name: 'id',
+      //   type: 'ID',
+      //   isNullable: false,
+      //   isList: false,
+      //   directives: [],
+      // });
     }
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -437,13 +437,6 @@ export class AppSyncModelVisitor<
       idField.isNullable = false;
     } else {
       throw new Error(`${model.name} model does not have the required id field`);
-      // model.fields.splice(0, 0, {
-      //   name: 'id',
-      //   type: 'ID',
-      //   isNullable: false,
-      //   isList: false,
-      //   directives: [],
-      // });
     }
   }
 


### PR DESCRIPTION
_Issue #, if available:_     #42

_Description of changes:_ 
These changes add a validation step to the GraphQL schema to throw error if any model is specified without a `id: ID!` field. 
These discussion comments: [customer's comment](https://github.com/aws-amplify/amplify-codegen/issues/42#issuecomment-616865432) and [our reply](https://github.com/aws-amplify/amplify-codegen/issues/42#issuecomment-616874233), point to a need for such validation step. 
We would not generate `id` fields if the schema does not have one and through the error message point the user to the model that is missing `id: ID!` field. This is a current constraint for DataStore as it requires this field as noted [here](https://github.com/aws-amplify/amplify-codegen/issues/42#issuecomment-592279776).

_How are these changes tested:_
Unit tests to verify the additional validation step added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
