### PR TITLE
fix(amplify-codegen): have correct error msg for api meta not found

### DIFF
--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -38,7 +38,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     apis = getAppSyncAPIDetails(context);
   }
   if (!apis.length && !withoutInit) {
-    throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+    throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_META);
   }
   const project = projects[0];
   const { frontend } = project.amplifyExtension;

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -36,6 +36,7 @@ module.exports = {
   CMD_DESCRIPTION_CONFIGURE: 'Change/Update codegen configuration',
   ERROR_CODEGEN_NO_API_CONFIGURED: 'code generation is not configured. Configure it by running \n$amplify codegen add',
   ERROR_CODEGEN_PENDING_API_PUSH: 'AppSync API is not pushed to the cloud. Did you forget to do \n$amplify api push',
+  ERROR_CODEGEN_NO_API_META: 'Cannot find API metadata. Please reset codegen by running \n$amplify codegen remove && amplify codegen add --apiId ${YOUR_API_ID}',
   WARNING_CODEGEN_PENDING_API_PUSH: 'The APIs listed below are not pushed to the cloud. Run amplify api push',
   ERROR_APPSYNC_API_NOT_FOUND:
     'Could not find the AppSync API. If you have removed the AppSync API in the console run amplify codegen remove',

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -36,7 +36,7 @@ module.exports = {
   CMD_DESCRIPTION_CONFIGURE: 'Change/Update codegen configuration',
   ERROR_CODEGEN_NO_API_CONFIGURED: 'code generation is not configured. Configure it by running \n$amplify codegen add',
   ERROR_CODEGEN_PENDING_API_PUSH: 'AppSync API is not pushed to the cloud. Did you forget to do \n$amplify api push',
-  ERROR_CODEGEN_NO_API_META: 'Cannot find API metadata. Please reset codegen by running \n$amplify codegen remove && amplify codegen add --apiId ${YOUR_API_ID}',
+  ERROR_CODEGEN_NO_API_META: 'Cannot find API metadata. Please reset codegen by running $amplify codegen remove && amplify codegen add --apiId YOUR_API_ID',
   WARNING_CODEGEN_PENDING_API_PUSH: 'The APIs listed below are not pushed to the cloud. Run amplify api push',
   ERROR_APPSYNC_API_NOT_FOUND:
     'Could not find the AppSync API. If you have removed the AppSync API in the console run amplify codegen remove',

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -32,11 +32,10 @@ jest.mock('amplify-cli-core', () => {
         if (name === 'codegen.useTypesGeneratorPlugin') {
           return true;
         }
-      })
+      }),
     },
   };
 });
-
 
 const MOCK_INCLUDE_PATH = 'MOCK_INCLUDE';
 const MOCK_STATEMENTS_PATH = 'MOCK_STATEMENTS_PATH';
@@ -90,7 +89,7 @@ describe('command - generateStatementsAndTypes', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload
+      forceDownload,
     );
   });
 
@@ -99,5 +98,15 @@ describe('command - generateStatementsAndTypes', () => {
       getProjects: jest.fn().mockReturnValue([]),
     });
     await expect(generateStatementsAndTypes(MOCK_CONTEXT, false)).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
+  });
+
+  it('should show a warning if there are no API metadata', async () => {
+    getAppSyncAPIDetails.mockReturnValue([]);
+    const codegenWithoutApiMeta = async () => generateStatementsAndTypes(MOCK_CONTEXT, false);
+    await expect(codegenWithoutApiMeta).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError)
+    await expect(codegenWithoutApiMeta).rejects.toThrowErrorMatchingInlineSnapshot(`
+            "Cannot find API metadata. Please reset codegen by running 
+            $amplify codegen remove && amplify codegen add --apiId \${YOUR_API_ID}"
+          `);
   });
 });

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -103,10 +103,9 @@ describe('command - generateStatementsAndTypes', () => {
   it('should show a warning if there are no API metadata', async () => {
     getAppSyncAPIDetails.mockReturnValue([]);
     const codegenWithoutApiMeta = async () => generateStatementsAndTypes(MOCK_CONTEXT, false);
-    await expect(codegenWithoutApiMeta).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError)
-    await expect(codegenWithoutApiMeta).rejects.toThrowErrorMatchingInlineSnapshot(`
-            "Cannot find API metadata. Please reset codegen by running 
-            $amplify codegen remove && amplify codegen add --apiId \${YOUR_API_ID}"
-          `);
+    await expect(codegenWithoutApiMeta).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
+    await expect(codegenWithoutApiMeta).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Cannot find API metadata. Please reset codegen by running $amplify codegen remove && amplify codegen add --apiId YOUR_API_ID"`,
+    );
   });
 });


### PR DESCRIPTION
_Issue #, if available:_
fix #121
_Description of changes:_
Change the error message for api metadata not found scenario in case of confusing users.
_How are these changes tested:_
`yarn test`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
