### PR TITLE
fix(amplify-codegen): Add Amplify CLI version as a comment for the Modelgen output files

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -141,7 +141,8 @@ async function generateModels(context) {
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;
     fs.ensureFileSync(outPutPath);
-    fs.writeFileSync(outPutPath, generatedCode[idx]);
+    const contentToWrite = [getAmplifyCLIVersionComment(context), generatedCode[idx]].join('\n\n');
+    fs.writeFileSync(outPutPath, contentToWrite);
   });
 
   generateEslintIgnore(context);
@@ -195,6 +196,13 @@ function getModelOutputPath(context) {
     default:
       return '.';
   }
+}
+
+function getAmplifyCLIVersionComment(context) {
+  if (context.usageData == null || !context.usageData.version) {
+    return null
+  }
+  return '// Generated using Amplify CLI version: ' + context.usageData.version;
 }
 
 function generateEslintIgnore(context) {

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -206,11 +206,14 @@ function getVersionsMetadataComment(context) {
     versionMetadata.push('amplify-cli-version: ' + context.usageData.version);
   }
 
-  const codegenPluginsInfo = context?.pluginPlatform?.plugins?.codegen;
-  if (codegenPluginsInfo && codegenPluginsInfo.length > 0) {
-    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(plugin => plugin.packageName == 'amplify-codegen');
-    if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
-      versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);
+  if (context.pluginPlatform && context.pluginPlatform.plugins && 
+    context.pluginPlatform.plugins.codegen) {
+    const codegenPluginsInfo = context.pluginPlatform.plugins.codegen;
+    if (codegenPluginsInfo.length > 0) {
+      const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(plugin => plugin.packageName == 'amplify-codegen');
+      if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
+        versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);
+      }
     }
   }
 

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -206,10 +206,9 @@ function getVersionsMetadataComment(context) {
     versionMetadata.push('amplify-cli-version: ' + context.usageData.version);
   }
 
-  if (context.pluginPlatform && context.pluginPlatform.plugins && 
-    context.pluginPlatform.plugins.codegen) {
+  if (context.pluginPlatform && context.pluginPlatform.plugins) {
     const codegenPluginsInfo = context.pluginPlatform.plugins.codegen;
-    if (codegenPluginsInfo.length > 0) {
+    if (codegenPluginsInfo && codegenPluginsInfo.length > 0) {
       const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(plugin => plugin.packageName == 'amplify-codegen');
       if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
         versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -141,7 +141,10 @@ async function generateModels(context) {
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;
     fs.ensureFileSync(outPutPath);
-    const contentToWrite = [getAmplifyCLIVersionComment(context), generatedCode[idx]].join('\n\n');
+    const contentsToWrite = [getVersionsMetadataComment(context), generatedCode[idx]].filter(function (content) {
+      return content != null;
+    });
+    const contentToWrite = contentsToWrite.join('\n\n');
     fs.writeFileSync(outPutPath, contentToWrite);
   });
 
@@ -198,11 +201,27 @@ function getModelOutputPath(context) {
   }
 }
 
-function getAmplifyCLIVersionComment(context) {
-  if (context.usageData == null || !context.usageData.version) {
-    return null
+// Generate a Comment string with Amplify CLI and Amplify Codegen version metadata
+function getVersionsMetadataComment(context) {
+  const versionMetadata = [];
+  if (context.usageData && context.usageData.version) {
+    versionMetadata.push('amplify-cli-version: ' + context.usageData.version);
   }
-  return 'Generated using amplify-cli-version: ' + context.usageData.version;
+
+  const codegenPluginsInfo = context?.pluginPlatform?.plugins?.codegen;
+  if (codegenPluginsInfo && codegenPluginsInfo.length > 0) {
+    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(function(plugin) {
+      return plugin.packageName == 'amplify-codegen';
+    });
+    if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
+      versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);
+    }
+  }
+
+  if (versionMetadata.length > 0) {
+    return '// Generated using ' + versionMetadata.join(', ');
+  }
+  return null;
 }
 
 function generateEslintIgnore(context) {

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -141,9 +141,7 @@ async function generateModels(context) {
   appsyncLocalConfig.forEach((cfg, idx) => {
     const outPutPath = cfg.filename;
     fs.ensureFileSync(outPutPath);
-    const contentsToWrite = [getVersionsMetadataComment(context), generatedCode[idx]].filter(function (content) {
-      return content != null;
-    });
+    const contentsToWrite = [getVersionsMetadataComment(context), generatedCode[idx]].filter(content => content);
     const contentToWrite = contentsToWrite.join('\n\n');
     fs.writeFileSync(outPutPath, contentToWrite);
   });
@@ -210,9 +208,7 @@ function getVersionsMetadataComment(context) {
 
   const codegenPluginsInfo = context?.pluginPlatform?.plugins?.codegen;
   if (codegenPluginsInfo && codegenPluginsInfo.length > 0) {
-    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(function(plugin) {
-      return plugin.packageName == 'amplify-codegen';
-    });
+    const amplifyCodegenPluginInfo =  codegenPluginsInfo.filter(plugin => plugin.packageName == 'amplify-codegen');
     if (amplifyCodegenPluginInfo && amplifyCodegenPluginInfo.length > 0 && amplifyCodegenPluginInfo[0].packageVersion) {
       versionMetadata.push('amplify-codegen-version: ' + amplifyCodegenPluginInfo[0].packageVersion);
     }

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -202,7 +202,7 @@ function getAmplifyCLIVersionComment(context) {
   if (context.usageData == null || !context.usageData.version) {
     return null
   }
-  return '// Generated using Amplify CLI version: ' + context.usageData.version;
+  return 'Generated using amplify-cli-version: ' + context.usageData.version;
 }
 
 function generateEslintIgnore(context) {

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -5,25 +5,6 @@ const fs = require('fs');
 const path = require('path');
 
 jest.mock('@graphql-codegen/core');
-const MOCK_CONTEXT = {
-  print: {
-    info: jest.fn(),
-    warning: jest.fn(),
-  },
-  amplify: {
-    getProjectMeta: jest.fn(),
-    getEnvInfo: jest.fn(),
-    getResourceStatus: jest.fn(),
-    executeProviderUtils: jest.fn(),
-    pathManager: {
-      getBackendDirPath: jest.fn(),
-    },
-    getProjectConfig: jest.fn(),
-  },
-  usageData: {
-    version: '0.0.0'
-  }
-};
 const OUTPUT_PATHS = {
     javascript: 'src/models',
     android: 'app/src/main/java/com/amplifyframework/datastore/generated/model',
@@ -54,7 +35,6 @@ jest.mock('amplify-cli-core', MOCK_PROJECT_ROOT => {
 describe('command-models-generates models in expected output path', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    addMocksToContext();
     graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
   });
 
@@ -69,11 +49,11 @@ describe('command-models-generates models in expected output path', () => {
       };
       mockedFiles[outputDirectory] = {};
       mockFs(mockedFiles);
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
       // assert empty folder before generation
       expect(fs.readdirSync(outputDirectory).length).toEqual(0);
-      await generateModels(MOCK_CONTEXT);
+      await generateModels(context);
       // assert model generation succeeds with a single schema file
       expect(graphqlCodegen.codegen).toBeCalled();
 
@@ -91,12 +71,12 @@ describe('command-models-generates models in expected output path', () => {
       };
       mockedFiles[outputDirectory] = {};
       mockFs(mockedFiles);
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-
+      const context = createMockContext();
+      addMocksToContext(context, frontend);
       // assert empty folder before generation
       expect(fs.readdirSync(outputDirectory).length).toEqual(0);
 
-      await generateModels(MOCK_CONTEXT);
+      await generateModels(context);
 
       // assert model generation succeeds with a single schema file
       expect(graphqlCodegen.codegen).toBeCalled();
@@ -338,6 +318,7 @@ function createMockContext() {
   const MOCK_CONTEXT = {
     print: {
       info: jest.fn(),
+      warning: jest.fn(),
     },
     amplify: {
       getProjectMeta: jest.fn(),

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -139,7 +139,7 @@ describe('command-models adds Amplify CLI version comment', () => {
         fs.readdirSync(outputDirectory).forEach(filename => {
           const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
           // assert version is appended to each of the generated files
-          expect(data === '// Generated using Amplify CLI version: 0.0.0\n\nThis code is auto-generated!');
+          expect(data === '// Generated using amplify-cli-version: 0.0.0\n\nThis code is auto-generated!');
         });
     });
 

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -20,12 +20,15 @@ const MOCK_CONTEXT = {
     },
     getProjectConfig: jest.fn(),
   },
+  usageData: {
+    version: '0.0.0'
+  }
 };
 const OUTPUT_PATHS = {
-  javascript: 'src',
-  android: 'app/src/main/java',
-  ios: 'amplify/generated/models',
-  flutter: 'lib/models',
+    javascript: 'src/models',
+    android: 'app/src/main/java/com/amplifyframework/datastore/generated/model',
+    ios: 'amplify/generated/models',
+    flutter: 'lib/models'
 };
 const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PROJECT_NAME = 'myapp';
@@ -109,13 +112,132 @@ describe('command-models-generates models in expected output path', () => {
   afterEach(mockFs.restore);
 });
 
-describe('codegen models respects cleanGeneratedModelsDirectory', () => {
+describe('command-models adds Amplify CLI version comment', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     addMocksToContext();
     graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
   });
 
+  for (const frontend in OUTPUT_PATHS) {
+    it(frontend + ': Should append cli version comment to generated files', async () => {
+        const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+        createMockFS(outputDirectory);
+        MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+
+        // assert empty folder before generation
+        expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+        await generateModels(MOCK_CONTEXT);
+
+        // assert model generation succeeds with a single schema file
+        expect(graphqlCodegen.codegen).toBeCalled();
+
+        // assert model files are generated in expected output directory
+        expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+        fs.readdirSync(outputDirectory).forEach(filename => {
+          const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+          // assert version is appended to each of the generated files
+          expect(data === '// Generated using Amplify CLI version: 0.0.0\n\nThis code is auto-generated!');
+        });
+    });
+
+    it(frontend + ': Should not break codegen if cli version is not available', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+      MOCK_CONTEXT.usageData = null;
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(MOCK_CONTEXT);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data === 'This code is auto-generated!');
+      });
+    });
+
+    it(frontend + ': Handle empty cli version string', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+      MOCK_CONTEXT.usageData = {version: ''};
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(MOCK_CONTEXT);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data === 'This code is auto-generated!');
+      });
+    });
+
+    it(frontend + ': Handle undefined cli version string', async () => {
+      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
+      createMockFS(outputDirectory);
+      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({frontend: frontend});
+      MOCK_CONTEXT.usageData = {version: undefined};
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+
+      await generateModels(MOCK_CONTEXT);
+
+      // assert model generation succeeds with a single schema file
+      expect(graphqlCodegen.codegen).toBeCalled();
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
+
+      fs.readdirSync(outputDirectory).forEach(filename => {
+        const data = fs.readFileSync(path.resolve(outputDirectory, filename), {encoding:'utf8', flag:'r'}); 
+        // assert version is not appended to any of the generated files
+        expect(data === 'This code is auto-generated!');
+      });
+    });
+
+    function createMockFS(outputDirectory) {
+      // mock the input and output file structure
+      const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
+      const mockedFiles = {};
+      mockedFiles[schemaFilePath] = {
+          'schema.graphql': ' type SimpleModel { id: ID! status: String } '
+      };
+      mockedFiles[outputDirectory] = {};
+      mockFs(mockedFiles);
+    }
+  };
+
+  afterEach(mockFs.restore);
+});
+
+/*
+describe('codegen models respects cleanGeneratedModelsDirectory', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    addMocksToContext();
+    graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
+  });
+ 
   for (const frontend in OUTPUT_PATHS) {
     it(frontend + ': Should clear the output directory before generation if cleanGeneratedModelsDirectory is true', async () => {
       MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
@@ -165,13 +287,13 @@ describe('codegen models respects cleanGeneratedModelsDirectory', () => {
       expect(fs.existsSync(preExistingFilePath));
 
       await generateModels(MOCK_CONTEXT);
-
+ 
       // assert model generation succeeds
       expect(graphqlCodegen.codegen).toBeCalled();
-
+ 
       // assert that codegen generated in correct place
       expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(1);
-
+ 
       // assert that the pre-existing file is retained
       expect(fs.existsSync(preExistingFilePath)).toBeTruthy;
     });
@@ -190,9 +312,11 @@ describe('codegen models respects cleanGeneratedModelsDirectory', () => {
   }
 
   afterEach(mockFs.restore);
-});
+}); 
+*/
 
 // Add models generation specific mocks to Amplify Context
+
 function addMocksToContext() {
   MOCK_CONTEXT.amplify.getEnvInfo.mockReturnValue({ projectPath: MOCK_PROJECT_ROOT });
   MOCK_CONTEXT.amplify.getResourceStatus.mockReturnValue({

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -34,7 +34,6 @@ const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PROJECT_NAME = 'myapp';
 const MOCK_BACKEND_DIRECTORY = 'backend';
 const MOCK_GENERATED_CODE = 'This code is auto-generated!';
-const MOCK_PRE_EXISTING_FILE = 'preexisting.txt';
 
 // Mock the Feature flag to use migrated moldegen
 jest.mock('amplify-cli-core', MOCK_PROJECT_ROOT => {
@@ -314,91 +313,6 @@ describe('command-models adds Amplify CLI version comment', () => {
 
   afterEach(mockFs.restore);
 });
-
-/*
-describe('codegen models respects cleanGeneratedModelsDirectory', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    addMocksToContext();
-    graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
-  });
- 
-  for (const frontend in OUTPUT_PATHS) {
-    it(frontend + ': Should clear the output directory before generation if cleanGeneratedModelsDirectory is true', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-        if (name === 'codegen.useappsyncmodelgenplugin' || name === 'codegen.cleanGeneratedModelsDirectory') {
-          return true;
-        }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
-
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
-
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
-
-      // assert that the pre-existing file is deleted
-      expect(fs.existsSync(preExistingFilePath)).toBeFalsy;
-    });
-
-    it(frontend + ': Should not clear the output directory before generation if cleanGeneratedModelsDirectory is false', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-        if (name === 'codegen.useappsyncmodelgenplugin') {
-          return true;
-        }
-        if (name === 'codegen.cleanGeneratedModelsDirectory') {
-          return false;
-        }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
- 
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
- 
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(1);
- 
-      // assert that the pre-existing file is retained
-      expect(fs.existsSync(preExistingFilePath)).toBeTruthy;
-    });
-  }
-
-  function createMockFS(outputDirectory) {
-    // mock the input and output file structure
-    const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
-    const mockedFiles = {};
-    mockedFiles[schemaFilePath] = {
-      'schema.graphql': ' type SimpleModel { id: ID! status: String } ',
-    };
-    mockedFiles[outputDirectory] = {};
-    mockedFiles[outputDirectory][MOCK_PRE_EXISTING_FILE] = 'A pre-existing mock file';
-    mockFs(mockedFiles);
-  }
-
-  afterEach(mockFs.restore);
-}); 
-*/
 
 // Add models generation specific mocks to Amplify Context
 function addMocksToContext(context, frontend) {


### PR DESCRIPTION
_Issue #, if available:_   #90

_Description of changes:_
These changes fix the backwards compatibility issue with the changes introduced in this PR: https://github.com/aws-amplify/amplify-codegen/pull/116.

_How are these changes tested:_
Unit tests and manual testing using `amplify-dev` for iOS and typescript projects. More platforms were already tested in https://github.com/aws-amplify/amplify-codegen/pull/116.
Update: Tested on iOS, Android, TS, JS, Dart sample apps on MacOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
