### PR TITLE
fix(modelgen): revert not adding ID field automatically

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -17,30 +17,6 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
-  it('should throw error when model has no id field', () => {
-    const schema = /* GraphQL */ `
-      enum Status {
-        draft
-        inReview
-        published
-      }
-      type Post @model {
-        title: String!
-        content: String
-        comments: [Comment] @connection
-        status: Status!
-      }
-
-      type Comment @model {
-        comment: String!
-        post: Post @connection
-      }
-    `;
-    const ast = parse(schema);
-    const builtSchema = buildSchemaWithDirectives(schema);
-    const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
-    expect(() => visit(ast, { leave: visitor })).toThrowErrorMatchingInlineSnapshot('"Post model does not have the required id field"');
-  });
 
   it('should support schema with id', () => {
     const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -436,7 +436,13 @@ export class AppSyncModelVisitor<
       // Make id field required
       idField.isNullable = false;
     } else {
-      throw new Error(`${model.name} model does not have the required id field`);
+      model.fields.splice(0, 0, {
+        name: 'id',
+        type: 'ID',
+        isNullable: false,
+        isList: false,
+        directives: [],
+      });
     }
   }
 


### PR DESCRIPTION
_Description of changes:_
Reverts the changes in https://github.com/aws-amplify/amplify-codegen/pull/120 to continue supporting autogeneration of ID fields for existing customers. 

_How are these changes tested:_
Tested using iOS sample app with a model not having ID field and verified that it adds the ID field in output models. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
