### PR TITLE
Release: Fix modelgen failure for existing models without ID fields

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -17,30 +17,6 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
-  it('should throw error when model has no id field', () => {
-    const schema = /* GraphQL */ `
-      enum Status {
-        draft
-        inReview
-        published
-      }
-      type Post @model {
-        title: String!
-        content: String
-        comments: [Comment] @connection
-        status: Status!
-      }
-
-      type Comment @model {
-        comment: String!
-        post: Post @connection
-      }
-    `;
-    const ast = parse(schema);
-    const builtSchema = buildSchemaWithDirectives(schema);
-    const visitor = new AppSyncModelVisitor(builtSchema, { directives, target: 'android', generate: CodeGenGenerateEnum.code }, {});
-    expect(() => visit(ast, { leave: visitor })).toThrowErrorMatchingInlineSnapshot('"Post model does not have the required id field"');
-  });
 
   it('should support schema with id', () => {
     const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -436,7 +436,13 @@ export class AppSyncModelVisitor<
       // Make id field required
       idField.isNullable = false;
     } else {
-      throw new Error(`${model.name} model does not have the required id field`);
+      model.fields.splice(0, 0, {
+        name: 'id',
+        type: 'ID',
+        isNullable: false,
+        isList: false,
+        directives: [],
+      });
     }
   }
 


### PR DESCRIPTION
_Description of changes:_
We released a feature with modelgen version `1.23.0` that prevents auto-generation of `ID` fields if they are not present in the models. This is being reverted to continue supporting these models for existing customers. 

_How are these changes tested:_
tested using iOS sample app

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
