### PR TITLE
fix(amplify-codegen): Correct cli help re: codegen `--maxDepth` flag

### DIFF
--- a/packages/amplify-codegen/commands/codegen/codegen.js
+++ b/packages/amplify-codegen/commands/codegen/codegen.js
@@ -7,7 +7,7 @@ module.exports = {
   name: featureName,
   run: async context => {
     if (context.parameters.options.help) {
-      const header = `amplify ${featureName} [subcommand] [[--nodownload] [--max-depth <number>]]\nDescriptions:
+      const header = `amplify ${featureName} [subcommand] [[--nodownload] [--maxDepth <number>]]\nDescriptions:
       Generates GraphQL statements (queries, mutations and subscriptions) and type annotations. \nSub Commands:`;
 
       const commands = [
@@ -16,7 +16,7 @@ module.exports = {
           description: constants.CMD_DESCRIPTION_GENERATE_TYPES,
         },
         {
-          name: 'statements [--nodownload] [--max-depth]',
+          name: 'statements [--nodownload] [--maxDepth]',
           description: constants.CMD_DESCRIPTION_GENERATE_STATEMENTS,
         },
         {


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws-amplify/docs/issues/2720

_Description of changes:_

Previously, users could execute the `amplify codegen` command with a `--max-depth` flag. Accordingly, when users would run `amplify codegen --help` the above usage would be described. However, at some point in 2019, the above flag was changed to `--maxDepth` (see https://github.com/aws-amplify/amplify-cli/pull/2175). To date, neither the CLI help nor the official documentation reflect this change. 

<img width="1110" alt="Screen Shot 2021-03-31 at 5 03 44 PM" src="https://user-images.githubusercontent.com/14793389/113211215-3683bf00-9243-11eb-9140-fd7590398175.png">

<img width="567" alt="Screen Shot 2021-03-31 at 5 05 33 PM" src="https://user-images.githubusercontent.com/14793389/113211344-5c10c880-9243-11eb-8eac-ce7080d131e3.png">

This PR addresses the CLI help output. 

_How are these changes tested:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
