### PR TITLE
fix(amplify-codegen): add correct error msg for flutter codegen

### DIFF
--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -19,6 +19,7 @@ module.exports = {
   PROMPT_MSG_SELECT_PROJECT: 'Choose the AppSync API',
   PROMPT_MSG_SELECT_REGION: 'Choose AWS Region',
   ERROR_CODEGEN_TARGET_NOT_SUPPORTED: 'is not supported by codegen plugin',
+  ERROR_FLUTTER_CODEGEN_NOT_SUPPORTED: 'Flutter only supports the command $amplify codegen models. All the other codegen commands are not supported.',
   ERROR_CODEGEN_FRONTEND_NOT_SUPPORTED: 'The project frontend is not supported by codegen',
   ERROR_MSG_MAX_DEPTH: 'Depth should be a integer greater than 0',
   ERROR_CODEGEN_NO_API_AVAILABLE: 'There are no GraphQL APIs available.\nAdd by running $amplify api add',

--- a/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
@@ -15,6 +15,12 @@ async function askCodeGenTargetLanguage(context, target, withoutInit = false, de
   if (!withoutInit) {
     frontend = getFrontEndHandler(context);
   }
+  
+  //flutter only supports modelgen but the amplify graphql codegen
+  if (frontend === 'flutter') {
+    throw new AmplifyCodeGenNotSupportedError(constants.ERROR_FLUTTER_CODEGEN_NOT_SUPPORTED);
+  }
+
   const isAngular =
     frontend === 'javascript' && getFrontEndFramework(context, withoutInit, decoupleFrontend, decoupleFramework) === 'angular';
   const isIonic = frontend === 'javascript' && getFrontEndFramework(context, withoutInit, decoupleFrontend, decoupleFramework) === 'ionic';

--- a/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/languageTarget.js
@@ -15,7 +15,7 @@ async function askCodeGenTargetLanguage(context, target, withoutInit = false, de
   if (!withoutInit) {
     frontend = getFrontEndHandler(context);
   }
-  
+
   //flutter only supports modelgen but the amplify graphql codegen
   if (frontend === 'flutter') {
     throw new AmplifyCodeGenNotSupportedError(constants.ERROR_FLUTTER_CODEGEN_NOT_SUPPORTED);

--- a/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
+++ b/packages/amplify-codegen/tests/commands/generateStatementsAndTypes.test.js
@@ -102,9 +102,9 @@ describe('command - generateStatementsAndTypes', () => {
 
   it('should show a warning if there are no API metadata', async () => {
     getAppSyncAPIDetails.mockReturnValue([]);
-    const codegenWithoutApiMeta = async () => generateStatementsAndTypes(MOCK_CONTEXT, false);
-    await expect(codegenWithoutApiMeta).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
-    await expect(codegenWithoutApiMeta).rejects.toThrowErrorMatchingInlineSnapshot(
+    const codegenWithoutApiMeta = async () => await generateStatementsAndTypes(MOCK_CONTEXT, false);
+    expect(codegenWithoutApiMeta).rejects.toBeInstanceOf(AmplifyCodeGenNoAppSyncAPIAvailableError);
+    expect(codegenWithoutApiMeta).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Cannot find API metadata. Please reset codegen by running $amplify codegen remove && amplify codegen add --apiId YOUR_API_ID"`,
     );
   });

--- a/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
+++ b/packages/amplify-codegen/tests/walkthrough/questions/languageTarget.test.js
@@ -41,4 +41,13 @@ describe('askCodegenTargetLanguage', () => {
     expect(questions[0].name).toEqual('target');
     expect(questions[0].choices).toEqual(['javascript', 'typescript', 'flow']);
   });
+
+  it('should throw error if the frontend is flutter which only supports modelgen', async () => {
+    getFrontEndHandler.mockReturnValue('flutter');
+    const codegenWithFlutterFrontend = async () => await askCodegenTargetLanguage(mockContext);
+    expect(codegenWithFlutterFrontend).rejects.toBeInstanceOf(AmplifyCodeGenNotSupportedError);
+    expect(codegenWithFlutterFrontend).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Flutter only supports the command $amplify codegen models. All the other codegen commands are not supported."`,
+    );
+  });
 });


### PR DESCRIPTION
_Issue #, if available:_
fix #137 
_Description of changes:_
Add correct error messaging for flutter frontend which informs that flutter only supports `amplify codegen models` but other codegen commands.
_How are these changes tested:_

- `yarn test` for unit testing
- `amplify-dev codegen add/configure` for integration testing with CLI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
