### PR TITLE
ModelGen(Swift, Java): Handle nullability of lists transparently based on the GraphQL schema specification

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -230,11 +230,7 @@ module.exports = {
     'function-template-dir',
 
     // Ignore output directories of typescript project until move to tsc and fixing src locations
-    '/packages/appsync-modelgen-plugin/lib',
-    '/packages/graphql-docs-generator/lib',
-    '/packages/graphql-types-generator/lib',
-    '/packages/amplify-codegen-e2e-core/lib',
-    '/packages/amplify-codegen-e2e-tests/lib',
+    '/packages/*/lib',
 
     // Ignore CHANGELOG.md files
     '/packages/*/CHANGELOG.md'

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -99,6 +99,7 @@ async function generateModels(context) {
       emitAuthProvider,
       generateIndexRules,
       enableDartNullSafety,
+      handleListNullabilityTransparently
     },
   });
 

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -89,6 +89,8 @@ async function generateModels(context) {
       );
     }
   }
+  const handleListNullabilityTransparently = readFeatureFlag('codegen.handleListNullabilityTransparently');
+
   const appsyncLocalConfig = await appSyncDataStoreCodeGen.preset.buildGeneratesSection({
     baseOutputDir: outputPath,
     schema,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -3682,7 +3682,7 @@ public final class SimpleModel implements Model {
 "
 `;
 
-exports[`AppSyncModelVisitor Should generate a class for a Model 2`] = `
+exports[`AppSyncModelVisitor Should handle nullability of lists appropriately 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
 import com.amplifyframework.core.model.temporal.Temporal;
@@ -3701,13 +3701,19 @@ import com.amplifyframework.core.model.query.predicate.QueryField;
 
 import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 
-/** This is an auto generated class representing the SimpleModel type in your schema. */
+/** This is an auto generated class representing the ListContainer type in your schema. */
 @SuppressWarnings(\\"all\\")
-@ModelConfig(pluralName = \\"SimpleModels\\")
-public final class SimpleModel implements Model {
-  public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
-  public static final QueryField NAME = field(\\"SimpleModel\\", \\"name\\");
-  public static final QueryField BAR = field(\\"SimpleModel\\", \\"bar\\");
+@ModelConfig(pluralName = \\"ListContainers\\")
+public final class ListContainer implements Model {
+  public static final QueryField ID = field(\\"ListContainer\\", \\"id\\");
+  public static final QueryField NAME = field(\\"ListContainer\\", \\"name\\");
+  public static final QueryField LIST = field(\\"ListContainer\\", \\"list\\");
+  public static final QueryField REQUIRED_LIST = field(\\"ListContainer\\", \\"requiredList\\");
+  public static final QueryField REQUIRED_LIST_OF_REQUIRED = field(\\"ListContainer\\", \\"requiredListOfRequired\\");
+  public static final QueryField LIST_OF_REQUIRED = field(\\"ListContainer\\", \\"listOfRequired\\");
+  public static final QueryField REQUIRED_LIST_OF_REQUIRED_DATES = field(\\"ListContainer\\", \\"requiredListOfRequiredDates\\");
+  public static final QueryField LIST_OF_REQUIRED_FLOATS = field(\\"ListContainer\\", \\"listOfRequiredFloats\\");
+  public static final QueryField REQUIRED_LIST_OF_CUSTOM_TYPES = field(\\"ListContainer\\", \\"requiredListOfCustomTypes\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
   private final @ModelField(targetType=\\"String\\") String bar;
@@ -3721,8 +3727,8 @@ public final class SimpleModel implements Model {
       return name;
   }
   
-  public String getBar() {
-      return bar;
+  public List<Integer> getList() {
+      return list;
   }
   
   public Temporal.DateTime getCreatedAt() {
@@ -3736,7 +3742,13 @@ public final class SimpleModel implements Model {
   private SimpleModel(String id, String name, String bar) {
     this.id = id;
     this.name = name;
-    this.bar = bar;
+    this.list = list;
+    this.requiredList = requiredList;
+    this.requiredListOfRequired = requiredListOfRequired;
+    this.listOfRequired = listOfRequired;
+    this.requiredListOfRequiredDates = requiredListOfRequiredDates;
+    this.listOfRequiredFloats = listOfRequiredFloats;
+    this.requiredListOfCustomTypes = requiredListOfCustomTypes;
   }
   
   @Override
@@ -3770,7 +3782,7 @@ public final class SimpleModel implements Model {
   @Override
    public String toString() {
     return new StringBuilder()
-      .append(\\"SimpleModel {\\")
+      .append(\\"ListContainer {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
       .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
@@ -3780,7 +3792,7 @@ public final class SimpleModel implements Model {
       .toString();
   }
   
-  public static BuildStep builder() {
+  public static RequiredListOfRequiredStep builder() {
       return new Builder();
   }
   
@@ -3793,7 +3805,7 @@ public final class SimpleModel implements Model {
    * @return an instance of this model with only ID populated
    * @throws IllegalArgumentException Checks that ID is in the proper format
    */
-  public static SimpleModel justId(String id) {
+  public static ListContainer justId(String id) {
     try {
       UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
     } catch (Exception exception) {
@@ -3803,8 +3815,14 @@ public final class SimpleModel implements Model {
               \\"creating a new object, use the standard builder method and leave the ID field blank.\\"
       );
     }
-    return new SimpleModel(
+    return new ListContainer(
       id,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
       null,
       null
     );
@@ -3813,28 +3831,96 @@ public final class SimpleModel implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       name,
-      bar);
+      list,
+      requiredList,
+      requiredListOfRequired,
+      listOfRequired,
+      requiredListOfRequiredDates,
+      listOfRequiredFloats,
+      requiredListOfCustomTypes);
   }
-  public interface BuildStep {
-    SimpleModel build();
-    BuildStep id(String id) throws IllegalArgumentException;
-    BuildStep name(String name);
-    BuildStep bar(String bar);
+  public interface RequiredListStep {
+    RequiredListOfRequiredStep requiredList(List<String> requiredList);
   }
   
 
-  public static class Builder implements BuildStep {
+  public interface RequiredListOfRequiredStep {
+    RequiredListOfRequiredDatesStep requiredListOfRequired(List<StatusEnum> requiredListOfRequired);
+  }
+  
+
+  public interface RequiredListOfRequiredDatesStep {
+    RequiredListOfCustomTypesStep requiredListOfRequiredDates(List<Temporal.Date> requiredListOfRequiredDates);
+  }
+  
+
+  public interface RequiredListOfCustomTypesStep {
+    BuildStep requiredListOfCustomTypes(List<CustomType> requiredListOfCustomTypes);
+  }
+  
+
+  public interface BuildStep {
+    ListContainer build();
+    BuildStep id(String id) throws IllegalArgumentException;
+    BuildStep name(String name);
+    BuildStep list(List<Integer> list);
+    BuildStep listOfRequired(List<Boolean> listOfRequired);
+    BuildStep listOfRequiredFloats(List<Double> listOfRequiredFloats);
+  }
+  
+
+  public static class Builder implements RequiredListStep, RequiredListOfRequiredStep, RequiredListOfRequiredDatesStep, RequiredListOfCustomTypesStep, BuildStep {
     private String id;
+    private List<String> requiredList;
+    private List<StatusEnum> requiredListOfRequired;
+    private List<Temporal.Date> requiredListOfRequiredDates;
+    private List<CustomType> requiredListOfCustomTypes;
     private String name;
-    private String bar;
+    private List<Integer> list;
+    private List<Boolean> listOfRequired;
+    private List<Double> listOfRequiredFloats;
     @Override
-     public SimpleModel build() {
+     public ListContainer build() {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
-        return new SimpleModel(
+        return new ListContainer(
           id,
           name,
-          bar);
+          list,
+          requiredList,
+          requiredListOfRequired,
+          listOfRequired,
+          requiredListOfRequiredDates,
+          listOfRequiredFloats,
+          requiredListOfCustomTypes);
+    }
+    
+    @Override
+     public RequiredListOfRequiredStep requiredList(List<String> requiredList) {
+        Objects.requireNonNull(requiredList);
+        this.requiredList = requiredList;
+        return this;
+    }
+    
+    @Override
+     public RequiredListOfRequiredDatesStep requiredListOfRequired(List<StatusEnum> requiredListOfRequired) {
+        Objects.requireNonNull(requiredListOfRequired);
+        this.requiredListOfRequired = requiredListOfRequired;
+        return this;
+    }
+    
+    @Override
+     public RequiredListOfCustomTypesStep requiredListOfRequiredDates(List<Temporal.Date> requiredListOfRequiredDates) {
+        Objects.requireNonNull(requiredListOfRequiredDates);
+        this.requiredListOfRequiredDates = requiredListOfRequiredDates;
+        return this;
+    }
+    
+    @Override
+     public BuildStep requiredListOfCustomTypes(List<CustomType> requiredListOfCustomTypes) {
+        Objects.requireNonNull(requiredListOfCustomTypes);
+        this.requiredListOfCustomTypes = requiredListOfCustomTypes;
+        return this;
     }
     
     @Override
@@ -3844,8 +3930,20 @@ public final class SimpleModel implements Model {
     }
     
     @Override
-     public BuildStep bar(String bar) {
-        this.bar = bar;
+     public BuildStep list(List<Integer> list) {
+        this.list = list;
+        return this;
+    }
+    
+    @Override
+     public BuildStep listOfRequired(List<Boolean> listOfRequired) {
+        this.listOfRequired = listOfRequired;
+        return this;
+    }
+    
+    @Override
+     public BuildStep listOfRequiredFloats(List<Double> listOfRequiredFloats) {
+        this.listOfRequiredFloats = listOfRequiredFloats;
         return this;
     }
     
@@ -3872,10 +3970,36 @@ public final class SimpleModel implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String name, String bar) {
+    private CopyOfBuilder(String id, String name, List<Integer> list, List<String> requiredList, List<StatusEnum> requiredListOfRequired, List<Boolean> listOfRequired, List<Temporal.Date> requiredListOfRequiredDates, List<Double> listOfRequiredFloats, List<CustomType> requiredListOfCustomTypes) {
       super.id(id);
-      super.name(name)
-        .bar(bar);
+      super.requiredListOfRequired(requiredListOfRequired)
+        .listOfRequired(listOfRequired)
+        .requiredListOfRequiredDates(requiredListOfRequiredDates)
+        .listOfRequiredFloats(listOfRequiredFloats)
+        .name(name)
+        .list(list)
+        .requiredList(requiredList)
+        .requiredListOfCustomTypes(requiredListOfCustomTypes);
+    }
+    
+    @Override
+     public CopyOfBuilder requiredListOfRequired(List<StatusEnum> requiredListOfRequired) {
+      return (CopyOfBuilder) super.requiredListOfRequired(requiredListOfRequired);
+    }
+    
+    @Override
+     public CopyOfBuilder listOfRequired(List<Boolean> listOfRequired) {
+      return (CopyOfBuilder) super.listOfRequired(listOfRequired);
+    }
+    
+    @Override
+     public CopyOfBuilder requiredListOfRequiredDates(List<Temporal.Date> requiredListOfRequiredDates) {
+      return (CopyOfBuilder) super.requiredListOfRequiredDates(requiredListOfRequiredDates);
+    }
+    
+    @Override
+     public CopyOfBuilder listOfRequiredFloats(List<Double> listOfRequiredFloats) {
+      return (CopyOfBuilder) super.listOfRequiredFloats(listOfRequiredFloats);
     }
     
     @Override
@@ -3884,8 +4008,18 @@ public final class SimpleModel implements Model {
     }
     
     @Override
-     public CopyOfBuilder bar(String bar) {
-      return (CopyOfBuilder) super.bar(bar);
+     public CopyOfBuilder list(List<Integer> list) {
+      return (CopyOfBuilder) super.list(list);
+    }
+    
+    @Override
+     public CopyOfBuilder requiredList(List<String> requiredList) {
+      return (CopyOfBuilder) super.requiredList(requiredList);
+    }
+    
+    @Override
+     public CopyOfBuilder requiredListOfCustomTypes(List<CustomType> requiredListOfCustomTypes) {
+      return (CopyOfBuilder) super.requiredListOfCustomTypes(requiredListOfCustomTypes);
     }
   }
   

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -3716,7 +3716,13 @@ public final class ListContainer implements Model {
   public static final QueryField REQUIRED_LIST_OF_CUSTOM_TYPES = field(\\"ListContainer\\", \\"requiredListOfCustomTypes\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String name;
-  private final @ModelField(targetType=\\"String\\") String bar;
+  private final @ModelField(targetType=\\"Int\\") List<Integer> list;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) List<String> requiredList;
+  private final @ModelField(targetType=\\"StatusEnum\\", isRequired = true) List<StatusEnum> requiredListOfRequired;
+  private final @ModelField(targetType=\\"Boolean\\") List<Boolean> listOfRequired;
+  private final @ModelField(targetType=\\"AWSDate\\", isRequired = true) List<Temporal.Date> requiredListOfRequiredDates;
+  private final @ModelField(targetType=\\"Float\\") List<Double> listOfRequiredFloats;
+  private final @ModelField(targetType=\\"CustomType\\", isRequired = true) List<CustomType> requiredListOfCustomTypes;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
@@ -3731,6 +3737,30 @@ public final class ListContainer implements Model {
       return list;
   }
   
+  public List<String> getRequiredList() {
+      return requiredList;
+  }
+  
+  public List<StatusEnum> getRequiredListOfRequired() {
+      return requiredListOfRequired;
+  }
+  
+  public List<Boolean> getListOfRequired() {
+      return listOfRequired;
+  }
+  
+  public List<Temporal.Date> getRequiredListOfRequiredDates() {
+      return requiredListOfRequiredDates;
+  }
+  
+  public List<Double> getListOfRequiredFloats() {
+      return listOfRequiredFloats;
+  }
+  
+  public List<CustomType> getRequiredListOfCustomTypes() {
+      return requiredListOfCustomTypes;
+  }
+  
   public Temporal.DateTime getCreatedAt() {
       return createdAt;
   }
@@ -3739,7 +3769,7 @@ public final class ListContainer implements Model {
       return updatedAt;
   }
   
-  private SimpleModel(String id, String name, String bar) {
+  private ListContainer(String id, String name, List<Integer> list, List<String> requiredList, List<StatusEnum> requiredListOfRequired, List<Boolean> listOfRequired, List<Temporal.Date> requiredListOfRequiredDates, List<Double> listOfRequiredFloats, List<CustomType> requiredListOfCustomTypes) {
     this.id = id;
     this.name = name;
     this.list = list;
@@ -3758,12 +3788,18 @@ public final class ListContainer implements Model {
       } else if(obj == null || getClass() != obj.getClass()) {
         return false;
       } else {
-      SimpleModel simpleModel = (SimpleModel) obj;
-      return ObjectsCompat.equals(getId(), simpleModel.getId()) &&
-              ObjectsCompat.equals(getName(), simpleModel.getName()) &&
-              ObjectsCompat.equals(getBar(), simpleModel.getBar()) &&
-              ObjectsCompat.equals(getCreatedAt(), simpleModel.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), simpleModel.getUpdatedAt());
+      ListContainer listContainer = (ListContainer) obj;
+      return ObjectsCompat.equals(getId(), listContainer.getId()) &&
+              ObjectsCompat.equals(getName(), listContainer.getName()) &&
+              ObjectsCompat.equals(getList(), listContainer.getList()) &&
+              ObjectsCompat.equals(getRequiredList(), listContainer.getRequiredList()) &&
+              ObjectsCompat.equals(getRequiredListOfRequired(), listContainer.getRequiredListOfRequired()) &&
+              ObjectsCompat.equals(getListOfRequired(), listContainer.getListOfRequired()) &&
+              ObjectsCompat.equals(getRequiredListOfRequiredDates(), listContainer.getRequiredListOfRequiredDates()) &&
+              ObjectsCompat.equals(getListOfRequiredFloats(), listContainer.getListOfRequiredFloats()) &&
+              ObjectsCompat.equals(getRequiredListOfCustomTypes(), listContainer.getRequiredListOfCustomTypes()) &&
+              ObjectsCompat.equals(getCreatedAt(), listContainer.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), listContainer.getUpdatedAt());
       }
   }
   
@@ -3772,7 +3808,13 @@ public final class ListContainer implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getName())
-      .append(getBar())
+      .append(getList())
+      .append(getRequiredList())
+      .append(getRequiredListOfRequired())
+      .append(getListOfRequired())
+      .append(getRequiredListOfRequiredDates())
+      .append(getListOfRequiredFloats())
+      .append(getRequiredListOfCustomTypes())
       .append(getCreatedAt())
       .append(getUpdatedAt())
       .toString()
@@ -3785,7 +3827,13 @@ public final class ListContainer implements Model {
       .append(\\"ListContainer {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
-      .append(\\"bar=\\" + String.valueOf(getBar()) + \\", \\")
+      .append(\\"list=\\" + String.valueOf(getList()) + \\", \\")
+      .append(\\"requiredList=\\" + String.valueOf(getRequiredList()) + \\", \\")
+      .append(\\"requiredListOfRequired=\\" + String.valueOf(getRequiredListOfRequired()) + \\", \\")
+      .append(\\"listOfRequired=\\" + String.valueOf(getListOfRequired()) + \\", \\")
+      .append(\\"requiredListOfRequiredDates=\\" + String.valueOf(getRequiredListOfRequiredDates()) + \\", \\")
+      .append(\\"listOfRequiredFloats=\\" + String.valueOf(getListOfRequiredFloats()) + \\", \\")
+      .append(\\"requiredListOfCustomTypes=\\" + String.valueOf(getRequiredListOfCustomTypes()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -41,12 +41,12 @@ public struct ListContainer: Model {
   }
   internal init(id: String = UUID().uuidString,
       name: String? = nil,
-      list: [Int?] = [],
+      list: [Int?]? = nil,
       requiredList: [String?] = [],
       requiredListOfRequired: [StatusEnum] = [],
-      listOfRequired: [Bool] = [],
+      listOfRequired: [Bool]? = nil,
       requiredListOfRequiredDates: [Temporal.Date] = [],
-      listOfRequiredFloats: [Double] = [],
+      listOfRequiredFloats: [Double]? = nil,
       requiredListOfCustomTypes: [CustomType?] = [],
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
@@ -125,7 +125,7 @@ public struct CustomType: Embeddable {
 }"
 `;
 
-exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 1`] = `
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection as optional fields 1`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
@@ -133,34 +133,49 @@ import Foundation
 public struct Todo: Model {
   public let id: String
   public var title: String
-  public var tasks: List<task?>
+  public var requiredListOfTasks: List<task>?
+  public var listOfRequiredTasks: List<task>?
+  public var listOfTasks: List<task>?
+  public var requiredListOfRequiredTasks: List<task>?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
       title: String,
-      tasks: List<task?> = []) {
+      requiredListOfTasks: List<task>? = [],
+      listOfRequiredTasks: List<task> = [],
+      listOfTasks: List<task>? = [],
+      requiredListOfRequiredTasks: List<task> = []) {
     self.init(id: id,
       title: title,
-      tasks: tasks,
+      requiredListOfTasks: requiredListOfTasks,
+      listOfRequiredTasks: listOfRequiredTasks,
+      listOfTasks: listOfTasks,
+      requiredListOfRequiredTasks: requiredListOfRequiredTasks,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
       title: String,
-      tasks: List<task?> = [],
+      requiredListOfTasks: List<task>? = [],
+      listOfRequiredTasks: List<task> = [],
+      listOfTasks: List<task>? = [],
+      requiredListOfRequiredTasks: List<task> = [],
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.title = title
-      self.tasks = tasks
+      self.requiredListOfTasks = requiredListOfTasks
+      self.listOfRequiredTasks = listOfRequiredTasks
+      self.listOfTasks = listOfTasks
+      self.requiredListOfRequiredTasks = requiredListOfRequiredTasks
       self.createdAt = createdAt
       self.updatedAt = updatedAt
   }
 }"
 `;
 
-exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 2`] = `
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection as optional fields 2`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
@@ -170,7 +185,10 @@ extension Todo {
    public enum CodingKeys: String, ModelKey {
     case id
     case title
-    case tasks
+    case requiredListOfTasks
+    case listOfRequiredTasks
+    case listOfTasks
+    case requiredListOfRequiredTasks
     case createdAt
     case updatedAt
   }
@@ -186,7 +204,10 @@ extension Todo {
     model.fields(
       .id(),
       .field(todo.title, is: .required, ofType: .string),
-      .hasMany(todo.tasks, is: .required, ofType: task.self, associatedWith: task.keys.todo),
+      .hasMany(todo.requiredListOfTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
+      .hasMany(todo.listOfRequiredTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
+      .hasMany(todo.listOfTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
+      .hasMany(todo.requiredListOfRequiredTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
       .field(todo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -194,7 +215,7 @@ extension Todo {
 }"
 `;
 
-exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 3`] = `
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection as optional fields 3`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
@@ -229,7 +250,7 @@ public struct task: Model {
 }"
 `;
 
-exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 4`] = `
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection as optional fields 4`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListContainer: Model {
+  public let id: String
+  public var name: String?
+  public var list: [String?]?
+  public var requiredList: [String?]
+  public var requiredListOfRequired: [String]
+  public var listOfRequired: [String]?
+  
+  public init(id: String = UUID().uuidString,
+      name: String? = nil,
+      list: [String?]? = [],
+      requiredList: [String?] = [],
+      requiredListOfRequired: [String] = [],
+      listOfRequired: [String]? = []) {
+      self.id = id
+      self.name = name
+      self.list = list
+      self.requiredList = requiredList
+      self.requiredListOfRequired = requiredListOfRequired
+      self.listOfRequired = listOfRequired
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case list
+    case requiredList
+    case requiredListOfRequired
+    case listOfRequired
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listContainer = ListContainer.keys
+    
+    model.pluralName = \\"ListContainers\\"
+    
+    model.fields(
+      .id(),
+      .field(listContainer.name, is: .optional, ofType: .string),
+      .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.requiredList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.requiredListOfRequired, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.listOfRequired, is: .optional, ofType: .embeddedCollection(of: String.self))
+    )
+    }
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -15,16 +15,41 @@ public struct ListContainer: Model {
   public var requiredListOfRequiredDates: [Temporal.Date]
   public var listOfRequiredFloats: [Double]?
   public var requiredListOfCustomTypes: [CustomType?]
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
       name: String? = nil,
-      list: [Int?]? = [],
+      list: [Int?]? = nil,
       requiredList: [String?] = [],
       requiredListOfRequired: [StatusEnum] = [],
-      listOfRequired: [Bool]? = [],
+      listOfRequired: [Bool]? = nil,
       requiredListOfRequiredDates: [Temporal.Date] = [],
-      listOfRequiredFloats: [Double]? = [],
+      listOfRequiredFloats: [Double]? = nil,
       requiredListOfCustomTypes: [CustomType?] = []) {
+    self.init(id: id,
+      name: name,
+      list: list,
+      requiredList: requiredList,
+      requiredListOfRequired: requiredListOfRequired,
+      listOfRequired: listOfRequired,
+      requiredListOfRequiredDates: requiredListOfRequiredDates,
+      listOfRequiredFloats: listOfRequiredFloats,
+      requiredListOfCustomTypes: requiredListOfCustomTypes,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      name: String? = nil,
+      list: [Int?] = [],
+      requiredList: [String?] = [],
+      requiredListOfRequired: [StatusEnum] = [],
+      listOfRequired: [Bool] = [],
+      requiredListOfRequiredDates: [Temporal.Date] = [],
+      listOfRequiredFloats: [Double] = [],
+      requiredListOfCustomTypes: [CustomType?] = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.name = name
       self.list = list
@@ -34,6 +59,8 @@ public struct ListContainer: Model {
       self.requiredListOfRequiredDates = requiredListOfRequiredDates
       self.listOfRequiredFloats = listOfRequiredFloats
       self.requiredListOfCustomTypes = requiredListOfCustomTypes
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
   }
 }"
 `;
@@ -55,6 +82,8 @@ extension ListContainer {
     case requiredListOfRequiredDates
     case listOfRequiredFloats
     case requiredListOfCustomTypes
+    case createdAt
+    case updatedAt
   }
   
   public static let keys = CodingKeys.self
@@ -74,7 +103,9 @@ extension ListContainer {
       .field(listContainer.listOfRequired, is: .optional, ofType: .embeddedCollection(of: Bool.self)),
       .field(listContainer.requiredListOfRequiredDates, is: .required, ofType: .embeddedCollection(of: Temporal.Date.self)),
       .field(listContainer.listOfRequiredFloats, is: .optional, ofType: .embeddedCollection(of: Double.self)),
-      .field(listContainer.requiredListOfCustomTypes, is: .required, ofType: .embeddedCollection(of: CustomType.self))
+      .field(listContainer.requiredListOfCustomTypes, is: .required, ofType: .embeddedCollection(of: CustomType.self)),
+      .field(listContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(listContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
 }"
@@ -91,5 +122,143 @@ public struct CustomType: Embeddable {
   var requiredList: [String?]
   var requiredListOfRequired: [StatusEnum]
   var listOfRequired: [Bool]?
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Todo: Model {
+  public let id: String
+  public var title: String
+  public var tasks: List<task?>
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      tasks: List<task?> = []) {
+    self.init(id: id,
+      title: title,
+      tasks: tasks,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      tasks: List<task?> = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.tasks = tasks
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Todo {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case tasks
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let todo = Todo.keys
+    
+    model.pluralName = \\"Todos\\"
+    
+    model.fields(
+      .id(),
+      .field(todo.title, is: .required, ofType: .string),
+      .hasMany(todo.tasks, is: .required, ofType: task.self, associatedWith: task.keys.todo),
+      .field(todo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct task: Model {
+  public let id: String
+  public var title: String
+  public var todo: Todo?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      todo: Todo? = nil) {
+    self.init(id: id,
+      title: title,
+      todo: todo,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      todo: Todo? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.todo = todo
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should render lists with HAS_MANY connection according to the spec 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension task {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case todo
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let task = task.keys
+    
+    model.pluralName = \\"tasks\\"
+    
+    model.fields(
+      .id(),
+      .field(task.title, is: .required, ofType: .string),
+      .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
+      .field(task.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -8,23 +8,32 @@ import Foundation
 public struct ListContainer: Model {
   public let id: String
   public var name: String?
-  public var list: [String?]?
+  public var list: [Int?]?
   public var requiredList: [String?]
-  public var requiredListOfRequired: [String]
-  public var listOfRequired: [String]?
+  public var requiredListOfRequired: [StatusEnum]
+  public var listOfRequired: [Bool]?
+  public var requiredListOfRequiredDates: [Temporal.Date]
+  public var listOfRequiredFloats: [Double]?
+  public var requiredListOfCustomTypes: [CustomType?]
   
   public init(id: String = UUID().uuidString,
       name: String? = nil,
-      list: [String?]? = [],
+      list: [Int?]? = [],
       requiredList: [String?] = [],
-      requiredListOfRequired: [String] = [],
-      listOfRequired: [String]? = []) {
+      requiredListOfRequired: [StatusEnum] = [],
+      listOfRequired: [Bool]? = [],
+      requiredListOfRequiredDates: [Temporal.Date] = [],
+      listOfRequiredFloats: [Double]? = [],
+      requiredListOfCustomTypes: [CustomType?] = []) {
       self.id = id
       self.name = name
       self.list = list
       self.requiredList = requiredList
       self.requiredListOfRequired = requiredListOfRequired
       self.listOfRequired = listOfRequired
+      self.requiredListOfRequiredDates = requiredListOfRequiredDates
+      self.listOfRequiredFloats = listOfRequiredFloats
+      self.requiredListOfCustomTypes = requiredListOfCustomTypes
   }
 }"
 `;
@@ -43,6 +52,9 @@ extension ListContainer {
     case requiredList
     case requiredListOfRequired
     case listOfRequired
+    case requiredListOfRequiredDates
+    case listOfRequiredFloats
+    case requiredListOfCustomTypes
   }
   
   public static let keys = CodingKeys.self
@@ -56,11 +68,28 @@ extension ListContainer {
     model.fields(
       .id(),
       .field(listContainer.name, is: .optional, ofType: .string),
-      .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: Int.self)),
       .field(listContainer.requiredList, is: .required, ofType: .embeddedCollection(of: String.self)),
-      .field(listContainer.requiredListOfRequired, is: .required, ofType: .embeddedCollection(of: String.self)),
-      .field(listContainer.listOfRequired, is: .optional, ofType: .embeddedCollection(of: String.self))
+      .field(listContainer.requiredListOfRequired, is: .required, ofType: .embeddedCollection(of: StatusEnum.self)),
+      .field(listContainer.listOfRequired, is: .optional, ofType: .embeddedCollection(of: Bool.self)),
+      .field(listContainer.requiredListOfRequiredDates, is: .required, ofType: .embeddedCollection(of: Temporal.Date.self)),
+      .field(listContainer.listOfRequiredFloats, is: .optional, ofType: .embeddedCollection(of: Double.self)),
+      .field(listContainer.requiredListOfCustomTypes, is: .required, ofType: .embeddedCollection(of: CustomType.self))
     )
     }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct CustomType: Embeddable {
+  var name: String?
+  var list: [Int?]?
+  var requiredList: [String?]
+  var requiredListOfRequired: [StatusEnum]
+  var listOfRequired: [Bool]?
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -14,7 +14,7 @@ const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGene
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncModelJavaVisitor(
     builtSchema,
-    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP, isTimestampFieldsAdded: true },
+    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP, isTimestampFieldsAdded: true, handleListNullabilityTransparently: true },
     { selectedType },
   );
   visit(ast, { leave: visitor });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -89,7 +89,6 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
-    expect(generatedCode).toMatchSnapshot();
   });
 
   it('Should generate a class a model with all optional fields except id field', () => {
@@ -185,6 +184,38 @@ describe('AppSyncModelVisitor', () => {
       }
     `;
     const visitor = getVisitor(schema, 'authorBook');
+    const generatedCode = visitor.generate();
+    expect(() => validateJava(generatedCode)).not.toThrow();
+    expect(generatedCode).toMatchSnapshot();
+  });
+
+  it('Should handle nullability of lists appropriately', () => {
+    const schema = /* GraphQL */ `
+      enum StatusEnum {
+        pass
+        fail
+      }
+
+      type CustomType {
+        name: String
+      }
+
+      type ListContainer
+      @model
+      {
+        id: ID!
+        name: String
+        list: [Int]
+        requiredList: [String]!
+        requiredListOfRequired: [StatusEnum!]!
+        listOfRequired: [Boolean!]
+        requiredListOfRequiredDates: [AWSDate!]!
+        listOfRequiredFloats: [Float!]
+        requiredListOfCustomTypes: [CustomType]!
+      }
+    `;
+
+    const visitor = getVisitor(schema, 'ListContainer');
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -400,12 +400,16 @@ describe('AppSyncSwiftVisitor', () => {
     expect(customTypeVisitor.generate()).toMatchSnapshot();
   });
 
-  it('Should render lists with HAS_MANY connection according to the spec', () => {
+  it('Should render lists with HAS_MANY connection as optional fields', () => {
+    // This behavior for iOS differs from JS and will be addressed later.
     const schema = /* GraphQL */ `
       type Todo @model {
         id: ID!
         title: String!
-        tasks: [task]! @connection(name: "TodoTasks")
+        requiredListOfTasks: [task]! @connection(name: "TodoTasks")
+        listOfRequiredTasks: [task!] @connection(name: "TodoTasks")
+        listOfTasks: [task] @connection(name: "TodoTasks")
+        requiredListOfRequiredTasks: [task!]! @connection(name: "TodoTasks")
       }
 
       type task @model {
@@ -470,7 +474,7 @@ describe('AppSyncSwiftVisitor', () => {
             public var due_date: String?
             public var version: Int
             public var value: Double?
-            public var tasks: List<task?>?
+            public var tasks: List<task>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
@@ -481,7 +485,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task?>? = nil) {
+                tasks: List<task>? = []) {
               self.init(id: id,
                 title: title,
                 done: done,
@@ -500,7 +504,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task?> = [],
+                tasks: List<task>? = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -730,13 +734,13 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor?>?
+            public var editors: List<PostEditor>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor?>? = nil) {
+                editors: List<PostEditor>? = []) {
               self.init(id: id,
                 title: title,
                 editors: editors,
@@ -745,7 +749,7 @@ describe('AppSyncSwiftVisitor', () => {
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor?> = [],
+                editors: List<PostEditor>? = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -801,13 +805,13 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor?>?
+            public var editors: List<PostEditor>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor?>? = nil) {
+                editors: List<PostEditor>? = []) {
               self.init(id: id,
                 title: title,
                 editors: editors,
@@ -816,7 +820,7 @@ describe('AppSyncSwiftVisitor', () => {
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor?> = [],
+                editors: List<PostEditor>? = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -918,12 +922,12 @@ describe('AppSyncSwiftVisitor', () => {
             updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
-            intArr: [Int?] = [],
-            strArr: [String?] = [],
-            floatArr: [Double?] = [],
-            boolArr: [Bool?] = [],
-            dateArr: [Temporal.Date?] = [],
-            enumArr: [EnumType?] = [],
+            intArr: [Int?]? = nil,
+            strArr: [String?]? = nil,
+            floatArr: [Double?]? = nil,
+            boolArr: [Bool?]? = nil,
+            dateArr: [Temporal.Date?]? = nil,
+            enumArr: [EnumType?]? = nil,
             createdAt: Temporal.DateTime? = nil,
             updatedAt: Temporal.DateTime? = nil) {
             self.id = id
@@ -1043,10 +1047,10 @@ describe('AppSyncSwiftVisitor', () => {
         internal init(id: String = UUID().uuidString,
             name: String,
             location: Location,
-            nearByLocations: [Location?] = [],
+            nearByLocations: [Location?]? = nil,
             status: Status,
-            statusHistory: [Status?] = [],
-            tags: [String?] = [],
+            statusHistory: [Status?]? = nil,
+            tags: [String?]? = nil,
             createdAt: Temporal.DateTime? = nil,
             updatedAt: Temporal.DateTime? = nil) {
             self.id = id
@@ -1284,7 +1288,7 @@ describe('AppSyncSwiftVisitor', () => {
           internal init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
-              classes: [\`Class\`?] = [],
+              classes: [\`Class\`?]? = nil,
               nonNullClasses: [\`Class\`] = [],
               createdAt: Temporal.DateTime? = nil,
               updatedAt: Temporal.DateTime? = nil) {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -361,15 +361,31 @@ describe('AppSyncSwiftVisitor', () => {
 
   it('Should handle nullability of lists appropriately', () => {
     const schema = /* GraphQL */ `
+      enum StatusEnum {
+        pass
+        fail
+      }
+
+      type CustomType {
+        name: String
+        list: [Int]
+        requiredList: [String]!
+        requiredListOfRequired: [StatusEnum!]!
+        listOfRequired: [Boolean!]
+      }
+
       type ListContainer
       @model
       {
         id: ID!
         name: String
-        list: [String]
+        list: [Int]
         requiredList: [String]!
-        requiredListOfRequired: [String!]!
-        listOfRequired: [String!]
+        requiredListOfRequired: [StatusEnum!]!
+        listOfRequired: [Boolean!]
+        requiredListOfRequiredDates: [AWSDate!]!
+        listOfRequiredFloats: [Float!]
+        requiredListOfCustomTypes: [CustomType]!
       }
     `;
 
@@ -380,6 +396,9 @@ describe('AppSyncSwiftVisitor', () => {
     const metadataVisitor = getVisitor(schema, 'ListContainer', CodeGenGenerateEnum.metadata);
     const generatedMetadata = metadataVisitor.generate();
     expect(generatedMetadata).toMatchSnapshot();
+
+    const customTypeVisitor = getVisitor(schema, 'CustomType');
+    expect(customTypeVisitor.generate()).toMatchSnapshot();
   });
 
   describe('connection', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -374,9 +374,7 @@ describe('AppSyncSwiftVisitor', () => {
         listOfRequired: [Boolean!]
       }
 
-      type ListContainer
-      @model
-      {
+      type ListContainer @model {
         id: ID!
         name: String
         list: [Int]
@@ -399,6 +397,37 @@ describe('AppSyncSwiftVisitor', () => {
 
     const customTypeVisitor = getVisitor(schema, 'CustomType');
     expect(customTypeVisitor.generate()).toMatchSnapshot();
+  });
+
+  it('Should render lists with HAS_MANY connection according to the spec', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model {
+        id: ID!
+        title: String!
+        tasks: [task]! @connection(name: "TodoTasks")
+      }
+
+      type task @model {
+        id: ID
+        title: String!
+        todo: Todo @connection(name: "TodoTasks")
+      }
+    `;
+
+    const visitor = getVisitor(schema, 'Todo');
+    const generatedCode = visitor.generate();
+    expect(generatedCode).toMatchSnapshot();
+
+    const metadataVisitor = getVisitor(schema, 'Todo', CodeGenGenerateEnum.metadata);
+    const generatedMetadata = metadataVisitor.generate();
+    expect(generatedMetadata).toMatchSnapshot();
+
+    const taskVisitor = getVisitor(schema, 'task');
+    expect(taskVisitor.generate()).toMatchSnapshot();
+
+    const taskMetadataVisitor = getVisitor(schema, 'task', CodeGenGenerateEnum.metadata);
+    const generatedTaskMetadata = taskMetadataVisitor.generate();
+    expect(generatedTaskMetadata).toMatchSnapshot();
   });
 
   describe('connection', () => {
@@ -440,7 +469,7 @@ describe('AppSyncSwiftVisitor', () => {
             public var due_date: String?
             public var version: Int
             public var value: Double?
-            public var tasks: List<task>?
+            public var tasks: List<task?>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
@@ -451,7 +480,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task>? = []) {
+                tasks: List<task?>? = nil) {
               self.init(id: id,
                 title: title,
                 done: done,
@@ -470,7 +499,7 @@ describe('AppSyncSwiftVisitor', () => {
                 due_date: String? = nil,
                 version: Int,
                 value: Double? = nil,
-                tasks: List<task>? = [],
+                tasks: List<task?> = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -700,13 +729,13 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor>?
+            public var editors: List<PostEditor?>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor?>? = nil) {
               self.init(id: id,
                 title: title,
                 editors: editors,
@@ -715,7 +744,7 @@ describe('AppSyncSwiftVisitor', () => {
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = [],
+                editors: List<PostEditor?> = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -771,13 +800,13 @@ describe('AppSyncSwiftVisitor', () => {
           public struct Post: Model {
             public let id: String
             public var title: String
-            public var editors: List<PostEditor>?
+            public var editors: List<PostEditor?>?
             public var createdAt: Temporal.DateTime?
             public var updatedAt: Temporal.DateTime?
             
             public init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = []) {
+                editors: List<PostEditor?>? = nil) {
               self.init(id: id,
                 title: title,
                 editors: editors,
@@ -786,7 +815,7 @@ describe('AppSyncSwiftVisitor', () => {
             }
             internal init(id: String = UUID().uuidString,
                 title: String,
-                editors: List<PostEditor>? = [],
+                editors: List<PostEditor?> = [],
                 createdAt: Temporal.DateTime? = nil,
                 updatedAt: Temporal.DateTime? = nil) {
                 self.id = id
@@ -861,22 +890,22 @@ describe('AppSyncSwiftVisitor', () => {
 
       public struct ObjectWithNativeTypes: Model {
         public let id: String
-        public var intArr: [Int]?
-        public var strArr: [String]?
-        public var floatArr: [Double]?
-        public var boolArr: [Bool]?
-        public var dateArr: [Temporal.Date]?
-        public var enumArr: [EnumType]?
+        public var intArr: [Int?]?
+        public var strArr: [String?]?
+        public var floatArr: [Double?]?
+        public var boolArr: [Bool?]?
+        public var dateArr: [Temporal.Date?]?
+        public var enumArr: [EnumType?]?
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
-            intArr: [Int]? = [],
-            strArr: [String]? = [],
-            floatArr: [Double]? = [],
-            boolArr: [Bool]? = [],
-            dateArr: [Temporal.Date]? = [],
-            enumArr: [EnumType]? = []) {
+            intArr: [Int?]? = nil,
+            strArr: [String?]? = nil,
+            floatArr: [Double?]? = nil,
+            boolArr: [Bool?]? = nil,
+            dateArr: [Temporal.Date?]? = nil,
+            enumArr: [EnumType?]? = nil) {
           self.init(id: id,
             intArr: intArr,
             strArr: strArr,
@@ -888,12 +917,12 @@ describe('AppSyncSwiftVisitor', () => {
             updatedAt: nil)
         }
         internal init(id: String = UUID().uuidString,
-            intArr: [Int]? = [],
-            strArr: [String]? = [],
-            floatArr: [Double]? = [],
-            boolArr: [Bool]? = [],
-            dateArr: [Temporal.Date]? = [],
-            enumArr: [EnumType]? = [],
+            intArr: [Int?] = [],
+            strArr: [String?] = [],
+            floatArr: [Double?] = [],
+            boolArr: [Bool?] = [],
+            dateArr: [Temporal.Date?] = [],
+            enumArr: [EnumType?] = [],
             createdAt: Temporal.DateTime? = nil,
             updatedAt: Temporal.DateTime? = nil) {
             self.id = id
@@ -988,18 +1017,18 @@ describe('AppSyncSwiftVisitor', () => {
         public var location: Location
         public var nearByLocations: [Location?]?
         public var status: Status
-        public var statusHistory: [Status]?
-        public var tags: [String]?
+        public var statusHistory: [Status?]?
+        public var tags: [String?]?
         public var createdAt: Temporal.DateTime?
         public var updatedAt: Temporal.DateTime?
         
         public init(id: String = UUID().uuidString,
             name: String,
             location: Location,
-            nearByLocations: [Location?]? = [],
+            nearByLocations: [Location?]? = nil,
             status: Status,
-            statusHistory: [Status]? = [],
-            tags: [String]? = []) {
+            statusHistory: [Status?]? = nil,
+            tags: [String?]? = nil) {
           self.init(id: id,
             name: name,
             location: location,
@@ -1013,10 +1042,10 @@ describe('AppSyncSwiftVisitor', () => {
         internal init(id: String = UUID().uuidString,
             name: String,
             location: Location,
-            nearByLocations: [Location]? = [],
+            nearByLocations: [Location?] = [],
             status: Status,
-            statusHistory: [Status]? = [],
-            tags: [String]? = [],
+            statusHistory: [Status?] = [],
+            tags: [String?] = [],
             createdAt: Temporal.DateTime? = nil,
             updatedAt: Temporal.DateTime? = nil) {
             self.id = id
@@ -1241,7 +1270,7 @@ describe('AppSyncSwiftVisitor', () => {
           public init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
-              classes: [\`Class\`?]? = [],
+              classes: [\`Class\`?]? = nil,
               nonNullClasses: [\`Class\`] = []) {
             self.init(id: id,
               \`Class\`: \`Class\`,
@@ -1254,7 +1283,7 @@ describe('AppSyncSwiftVisitor', () => {
           internal init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
-              classes: [\`Class\`]? = [],
+              classes: [\`Class\`?] = [],
               nonNullClasses: [\`Class\`] = [],
               createdAt: Temporal.DateTime? = nil,
               updatedAt: Temporal.DateTime? = nil) {
@@ -1608,7 +1637,7 @@ describe('AppSyncSwiftVisitor', () => {
                 .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
-                .field(post.editors, is: .required, ofType: .embeddedCollection(of: String.self)),
+                .field(post.editors, is: .optional, ofType: .embeddedCollection(of: String.self)),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -359,6 +359,29 @@ describe('AppSyncSwiftVisitor', () => {
     `);
   });
 
+  it('Should handle nullability of lists appropriately', () => {
+    const schema = /* GraphQL */ `
+      type ListContainer
+      @model
+      {
+        id: ID!
+        name: String
+        list: [String]
+        requiredList: [String]!
+        requiredListOfRequired: [String!]!
+        listOfRequired: [String!]
+      }
+    `;
+
+    const visitor = getVisitor(schema, 'ListContainer');
+    const generatedCode = visitor.generate();
+    expect(generatedCode).toMatchSnapshot();
+
+    const metadataVisitor = getVisitor(schema, 'ListContainer', CodeGenGenerateEnum.metadata);
+    const generatedMetadata = metadataVisitor.generate();
+    expect(generatedMetadata).toMatchSnapshot();
+  });
+
   describe('connection', () => {
     describe('One to Many connection', () => {
       const schema = /* GraphQL */ `
@@ -944,7 +967,7 @@ describe('AppSyncSwiftVisitor', () => {
         public let id: String
         public var name: String
         public var location: Location
-        public var nearByLocations: [Location]?
+        public var nearByLocations: [Location?]?
         public var status: Status
         public var statusHistory: [Status]?
         public var tags: [String]?
@@ -954,7 +977,7 @@ describe('AppSyncSwiftVisitor', () => {
         public init(id: String = UUID().uuidString,
             name: String,
             location: Location,
-            nearByLocations: [Location]? = [],
+            nearByLocations: [Location?]? = [],
             status: Status,
             statusHistory: [Status]? = [],
             tags: [String]? = []) {
@@ -1054,7 +1077,7 @@ describe('AppSyncSwiftVisitor', () => {
       public struct Location: Embeddable {
         var lat: String
         var lang: String
-        var tags: [String]?
+        var tags: [String?]?
       }"
     `);
 
@@ -1191,7 +1214,7 @@ describe('AppSyncSwiftVisitor', () => {
           public let id: String
           public var \`Class\`: Class?
           public var nonNullClass: Class
-          public var classes: [\`Class\`]?
+          public var classes: [\`Class\`?]?
           public var nonNullClasses: [\`Class\`]
           public var createdAt: Temporal.DateTime?
           public var updatedAt: Temporal.DateTime?
@@ -1199,7 +1222,7 @@ describe('AppSyncSwiftVisitor', () => {
           public init(id: String = UUID().uuidString,
               \`Class\`: \`Class\`? = nil,
               nonNullClass: \`Class\`,
-              classes: [\`Class\`]? = [],
+              classes: [\`Class\`?]? = [],
               nonNullClasses: [\`Class\`] = []) {
             self.init(id: id,
               \`Class\`: \`Class\`,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -15,12 +15,13 @@ const getVisitor = (
   isTimestampFieldsAdded: boolean = true,
   emitAuthProvider: boolean = true,
   generateIndexRules: boolean = true,
+  handleListNullabilityTransparently: boolean = true
 ) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncSwiftVisitor(
     builtSchema,
-    { directives, target: 'swift', scalars: SWIFT_SCALAR_MAP, isTimestampFieldsAdded, emitAuthProvider, generateIndexRules },
+    { directives, target: 'swift', scalars: SWIFT_SCALAR_MAP, isTimestampFieldsAdded, emitAuthProvider, generateIndexRules, handleListNullabilityTransparently },
     { selectedType, generate },
   );
   visit(ast, { leave: visitor });

--- a/packages/appsync-modelgen-plugin/src/languages/java-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/java-declaration-block.ts
@@ -5,7 +5,14 @@ import stripIndent from 'strip-indent';
 // Todo: PR to @graphql-codegen/java-common to support method exceptions and comment
 export type Access = 'private' | 'public' | 'protected';
 export type Kind = 'class' | 'interface' | 'enum';
-export type MemberFlags = { transient?: boolean; final?: boolean; volatile?: boolean; static?: boolean; synchronized?: boolean };
+export type MemberFlags = { 
+  transient?: boolean; 
+  final?: boolean; 
+  volatile?: boolean; 
+  static?: boolean; 
+  synchronized?: boolean,
+  isListNullable?: boolean
+};
 export type ClassMember = {
   value: string;
   name: string;

--- a/packages/appsync-modelgen-plugin/src/languages/java-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/java-declaration-block.ts
@@ -5,11 +5,11 @@ import stripIndent from 'strip-indent';
 // Todo: PR to @graphql-codegen/java-common to support method exceptions and comment
 export type Access = 'private' | 'public' | 'protected';
 export type Kind = 'class' | 'interface' | 'enum';
-export type MemberFlags = { 
-  transient?: boolean; 
-  final?: boolean; 
-  volatile?: boolean; 
-  static?: boolean; 
+export type MemberFlags = {
+  transient?: boolean;
+  final?: boolean;
+  volatile?: boolean;
+  static?: boolean;
   synchronized?: boolean,
   isListNullable?: boolean
 };

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -122,7 +122,7 @@ export type VariableFlags = {
   variable?: boolean;
   isEnum?: boolean;
 };
-export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean };
+export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean; isListNullable?: boolean };
 export type PropertyFlags = StructFlags;
 export type MethodFlags = { static?: boolean };
 export type DeclarationFlag = { final?: boolean };
@@ -339,7 +339,8 @@ export class SwiftDeclarationBlock {
     const res: string[] = args.reduce((acc: string[], arg) => {
       const val: string | null = arg.value ? arg.value : arg.flags.isList ? '[]' : arg.flags.optional ? 'nil' : null;
       const type = arg.flags.isList ? this.getListType(arg) : escapeKeywords(arg.type);
-      acc.push([escapeKeywords(arg.name), ': ', type, arg.flags.optional ? '?' : '', val ? ` = ${val}` : ''].join(''));
+      const isArgOptional = arg.flags.isList ? arg.flags.isListNullable : arg.flags.optional
+      acc.push([escapeKeywords(arg.name), ': ', type, isArgOptional ? '?' : '', val ? ` = ${val}` : ''].join(''));
       return acc;
     }, []);
 
@@ -347,8 +348,12 @@ export class SwiftDeclarationBlock {
   }
 
   private generatePropertiesStr(prop: StructProperty): string {
-    const propertyTypeName = prop.flags.isList ? this.getListType(prop) : prop.type;
-    const propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.optional ? '?' : ''}` : '';
+    let propertyTypeName = prop.type;
+    let propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.optional ? '?' : ''}` : '';
+    if (prop.flags.isList) {
+      propertyTypeName = this.getListType(prop);
+      propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.isListNullable ? '?' : ''}` : '';
+    }
     let resultArr: string[] = [
       prop.access === 'DEFAULT' ? '' : prop.access,
       prop.flags.static ? 'static' : '',
@@ -388,10 +393,13 @@ export class SwiftDeclarationBlock {
       .trim();
   }
 
-  private getListType(typeDeclaration: VariableDeclaration): string {
+  private getListType(typeDeclaration: MethodArgument): string {
+    const listMemberType = typeDeclaration.flags.optional ?
+     `${escapeKeywords(typeDeclaration.type)}?`:
+     `${escapeKeywords(typeDeclaration.type)}`
     if (typeDeclaration.flags.listType === ListType.LIST) {
-      return `List<${escapeKeywords(typeDeclaration.type)}>`;
+      return `List<${listMemberType}>`;
     }
-    return `[${escapeKeywords(typeDeclaration.type)}]`;
+    return `[${listMemberType}]`;
   }
 }

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -125,7 +125,7 @@ export type VariableFlags = {
 export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean; isListNullable?: boolean };
 export type PropertyFlags = StructFlags;
 export type MethodFlags = { static?: boolean };
-export type DeclarationFlag = { final?: boolean };
+export type DeclarationFlag = { final?: boolean, handleListNullabilityTransparently?: boolean };
 export type Kind = 'class' | 'struct' | 'extension' | 'enum';
 export type VariableDeclaration = {
   value: string | undefined;
@@ -172,6 +172,11 @@ export class SwiftDeclarationBlock {
 
   final(isFinal: boolean = true): SwiftDeclarationBlock {
     this._flags.final = isFinal;
+    return this;
+  }
+
+  handleListNullabilityTransparently(handleListNullabilityTransparently?: boolean): SwiftDeclarationBlock {
+    this._flags.handleListNullabilityTransparently = handleListNullabilityTransparently;
     return this;
   }
 
@@ -338,9 +343,15 @@ export class SwiftDeclarationBlock {
   private generateArgsStr(args: MethodArgument[]): string {
     const res: string[] = args.reduce((acc: string[], arg) => {
       const type = arg.flags.isList ? this.getListType(arg) : escapeKeywords(arg.type);
-      const isArgOptional = arg.flags.isList ? arg.flags.isListNullable : arg.flags.optional
-      const val: string | null = arg.value ? arg.value : isArgOptional ? 'nil' : arg.flags.isList ? '[]' : null;
-      acc.push([escapeKeywords(arg.name), ': ', type, isArgOptional ? '?' : '', val ? ` = ${val}` : ''].join(''));
+      if (this._flags.handleListNullabilityTransparently) {
+        const isArgOptional = arg.flags.isList ? arg.flags.isListNullable : arg.flags.optional
+        const val: string | null = arg.value ? arg.value : isArgOptional ? 'nil' : arg.flags.isList ? '[]' : null;
+        acc.push([escapeKeywords(arg.name), ': ', type, isArgOptional ? '?' : '', val ? ` = ${val}` : ''].join(''));
+      }
+      else {
+        const val: string | null = arg.value ? arg.value : arg.flags.isList ? '[]' : arg.flags.optional ? 'nil' : null;
+        acc.push([escapeKeywords(arg.name), ': ', type, arg.flags.optional ? '?' : '', val ? ` = ${val}` : ''].join(''));
+      }
       return acc;
     }, []);
 
@@ -348,12 +359,13 @@ export class SwiftDeclarationBlock {
   }
 
   private generatePropertiesStr(prop: StructProperty): string {
-    let propertyTypeName = prop.type;
+    let propertyTypeName = prop.flags.isList ? this.getListType(prop) : prop.type;
     let propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.optional ? '?' : ''}` : '';
-    if (prop.flags.isList) {
-      propertyTypeName = this.getListType(prop);
+
+    if (this._flags.handleListNullabilityTransparently && prop.flags.isList) {
       propertyType = propertyTypeName ? `: ${propertyTypeName}${prop.flags.isListNullable ? '?' : ''}` : '';
     }
+
     let resultArr: string[] = [
       prop.access === 'DEFAULT' ? '' : prop.access,
       prop.flags.static ? 'static' : '',

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -337,9 +337,9 @@ export class SwiftDeclarationBlock {
 
   private generateArgsStr(args: MethodArgument[]): string {
     const res: string[] = args.reduce((acc: string[], arg) => {
-      const val: string | null = arg.value ? arg.value : arg.flags.isList ? '[]' : arg.flags.optional ? 'nil' : null;
       const type = arg.flags.isList ? this.getListType(arg) : escapeKeywords(arg.type);
       const isArgOptional = arg.flags.isList ? arg.flags.isListNullable : arg.flags.optional
+      const val: string | null = arg.value ? arg.value : isArgOptional ? 'nil' : arg.flags.isList ? '[]' : null;
       acc.push([escapeKeywords(arg.name), ': ', type, isArgOptional ? '?' : '', val ? ` = ${val}` : ''].join(''));
       return acc;
     }, []);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -338,10 +338,10 @@ export class AppSyncModelJavaVisitor<
    */
   protected generateStepBuilderInterfaces(model: CodeGenModel, isModel: boolean = true): JavaDeclarationBlock[] {
     const nonNullableFields = this.getWritableFields(model).filter(
-      field => field.isList ? !field.isListNullable : !field.isNullable
+      field => this.isRequiredField(field)
     );
     const nullableFields = this.getWritableFields(model).filter(
-      field => field.isList ? field.isListNullable : field.isNullable
+      field => !this.isRequiredField(field)
     );
     const requiredInterfaces = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const interfaces = requiredInterfaces.map((field, idx) => {
@@ -390,10 +390,10 @@ export class AppSyncModelJavaVisitor<
    */
   protected generateBuilderClass(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isModel: boolean = true): void {
     const nonNullableFields = this.getWritableFields(model).filter(
-      field => field.isList ? !field.isListNullable : !field.isNullable
+      field => this.isRequiredField(field)
     );
     const nullableFields = this.getWritableFields(model).filter(
-      field => field.isList ? field.isListNullable : field.isNullable
+      field => !this.isRequiredField(field)
     );
     const stepFields = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const stepInterfaces = stepFields.map((field: CodeGenField) => this.getStepInterfaceName(field.name));
@@ -842,10 +842,9 @@ export class AppSyncModelJavaVisitor<
     if (authRules.length) {
       this.usingAuth = true;
     }
-    const isOptionalField = field.isList ? field.isListNullable : field.isNullable;
     const annotationArgs: string[] = [
       `targetType="${field.type}"`,
-      !isOptionalField ? 'isRequired = true' : '',
+      this.isRequiredField(field) ? 'isRequired = true' : '',
       authRules.length ? `authRules = ${authRules}` : '',
       field.isReadOnly ? 'isReadOnly = true' : '',
     ].filter(arg => arg);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -337,8 +337,12 @@ export class AppSyncModelJavaVisitor<
    *
    */
   protected generateStepBuilderInterfaces(model: CodeGenModel, isModel: boolean = true): JavaDeclarationBlock[] {
-    const nonNullableFields = this.getWritableFields(model).filter(field => !field.isNullable);
-    const nullableFields = this.getWritableFields(model).filter(field => field.isNullable);
+    const nonNullableFields = this.getWritableFields(model).filter(
+      field => field.isList ? !field.isListNullable : !field.isNullable
+    );
+    const nullableFields = this.getWritableFields(model).filter(
+      field => field.isList ? field.isListNullable : field.isNullable
+    );
     const requiredInterfaces = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const interfaces = requiredInterfaces.map((field, idx) => {
       const isLastField = requiredInterfaces.length - 1 === idx ? true : false;
@@ -385,8 +389,12 @@ export class AppSyncModelJavaVisitor<
    * @returns JavaDeclarationBlock
    */
   protected generateBuilderClass(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isModel: boolean = true): void {
-    const nonNullableFields = this.getWritableFields(model).filter(field => !field.isNullable);
-    const nullableFields = this.getWritableFields(model).filter(field => field.isNullable);
+    const nonNullableFields = this.getWritableFields(model).filter(
+      field => field.isList ? !field.isListNullable : !field.isNullable
+    );
+    const nullableFields = this.getWritableFields(model).filter(
+      field => field.isList ? field.isListNullable : field.isNullable
+    );
     const stepFields = nonNullableFields.filter((field: CodeGenField) => !this.READ_ONLY_FIELDS.includes(field.name));
     const stepInterfaces = stepFields.map((field: CodeGenField) => this.getStepInterfaceName(field.name));
 
@@ -834,9 +842,10 @@ export class AppSyncModelJavaVisitor<
     if (authRules.length) {
       this.usingAuth = true;
     }
+    const isOptionalField = field.isList ? field.isListNullable : field.isNullable;
     const annotationArgs: string[] = [
       `targetType="${field.type}"`,
-      !field.isNullable ? 'isRequired = true' : '',
+      !isOptionalField ? 'isRequired = true' : '',
       authRules.length ? `authRules = ${authRules}` : '',
       field.isReadOnly ? 'isReadOnly = true' : '',
     ].filter(arg => arg);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -338,7 +338,10 @@ export class AppSyncSwiftVisitor<
     const name = `${modelKeysName}.${this.getFieldName(field)}`;
     const typeName = this.getSwiftModelTypeName(field);
     const { connectionInfo } = field;
-    const isOptionalField = field.isList ? field.isListNullable : field.isNullable
+    let isOptionalField = field.isList ? field.isListNullable : field.isNullable
+    if (field.connectionInfo && field.connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
+      isOptionalField = true;
+    }
     const isRequired = !isOptionalField ? '.required' : '.optional';
     // connected field
     if (connectionInfo) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -339,9 +339,6 @@ export class AppSyncSwiftVisitor<
     const typeName = this.getSwiftModelTypeName(field);
     const { connectionInfo } = field;
     let isOptionalField = field.isList ? field.isListNullable : field.isNullable
-    if (field.connectionInfo && field.connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
-      isOptionalField = true;
-    }
     const isRequired = !isOptionalField ? '.required' : '.optional';
     // connected field
     if (connectionInfo) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -89,6 +89,7 @@ export class AppSyncSwiftVisitor<
           variable: isVariable,
           isEnum: this.isEnumType(field),
           listType: field.isList ? listType : undefined,
+          isListNullable: field.isListNullable
         });
       });
       const initParams: CodeGenField[] = this.getWritableFields(obj);
@@ -205,6 +206,7 @@ export class AppSyncSwiftVisitor<
           variable: true,
           isEnum: this.isEnumType(field),
           listType: field.isList ? ListType.ARRAY : undefined,
+          isListNullable: field.isListNullable
         });
       });
       result.push(structBlock.string);
@@ -336,7 +338,8 @@ export class AppSyncSwiftVisitor<
     const name = `${modelKeysName}.${this.getFieldName(field)}`;
     const typeName = this.getSwiftModelTypeName(field);
     const { connectionInfo } = field;
-    const isRequired = this.isFieldRequired(field) ? '.required' : '.optional';
+    const isOptionalField = field.isList ? field.isListNullable : field.isNullable
+    const isRequired = !isOptionalField ? '.required' : '.optional';
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -119,6 +119,8 @@ export class AppSyncSwiftVisitor<
                 isList: field.isList,
                 isEnum: this.isEnumType(field),
                 listType: field.isList ? listType : undefined,
+                isListNullable: field.isListNullable,
+                handleListNullabilityTransparently: this.isHasManyConnectionField(field) ? false : this.config.handleListNullabilityTransparently
               },
             };
           }),
@@ -141,6 +143,8 @@ export class AppSyncSwiftVisitor<
                 isList: field.isList,
                 isEnum: this.isEnumType(field),
                 listType: field.isList ? listType : undefined,
+                isListNullable: field.isListNullable,
+                handleListNullabilityTransparently: this.isHasManyConnectionField(field) ? false : this.config.handleListNullabilityTransparently
               },
             };
           }),
@@ -164,6 +168,8 @@ export class AppSyncSwiftVisitor<
                 isList: field.isList,
                 isEnum: this.isEnumType(field),
                 listType: field.isList ? listType : undefined,
+                isListNullable: field.isListNullable,
+                handleListNullabilityTransparently: this.isHasManyConnectionField(field) ? false : this.config.handleListNullabilityTransparently
               },
             };
           }),
@@ -441,7 +447,7 @@ export class AppSyncSwiftVisitor<
 
     return keyDirectives
   }
-  
+
   protected isHasManyConnectionField(field: CodeGenField): boolean {
     if (field.connectionInfo && field.connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
       return true;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -78,8 +78,7 @@ export class AppSyncSwiftVisitor<
       const structBlock: SwiftDeclarationBlock = new SwiftDeclarationBlock()
         .withName(this.getModelName(obj))
         .access('public')
-        .withProtocols(['Model'])
-        .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+        .withProtocols(['Model']);
       Object.entries(obj.fields).forEach(([fieldName, field]) => {
         const fieldType = this.getNativeType(field);
         const isVariable = field.name !== 'id';
@@ -90,7 +89,8 @@ export class AppSyncSwiftVisitor<
           variable: isVariable,
           isEnum: this.isEnumType(field),
           listType: field.isList ? listType : undefined,
-          isListNullable: field.isListNullable
+          isListNullable: field.isListNullable,
+          handleListNullabilityTransparently: this.isHasManyConnectionField(field) ? false : this.config.handleListNullabilityTransparently
         });
       });
       const initParams: CodeGenField[] = this.getWritableFields(obj);
@@ -182,8 +182,7 @@ export class AppSyncSwiftVisitor<
         .asKind('enum')
         .access('public')
         .withProtocols(['String', 'EnumPersistable'])
-        .withName(this.getEnumName(enumValue))
-        .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+        .withName(this.getEnumName(enumValue));
 
       Object.entries(enumValue.values).forEach(([name, value]) => {
         enumDeclaration.addEnumValue(name, value);
@@ -199,8 +198,7 @@ export class AppSyncSwiftVisitor<
       const structBlock: SwiftDeclarationBlock = new SwiftDeclarationBlock()
         .withName(this.getModelName(obj))
         .access('public')
-        .withProtocols(['Embeddable'])
-        .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+        .withProtocols(['Embeddable']);
       Object.values(obj.fields).forEach(field => {
         const fieldType = this.getNativeType(field);
         structBlock.addProperty(this.getFieldName(field), fieldType, undefined, 'DEFAULT', {
@@ -209,7 +207,8 @@ export class AppSyncSwiftVisitor<
           variable: true,
           isEnum: this.isEnumType(field),
           listType: field.isList ? ListType.ARRAY : undefined,
-          isListNullable: field.isListNullable
+          isListNullable: field.isListNullable,
+          handleListNullabilityTransparently: this.isHasManyConnectionField(field) ? false : this.config.handleListNullabilityTransparently
         });
       });
       result.push(structBlock.string);
@@ -225,8 +224,7 @@ export class AppSyncSwiftVisitor<
       .forEach(model => {
         const schemaDeclarations = new SwiftDeclarationBlock()
         .asKind('extension')
-        .withName(this.getModelName(model))
-        .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+        .withName(this.getModelName(model));
 
         this.generateCodingKeys(this.getModelName(model), model, schemaDeclarations),
           this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
@@ -237,8 +235,7 @@ export class AppSyncSwiftVisitor<
     Object.values(this.getSelectedNonModels()).forEach(model => {
       const schemaDeclarations = new SwiftDeclarationBlock()
       .asKind('extension')
-      .withName(this.getNonModelName(model))
-      .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+      .withName(this.getNonModelName(model));
 
       this.generateCodingKeys(this.getNonModelName(model), model, schemaDeclarations),
         this.generateModelSchema(this.getNonModelName(model), model, schemaDeclarations);
@@ -254,8 +251,7 @@ export class AppSyncSwiftVisitor<
       .access('public')
       .withName('CodingKeys')
       .withProtocols(['String', 'ModelKey'])
-      .withComment('MARK: - CodingKeys')
-      .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+      .withComment('MARK: - CodingKeys');
 
     // AddEnums.name
     model.fields.forEach(field => codingKeyEnum.addEnumValue(this.getFieldName(field), field.name));
@@ -307,8 +303,7 @@ export class AppSyncSwiftVisitor<
       .asKind('class')
       .withProtocols(['AmplifyModelRegistration'])
       .final()
-      .withComment('Contains the set of classes that conforms to the `Model` protocol.')
-      .handleListNullabilityTransparently(this.config.handleListNullabilityTransparently);
+      .withComment('Contains the set of classes that conforms to the `Model` protocol.');
 
     classDeclaration.addProperty('version', 'String', `"${this.computeVersion()}"`, 'public', {});
     const body = structList.map(modelClass => `ModelRegistry.register(modelType: ${modelClass})`).join('\n');
@@ -349,7 +344,9 @@ export class AppSyncSwiftVisitor<
     const name = `${modelKeysName}.${this.getFieldName(field)}`;
     const typeName = this.getSwiftModelTypeName(field);
     const { connectionInfo } = field;
-    const isRequired = this.isRequiredField(field) ? '.required' : '.optional';
+    const isRequiredField = ((!this.isHasManyConnectionField(field)) && this.config.handleListNullabilityTransparently) ?
+     this.isRequiredField(field) : this.isFieldRequired(field);
+    const isRequired = isRequiredField ? '.required' : '.optional';
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
@@ -427,7 +424,7 @@ export class AppSyncSwiftVisitor<
    * @param field field
    */
   protected isFieldRequired(field: CodeGenField): boolean {
-    if (field.connectionInfo && field.connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
+    if (this.isHasManyConnectionField(field)) {
       return false;
     }
     return !field.isNullable;
@@ -442,7 +439,14 @@ export class AppSyncSwiftVisitor<
         return `.index(fields: [${fields}], name: ${name})`;
       });
 
-      return keyDirectives
+    return keyDirectives
+  }
+  
+  protected isHasManyConnectionField(field: CodeGenField): boolean {
+    if (field.connectionInfo && field.connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
+      return true;
+    }
+    return false;
   }
 
   protected generateAuthRules(model: CodeGenModel): string {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -562,7 +562,7 @@ export class AppSyncModelVisitor<
 
   /**
    * Check if the given field is nullable or required
-   * @param field 
+   * @param field
    */
    protected isRequiredField(field: CodeGenField): boolean | undefined {
     return !(this.config.handleListNullabilityTransparently ? (field.isList ? field.isListNullable : field.isNullable) : field.isNullable);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -97,11 +97,17 @@ export interface RawAppSyncModelConfig extends RawConfig {
    */
   directives?: string;
   /**
-   * @name directives
+   * @name isTimestampFieldsAdded
    * @type boolean
    * @descriptions optional boolean which adds the read-only timestamp fields or not
    */
   isTimestampFieldsAdded?: boolean;
+  /**
+   * @name handleListNullabilityTransparently
+   * @type boolean
+   * @descriptions optional boolean which generates the list types to respect the nullability as defined in the schema
+   */
+   handleListNullabilityTransparently?: boolean;
 }
 
 // Todo: need to figure out how to share config
@@ -110,6 +116,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   generate?: CodeGenGenerateEnum;
   target?: string;
   isTimestampFieldsAdded?: boolean;
+  handleListNullabilityTransparently?: boolean;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -176,6 +183,7 @@ export class AppSyncModelVisitor<
       scalars: buildScalars(_schema, rawConfig.scalars || '', defaultScalars),
       target: rawConfig.target,
       isTimestampFieldsAdded: rawConfig.isTimestampFieldsAdded,
+      handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently
     });
 
     const typesUsedInDirectives: string[] = [];
@@ -551,6 +559,14 @@ export class AppSyncModelVisitor<
     addFieldToModel(model, createdAtField);
     addFieldToModel(model, updatedAtField);
   }
+
+  /**
+   * Check if the given field is nullable or required
+   * @param field 
+   */
+   protected isRequiredField(field: CodeGenField): boolean | undefined {
+    return !(this.config.handleListNullabilityTransparently ? (field.isList ? field.isListNullable : field.isNullable) : field.isNullable);
+   }
 
   get models() {
     return this.modelMap;


### PR DESCRIPTION
Issue #, if available:
fix #104

Description of changes:
This PR fixes the bug in handling nullable lists and list components for `iOS` and `Android` platforms. 

There could be various combinations of optional lists in swift like `[String?]?, [String]?, [String?] and [String]`. These have to be generated correctly based on their graphQL definitions `[String], [String!], [String]! and [String!]!`.

Android DataStore on the other hand, does not enforce any checks for nullability of list components. So, a GraphQL field definition like `[String!]` will not be caught during runtime but throws the exception returned from Appsync server when a `null` value is present in the list. This PR includes fix to a bug related to handling the `required` list fields. 

This change will be released behind a Feature Flag. 

How are these changes tested:
Unit test that covers all combinations of nullability in a list and verifies appropriate swift/java type is generated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
