### PR TITLE
chore: optimize local testing of amplify-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,24 +4,52 @@ Thank you for your interest in contributing to our project! 💛
 
 Whether it's a bug report, new feature, correction, or additional documentation, we greatly value feedback and contributions from our community. Please read through these guidelines carefully before submitting a PR or issue and let us know if it's not up-to-date (or even better, submit a PR with your proposed corrections 😉).
 
-# Development Process
+## Getting Started
 
 Our work is done directly on Github and PR's are sent to the GitHub repo by core team members and contributors. Everyone undergoes the same review process to get their changes into the repo.
 
-# Setting up for local development
+This section should get you running with **Amplify Codegen**.
 
-This section should get you running with **Amplify Codegen**. You will need the latest version of [nodejs](https://nodejs.org/en/) on your system and developing locally also requires `yarn` workspaces. You can install it [here](https://classic.yarnpkg.com/en/docs/install#mac-stable).
+### Setting up for local development
 
-Start by, [Forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the main branch of [amplify-codegen](https://github.com/aws-amplify/amplify-codegen).
+1. You will need the latest version of [nodejs](https://nodejs.org/en/) on your system and developing locally also requires `yarn` workspaces. You can install it [here](https://classic.yarnpkg.com/en/docs/install#mac-stable).
 
-```
+2. Start by [Forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the main branch of [amplify-codegen](https://github.com/aws-amplify/amplify-codegen).
+
+```sh
 $ git clone git@github.com:[username]/amplify-codegen.git
-$ cd amplify-codegen
-
-$ yarn run setup-dev
 ```
 
-# Bugs
+> NOTE: Make sure to always [sync your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) with _main_ branch of amplify-codegen
+
+3. Move into your project folder
+
+```sh
+$ cd amplify-codegen
+```
+
+4. Run `setup-dev` script to installs dependencies and perform initial configuration. This command will also link a `amplify-dev` binary for your local testing.
+
+```sh
+$ yarn setup-dev
+```
+
+> NOTE: The `amplify-dev` binary is built based on the latest amplify cli from npm registry and your local codegen packages. All your local changes from codegen can be reflected (typescript files need to be build by `tsc`). In addition, if you are a developer of cli repo, you can run the same command to override the `amplify-dev` binary.
+
+### Architecture of the codebase
+
+Amplify Codegen is a monorepo built with [Yarn Workspaces](https://yarnpkg.com/features/workspaces) and [Lerna](https://github.com/lerna/lerna). All packages live within the `packages/` directory in the root. Each category inside packages has its own `src/` and `package.json`.
+
+### Steps towards contribution
+
+- Make changes to required file.
+- Write unit tests
+- Yarn build
+- Run test suite
+- Test in sample app using [amplify-dev](#tests)
+- Submit a PR
+
+## Bugs
 
 Bug reports and feature suggestions are always welcome. Good bug reports are extremely helpful, so thanks in advance!
 
@@ -40,20 +68,20 @@ Guidelines for bug reports:
 - Format any code snippets using [Markdown](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) syntax
 - If you're not using the latest version of the CLI, see if the issue still persists after upgrading - this helps to isolate regressions!
 
-# Pull Requests
-
+## Pull Requests
 
 Pull requests are welcome!
 
-You should open an issue to discuss your pull request, unless it's a trivial change. It's best to ensure that your proposed change would be accepted so that you don't waste your own time. If you would like to implement support for a significant feature that is not yet available, please talk to us beforehand to avoid any duplication of effort. 
+You should open an issue to discuss your pull request, unless it's a trivial change. It's best to ensure that your proposed change would be accepted so that you don't waste your own time. If you would like to implement support for a significant feature that is not yet available, please talk to us beforehand to avoid any duplication of effort.
 
 Pull requests should generally be opened against **master**.
 
-Only include ***src*** files in your PR. Don't include any build files i.e. dist/. These will be built upon publish to npm and when a release is created on GitHub.
+Only include **_src_** files in your PR. Don't include any build files i.e. dist/. These will be built upon publish to npm and when a release is created on GitHub.
 
 Before submitting PR make sure to run `yarn` on the root of monorepo to ensure that commit lint and husky are installed.
 
 Make sure you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) commit message structure. You can automatically generate conventional commit message by running `yarn commit` in the root of the amplify mono repo. This will run through series of question shown below
+
 ```
 ? Select the type of change that you're committing: <type of commit (if its a feature, bug fix etc.,>
 ? What is the scope of this change (e.g. component or file name)? <package name if change is only in one package>
@@ -67,7 +95,25 @@ Make sure you follow [conventional commits](https://www.conventionalcommits.org/
 
 ## Tests
 
-Please ensure that your change still passes unit tests, and ideally integration/UI tests. Use `yarn run test-ci` to run the test suite like it would in our CI environment. It's OK if you're still working on tests at the time that you submit, but be prepared to be asked about them. Wherever possible, pull requests should contain tests as appropriate. Bugfixes should contain tests that exercise the corrected behavior (i.e., the test should fail without the bugfix and pass with it), and new features should be accompanied by tests exercising the feature.
+Please ensure that your change still passes unit tests, and ideally integration/UI tests. It's OK if you're still working on tests at the time that you submit, but be prepared to be asked about them. Wherever possible, pull requests should contain tests as appropriate. Bugfixes should contain tests that exercise the corrected behavior (i.e., the test should fail without the bugfix and pass with it), and new features should be accompanied by tests exercising the feature.
+
+To run the test suite:
+
+```sh
+# Unit tests
+$ yarn test
+
+# Tests in CI environment
+$ yarn test-ci
+```
+
+To test in a sample application with `amplify-dev`:
+
+```sh
+$ cd <your-test-frontend-project>
+$ amplify-dev init
+$ amplify-dev codegen <subcommand>
+```
 
 ## Code Style
 
@@ -91,7 +137,6 @@ For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of
 ## Security Issue Reporting
 
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
-
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 Pull requests should generally be opened against **master**.
 
-Only include **src** files in your PR. Don't include any build files i.e. dist/. These will be built upon publish to npm and when a release is created on GitHub.
+Only include **_src_** files in your PR. Don't include any build files i.e. `dist/`. These will be built upon publish to npm and when a release is created on GitHub.
 
 Before submitting PR make sure to run `yarn` on the root of monorepo to ensure that commit lint and husky are installed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Amplify Codegen is a monorepo built with [Yarn Workspaces](https://yarnpkg.com/f
 - Make changes to required file.
 - Write unit tests
 - Run `yarn build` to compile your changes
-- Run test suite (#tests)
+- [Run test suite](#tests)
 - Test in sample app using [amplify-dev](#tests)
 - Submit a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 Pull requests should generally be opened against **master**.
 
-Only include **_src_** files in your PR. Don't include any build files i.e. `dist/`. These will be built upon publish to npm and when a release is created on GitHub.
+Don't include any build files i.e. `dist/`. These will be built upon publish to npm and when a release is created on GitHub.
 
 Before submitting PR make sure to run `yarn` on the root of monorepo to ensure that commit lint and husky are installed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ Amplify Codegen is a monorepo built with [Yarn Workspaces](https://yarnpkg.com/f
 
 - Make changes to required file.
 - Write unit tests
-- Yarn build
-- Run test suite
+- Run `yarn build` to compile your changes
+- Run test suite (#tests)
 - Test in sample app using [amplify-dev](#tests)
 - Submit a PR
 
@@ -76,7 +76,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 Pull requests should generally be opened against **master**.
 
-Don't include any build files i.e. `dist/`. These will be built upon publish to npm and when a release is created on GitHub.
+Don't include any build files i.e. `dist/`, `lib/`. These will be built upon publish to npm and when a release is created on GitHub.
 
 Before submitting PR make sure to run `yarn` on the root of monorepo to ensure that commit lint and husky are installed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ You should open an issue to discuss your pull request, unless it's a trivial cha
 
 Pull requests should generally be opened against **master**.
 
-Only include **_src_** files in your PR. Don't include any build files i.e. dist/. These will be built upon publish to npm and when a release is created on GitHub.
+Only include **src** files in your PR. Don't include any build files i.e. dist/. These will be built upon publish to npm and when a release is created on GitHub.
 
 Before submitting PR make sure to run `yarn` on the root of monorepo to ensure that commit lint and husky are installed.
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lnk": "1.1.0",
     "prettier": "^1.19.1",
     "prettier-eslint": "^9.0.1",
-    "pretty-quick": "^2.0.1",
+    "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^25.5.0",
     "ts-node": "^8.10.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "hoist-cli": "rm -rf node_modules/amplify-cli && mkdir node_modules/amplify-cli && cp -r node_modules/@aws-amplify/cli/ node_modules/amplify-cli",
     "link-dev": "cd node_modules/amplify-cli && ln -s \"$(pwd)/bin/amplify\" \"$(yarn global bin)/amplify-dev\" && cd -",
     "rm-dev-link": "rm -f \"$(yarn global bin)/amplify-dev\"",
-
     "commit": "git-cz",
     "coverage": "codecov || exit 0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
     "verdaccio-publish": "yarn verdaccio-clean && yarn publish-to-verdaccio",
     "verdaccio-disconnect": "source .circleci/local_publish_helpers.sh && unsetNpmRegistryUrl",
     "verdaccio-stop": "kill -9 $(lsof -n -t -iTCP:4873 -sTCP:LISTEN)",
-    "setup-dev": "yarn && lerna run build",
+    "setup-dev": "(yarn && lerna run build) && (yarn hoist-cli && yarn rm-dev-link && yarn link-dev)",
+    "hoist-cli": "rm -rf node_modules/amplify-cli && mkdir node_modules/amplify-cli && cp -r node_modules/@aws-amplify/cli/ node_modules/amplify-cli",
+    "link-dev": "cd node_modules/amplify-cli && ln -s \"$(pwd)/bin/amplify\" \"$(yarn global bin)/amplify-dev\" && cd -",
+    "rm-dev-link": "rm -f \"$(yarn global bin)/amplify-dev\"",
+
     "commit": "git-cz",
     "coverage": "codecov || exit 0"
   },
@@ -89,8 +93,7 @@
     "ts-jest": "^25.5.0",
     "ts-node": "^8.10.1",
     "typescript": "^3.8.3",
-    "amplify-cli-core": "^1.17.2",
-    "graphql-transformer-core": "^6.26.2"
+    "@aws-amplify/cli": "^4.46.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The changes enable developers to use `amplify-dev` directly for local testing by just one command `yarn setup-dev`. The cli binary in `node_modules` can also be used for local amplify e2e tests.

- Add `@aws-amplify/cli` with caret version(latest) as the dev-dependency.
- Remove additional dependencies(cli-core, graphql-core) since they are already included in cli.
- Add scripts to hoist cli package in `node_modules` so that it can scan the related plugins successfully.
- Add scripts to link `amplify-dev` to yarn global

_How are these changes tested:_

- `yarn setup-dev` and run `amplify-dev -v`
- Run `amplify-dev codegen [subcommands]` to make sure it runs successfully and reflects local changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
