### PR TITLE
Add e2e tests for Codegen remove workflow

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -56,3 +56,20 @@ export function addCodegen(cwd: string, settings: any = {}): Promise<void> {
     });
   });
 }
+
+// CLI workflow to remove the configured codegen from the project
+export function removeCodegen(cwd: string, isCodegenAdded: boolean = true): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const chain = spawn(getCLIPath(), ['codegen', 'remove'], { cwd, stripColors: true });
+    if (!isCodegenAdded) {
+      chain.wait("Codegen is not configured");
+    }
+    chain.run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/__snapshots__/remove-codegen.test.ts.snap
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/__snapshots__/remove-codegen.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`codegen remove tests Do nothing during remove when codegen is previouly added in android project 1`] = `
+"projects: {}
+extensions:
+  amplify:
+    version: 3
+"
+`;
+
+exports[`codegen remove tests Do nothing during remove when codegen is previouly added in ios project 1`] = `
+"projects: {}
+extensions:
+  amplify:
+    version: 3
+"
+`;
+
+exports[`codegen remove tests Do nothing during remove when codegen is previouly added in javascript project 1`] = `
+"projects: {}
+extensions:
+  amplify:
+    version: 3
+"
+`;

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen.test.ts
@@ -70,7 +70,6 @@ import {
         // previously generated files should still exist
         expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
         // graphql configuration should be updated to remove previous configuration
-        console.log(readFileSync(path.join(projectRoot, graphqlConfigFile)));
         expect(readFileSync(path.join(projectRoot, graphqlConfigFile)).toString()).toMatchSnapshot();
       });
     });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen.test.ts
@@ -1,0 +1,77 @@
+import { 
+    createNewProjectDir, 
+    deleteProjectDir,
+    deleteProject,
+    initProjectWithProfile,
+    addApiWithSchema,
+    addCodegen,
+    DEFAULT_JS_CONFIG,
+    DEFAULT_ANDROID_CONFIG,
+    DEFAULT_IOS_CONFIG,
+    AmplifyFrontendConfig,
+    removeCodegen
+  } from "amplify-codegen-e2e-core";
+  import { existsSync, readFileSync } from "fs";
+  import path from 'path';
+  import { isNotEmptyDir, generateSourceCode } from '../utils';
+  
+  const frontendConfigs: AmplifyFrontendConfig[] = [
+    DEFAULT_JS_CONFIG,
+    DEFAULT_ANDROID_CONFIG,
+    DEFAULT_IOS_CONFIG
+  ];
+  const schema = 'simple_model.graphql';
+  const graphqlConfigFile = '.graphqlconfig.yml';
+  
+  describe('codegen remove tests', () => {
+    let projectRoot: string;
+  
+    beforeEach(async () => {
+      projectRoot = await createNewProjectDir('removeCodegen');
+    });
+  
+    afterEach(async () => {
+      const metaFilePath = path.join(projectRoot, 'amplify', '#current-cloud-backend', 'amplify-meta.json');
+      if (existsSync(metaFilePath)) {
+        await deleteProject(projectRoot);
+      }
+      deleteProjectDir(projectRoot);
+    });
+  
+    it(`Do nothing during remove when codegen is not added in JS project`, async () => {
+      // init project and add API category
+      await initProjectWithProfile(projectRoot, DEFAULT_JS_CONFIG);
+      await addApiWithSchema(projectRoot, schema);
+      
+      // remove command should give expected message
+      await expect(removeCodegen(projectRoot, false)).resolves.not.toThrow();
+    });
+
+    frontendConfigs.forEach(config => {
+      it(`Do nothing during remove when codegen is previouly added in ${config.frontendType} project`, async () => {
+        // init project and add API category
+        await initProjectWithProfile(projectRoot, { ...config });
+        await addApiWithSchema(projectRoot, schema);
+
+        // generate pre-existing user file
+        const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);
+        expect(existsSync(userSourceCodePath)).toBe(true);
+
+        // add codegen
+        await expect(addCodegen(projectRoot, { ...config })).resolves.not.toThrow();
+        expect(existsSync(path.join(projectRoot, graphqlConfigFile))).toBe(true);
+        expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
+
+        // remove codegen
+        await expect(removeCodegen(projectRoot)).resolves.not.toThrow();
+
+        // pre-existing file should still exist
+        expect(existsSync(userSourceCodePath)).toBe(true);
+        // previously generated files should still exist
+        expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
+        // graphql configuration should be updated to remove previous configuration
+        console.log(readFileSync(path.join(projectRoot, graphqlConfigFile)));
+        expect(readFileSync(path.join(projectRoot, graphqlConfigFile)).toString()).toMatchSnapshot();
+      });
+    });
+  });


### PR DESCRIPTION
_Description of changes:_
Adding e2e tests that cover P0 cases for the `amplify codegen remove` workflow.

_How are these changes tested:_
Tested the test suite locally using `jest remove-codegen.test.ts` with amplify binary `4.49.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
