### PR TITLE
test: add split e2e test script

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -188,6 +188,8 @@ workflows:
                 - e2e-testing
                 - split-e2e
       - e2e-test:
+          context:
+            - clean_e2e_resources
           os: linux_node15
           requires:
             - publish_to_local_registry

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -184,6 +184,7 @@ workflows:
             branches:
               only:
                 - e2e-testing
+                - split-e2e
       - e2e-test:
           os: linux_node15
           requires:
@@ -194,6 +195,7 @@ workflows:
             branches:
               only:
                 - e2e-testing
+                - split-e2e
       - deploy:
           os: linux_node15
           requires:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -119,7 +119,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Publish to verdaccio
           command: |

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -150,6 +150,7 @@ jobs:
           command: |
             cd packages/amplify-codegen-e2e-tests
             yarn run e2e --maxWorkers=3 $TEST_SUITE
+          no_output_timeout: 20m
       - store_test_results:
           path: packages/amplify-codegen-e2e-tests/
       - store_artifacts:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -3,11 +3,11 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 executors:
-  linux-node12:
+  linux_node12:
     docker:
       - image: circleci/node:12
     resource_class: large
-  linux-node15:
+  linux_node15:
     docker:
       - image: circleci/node:15
     resource_class: large

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -177,9 +177,11 @@ workflows:
           requires:
             - build-<< matrix.os >>
       - publish_to_local_registry:
-          os: linux_node15
+          matrix:
+            parameters:
+              os: linux_node15
           requires:
-            - build
+            - build-<< matrix.os >>
           filters:
             branches:
               only:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -179,7 +179,7 @@ workflows:
       - publish_to_local_registry:
           matrix:
             parameters:
-              os: linux_node15
+              os: [linux_node15]
           requires:
             - build-<< matrix.os >>
           filters:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -177,7 +177,7 @@ workflows:
           requires:
             - build-<< matrix.os >>
       - publish_to_local_registry:
-          os: linux-node15
+          os: linux_node15
           requires:
             - build
           filters:
@@ -185,7 +185,7 @@ workflows:
               only:
                 - e2e-testing
       - e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps:
@@ -195,7 +195,7 @@ workflows:
               only:
                 - e2e-testing
       - deploy:
-          os: linux-node15
+          os: linux_node15
           requires:
             - build
             - test
@@ -206,6 +206,6 @@ workflows:
                 - release
                 - master
       - done_with_node_e2e_tests:
-          os: linux-node15
+          os: linux_node15
           requires:
             - e2e-test

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -30,7 +30,6 @@ defaults: &defaults
 install_cli_with_local_codegen: &install_cli
   name: install Amplify CLI and amplify-app with local Amplify Codegen
   command: |
-    echo $OLD_CLI_BINARY
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
@@ -44,7 +43,6 @@ install_cli_with_local_codegen: &install_cli
 clean_up_e2e_resources: &cleanup_e2e
   name: Clean up e2e resources
   command: |
-    pwd
     cd packages/amplify-codegen-e2e-tests
     yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
   working_directory: ~/repo
@@ -180,7 +178,7 @@ workflows:
       - publish_to_local_registry:
           matrix:
             parameters:
-              os: [linux_node15]
+              os: [linux_node12]
           requires:
             - build-<< matrix.os >>
           filters:
@@ -191,7 +189,7 @@ workflows:
       - e2e-test:
           context:
             - cleanup-resources
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps:

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1,0 +1,211 @@
+version: 2.1
+machine:
+  environment:
+    PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
+executors:
+  linux-node12:
+    docker:
+      - image: circleci/node:12
+    resource_class: large
+  linux-node15:
+    docker:
+      - image: circleci/node:15
+    resource_class: large
+  windows_node12:
+    machine:
+      image: 'windows-server-2019-vs2019:stable'
+      resource_class: windows.large
+      shell: bash.exe
+  macos_node12:
+    macos:
+      xcode: "11.2.1"
+      resource_class: large
+
+defaults: &defaults
+  working_directory: ~/repo
+  parameters:
+      os:
+        type: executor
+
+install_cli_with_local_codegen: &install_cli
+  name: install Amplify CLI and amplify-app with local Amplify Codegen
+  command: |
+    echo $OLD_CLI_BINARY
+    source .circleci/local_publish_helpers.sh
+    startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+    setNpmRegistryUrlToLocal
+    sudo npm install -g @aws-amplify/cli
+    sudo npm install -g amplify-app
+    amplify -v
+    amplify-app --version
+    unsetNpmRegistryUrl
+  working_directory: ~/repo
+        
+clean_up_e2e_resources: &cleanup_e2e
+  name: Clean up e2e resources
+  command: |
+    pwd
+    cd packages/amplify-codegen-e2e-tests
+    yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
+  working_directory: ~/repo
+
+jobs:
+  build:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - checkout
+      - run: yarn config set workspaces-experimental true
+      - run: yarn cache clean --force
+      - run: yarn run production-build
+      - save_cache:
+          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache
+      - save_cache:
+          key: amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}
+          paths:
+            - ~/.ssh
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  test:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Lint
+          command: yarn lint
+      - run:
+          name: Run tests
+          command: yarn test-ci
+      - run:
+          name: Collect code coverage
+          command: yarn coverage
+
+  deploy:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          keys:
+            - amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}
+            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Authenticate with npm
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run:
+          name: Publish Amplify Codegen
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              git config --global user.email $GITHUB_EMAIL
+              git config --global user.name $GITHUB_USER
+              npm run publish:$CIRCLE_BRANCH
+            else
+              echo "Skipping deploy."
+            fi
+
+  publish_to_local_registry:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Publish to verdaccio
+          command: |
+            source .circleci/local_publish_helpers.sh
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            setNpmRegistryUrlToLocal
+            loginToLocalRegistry
+            git config user.email not@used.com
+            git config user.name "Doesnt Matter"
+            yarn publish-to-verdaccio
+            unsetNpmRegistryUrl
+      - save_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/verdaccio-cache/
+
+  e2e-test:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
+      - run: *install_cli
+      - run:
+          name: Run e2e tests
+          command: |
+            cd packages/amplify-codegen-e2e-tests
+            yarn run e2e --maxWorkers=3 $TEST_SUITE
+      - store_test_results:
+          path: packages/amplify-codegen-e2e-tests/
+      - store_artifacts:
+          path: ~/repo/packages/amplify-codegen-e2e-tests/amplify-e2e-reports
+
+  done_with_node_e2e_tests:
+    <<: *defaults
+    executor: << parameters.os >>
+    steps:
+      - run: echo 'Done with Node CLI E2E Tests'
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build:
+          name: build-<< matrix.os >>
+          matrix:
+            parameters:
+              os: [linux_node15, linux_node12, windows_node12, macos_node12]
+      - test:
+          name: test-<< matrix.os >>
+          matrix:
+            parameters:
+              os: [linux_node15, linux_node12, windows_node12, macos_node12]
+          requires:
+            - build-<< matrix.os >>
+      - publish_to_local_registry:
+          os: linux-node15
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - e2e-testing
+      - e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          post-steps:
+            - run: *cleanup_e2e
+          filters:
+            branches:
+              only:
+                - e2e-testing
+      - deploy:
+          os: linux-node15
+          requires:
+            - build
+            - test
+            - done_with_node_e2e_tests
+          filters:
+            branches:
+              only:
+                - release
+                - master
+      - done_with_node_e2e_tests:
+          os: linux-node15
+          requires:
+            - e2e-test

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -189,7 +189,7 @@ workflows:
                 - split-e2e
       - e2e-test:
           context:
-            - clean_e2e_resources
+            - cleanup-resources
           os: linux_node15
           requires:
             - publish_to_local_registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ machine:
 executors:
   linux-node12:
     docker:
-      - image: 'circleci/node:12'
+      - image: circleci/node:12
     resource_class: large
   linux-node15:
     docker:
-      - image: 'circleci/node:15'
+      - image: circleci/node:15
     resource_class: large
   windows_node12:
     machine:
@@ -19,7 +19,7 @@ executors:
       shell: bash.exe
   macos_node12:
     macos:
-      xcode: 11.2.1
+      xcode: "11.2.1"
       resource_class: large
 defaults:
   working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,8 @@ workflows:
       - publish_to_local_registry:
           matrix:
             parameters:
-              os: linux_node15
+              os:
+                - linux_node15
           requires:
             - build-<< matrix.os >>
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+# auto generated file. Edit config.base.yaml if you want to change
 version: 2.1
 machine:
   environment:
@@ -5,7 +6,7 @@ machine:
 executors:
   linux_node12:
     docker:
-      - image: circleci/node:12
+      - image: 'circleci/node:12'
     resource_class: large
   linux_node15:
     docker:
@@ -23,39 +24,33 @@ executors:
 
 defaults: &defaults
   working_directory: ~/repo
-  parameters:
-      os:
-        type: executor
-
-install_cli_with_local_codegen: &install_cli
+  parameters: &ref_0
+    os:
+      type: executor
+install_cli_with_local_codegen: &ref_1
   name: install Amplify CLI and amplify-app with local Amplify Codegen
   command: |
-    npm get prefix
+    echo $OLD_CLI_BINARY
     source .circleci/local_publish_helpers.sh
-    local_registry=http://localhost:4873
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
-    setNpmRegistryUrlToLocal "$local_registry"
-    git config user.email not@used.com
-    git config user.name "Doesnt Matter"
-    yarn verdaccio-publish || yarn verdaccio-publish
-    sudo npm i -g @aws-amplify/cli --registry $local_registry
-    sudo npm i -g amplify-app --registry $local_registry
+    setNpmRegistryUrlToLocal
+    sudo npm install -g @aws-amplify/cli
+    sudo npm install -g amplify-app
     amplify -v
     amplify-app --version
     unsetNpmRegistryUrl
   working_directory: ~/repo
-        
-clean_up_e2e_resources: &cleanup_e2e
+clean_up_e2e_resources:
   name: Clean up e2e resources
   command: |
     pwd
     cd packages/amplify-codegen-e2e-tests
     yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
   working_directory: ~/repo
-
 jobs:
   build:
-    <<: *defaults
+    working_directory: ~/repo
+    parameters: *ref_0
     executor: << parameters.os >>
     steps:
       - checkout
@@ -73,9 +68,9 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: .
-
   test:
-    <<: *defaults
+    working_directory: ~/repo
+    parameters: *ref_0
     executor: << parameters.os >>
     steps:
       - attach_workspace:
@@ -91,9 +86,9 @@ jobs:
       - run:
           name: Collect code coverage
           command: yarn coverage
-
   deploy:
-    <<: *defaults
+    working_directory: ~/repo
+    parameters: *ref_0
     executor: << parameters.os >>
     steps:
       - attach_workspace:
@@ -104,7 +99,7 @@ jobs:
             - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with npm
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          command: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc'
       - run:
           name: Publish Amplify Codegen
           command: |
@@ -115,26 +110,231 @@ jobs:
             else
               echo "Skipping deploy."
             fi
-
-  e2e-test:
-    <<: *defaults
+  publish_to_local_registry:
+    working_directory: ~/repo
+    parameters: *ref_0
     executor: << parameters.os >>
     steps:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - run: *install_cli
+            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: Publish to verdaccio
+          command: |
+            source .circleci/local_publish_helpers.sh
+            startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
+            setNpmRegistryUrlToLocal
+            loginToLocalRegistry
+            git config user.email not@used.com
+            git config user.name "Doesnt Matter"
+            yarn publish-to-verdaccio
+            unsetNpmRegistryUrl
+      - save_cache:
+          key: 'amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}'
+          paths:
+            - ~/verdaccio-cache/
+  e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: &ref_2
+      - attach_workspace:
+          at: ./
+      - restore_cache:
+          key: 'amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}'
+      - run: *ref_1
       - run:
           name: Run e2e tests
           command: |
             cd packages/amplify-codegen-e2e-tests
-            yarn run e2e --maxWorkers=3
+            yarn run e2e --maxWorkers=3 $TEST_SUITE
       - store_test_results:
           path: packages/amplify-codegen-e2e-tests/
       - store_artifacts:
           path: ~/repo/packages/amplify-codegen-e2e-tests/amplify-e2e-reports
-
+  done_with_node_e2e_tests:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps:
+      - run: echo 'Done with Node CLI E2E Tests'
+  feature-flags-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/feature-flags.test.ts
+      CLI_REGION: us-east-2
+  remove-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
+      CLI_REGION: us-west-2
+  remove-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
+      CLI_REGION: eu-west-2
+  remove-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
+      CLI_REGION: eu-central-1
+  push-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/push-codegen-js.test.ts
+      CLI_REGION: ap-northeast-1
+  push-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/push-codegen-ios.test.ts
+      CLI_REGION: ap-southeast-1
+  push-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/push-codegen-android.test.ts
+      CLI_REGION: ap-southeast-2
+  pull-codegen-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/pull-codegen.test.ts
+      CLI_REGION: us-east-2
+  graphql-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
+      CLI_REGION: us-west-2
+  graphql-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
+      CLI_REGION: eu-west-2
+  graphql-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
+      CLI_REGION: eu-central-1
+  env-codegen-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/env-codegen.test.ts
+      CLI_REGION: ap-northeast-1
+  datastore-modelgen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-js.test.ts
+      CLI_REGION: ap-southeast-1
+  datastore-modelgen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-ios.test.ts
+      CLI_REGION: ap-southeast-2
+  datastore-modelgen-flutter-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-flutter.test.ts
+      CLI_REGION: us-east-2
+  datastore-modelgen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-android.test.ts
+      CLI_REGION: us-west-2
+  configure-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-js.test.ts
+      CLI_REGION: eu-west-2
+  configure-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-ios.test.ts
+      CLI_REGION: eu-central-1
+  configure-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-android.test.ts
+      CLI_REGION: ap-northeast-1
+  add-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/add-codegen-js.test.ts
+      CLI_REGION: ap-southeast-1
+  add-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/add-codegen-ios.test.ts
+      CLI_REGION: ap-southeast-2
+  add-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/add-codegen-android.test.ts
+      CLI_REGION: us-east-2
 workflows:
   version: 2
   build_test_deploy:
@@ -143,11 +343,18 @@ workflows:
           name: build-<< matrix.os >>
           matrix:
             parameters:
+<<<<<<< HEAD
               os: [linux_node15, linux_node12, windows_node12, macos_node12]
+=======
+              os:
+                - linux-node15
+                - linux-node10
+>>>>>>> 951f8a3... test: add split e2e test script
       - test:
           name: test-<< matrix.os >>
           matrix:
             parameters:
+<<<<<<< HEAD
               os: [linux_node15, linux_node12, windows_node12, macos_node12]
           requires:
             - build-<< matrix.os >>
@@ -161,6 +368,17 @@ workflows:
             - test-<< matrix.os >>
           post-steps:
             - run: *cleanup_e2e
+=======
+              os:
+                - linux-node15
+                - linux-node10
+          requires:
+            - build-<< matrix.os >>
+      - publish_to_local_registry:
+          os: linux-node15
+          requires:
+            - build
+>>>>>>> 951f8a3... test: add split e2e test script
           filters:
             branches:
               only:
@@ -170,9 +388,147 @@ workflows:
           requires:
             - build
             - test
-            - e2e-test
+            - done_with_node_e2e_tests
           filters:
             branches:
               only:
                 - release
                 - master
+      - done_with_node_e2e_tests:
+          os: linux-node15
+          requires:
+            - feature-flags-e2e-test
+            - pull-codegen-e2e-test
+            - datastore-modelgen-flutter-e2e-test
+            - add-codegen-android-e2e-test
+            - remove-codegen-js-e2e-test
+            - graphql-codegen-js-e2e-test
+            - datastore-modelgen-android-e2e-test
+            - remove-codegen-ios-e2e-test
+            - graphql-codegen-ios-e2e-test
+            - configure-codegen-js-e2e-test
+            - remove-codegen-android-e2e-test
+            - graphql-codegen-android-e2e-test
+            - configure-codegen-ios-e2e-test
+            - push-codegen-js-e2e-test
+            - env-codegen-e2e-test
+            - configure-codegen-android-e2e-test
+            - push-codegen-ios-e2e-test
+            - datastore-modelgen-js-e2e-test
+            - add-codegen-js-e2e-test
+            - push-codegen-android-e2e-test
+            - datastore-modelgen-ios-e2e-test
+            - add-codegen-ios-e2e-test
+      - feature-flags-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: &ref_3
+            branches:
+              only:
+                - e2e-testing
+      - pull-codegen-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - datastore-modelgen-flutter-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - add-codegen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - remove-codegen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - graphql-codegen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - datastore-modelgen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - remove-codegen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - graphql-codegen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - configure-codegen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - remove-codegen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - graphql-codegen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - configure-codegen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - push-codegen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - env-codegen-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - configure-codegen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - push-codegen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - datastore-modelgen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - add-codegen-js-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - push-codegen-android-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - datastore-modelgen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3
+      - add-codegen-ios-e2e-test:
+          os: linux-node15
+          requires:
+            - publish_to_local_registry
+          filters: *ref_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ defaults:
 install_cli_with_local_codegen: &ref_1
   name: install Amplify CLI and amplify-app with local Amplify Codegen
   command: |
-    echo $OLD_CLI_BINARY
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
@@ -42,7 +41,6 @@ install_cli_with_local_codegen: &ref_1
 clean_up_e2e_resources: &ref_3
   name: Clean up e2e resources
   command: |
-    pwd
     cd packages/amplify-codegen-e2e-tests
     yarn clean-e2e-resources job ${CIRCLE_BUILD_NUM}
   working_directory: ~/repo
@@ -371,7 +369,7 @@ workflows:
           matrix:
             parameters:
               os:
-                - linux_node15
+                - linux_node12
           requires:
             - build-<< matrix.os >>
           filters:
@@ -418,7 +416,7 @@ workflows:
       - remove-codegen-js-e2e-test:
           context: &ref_4
             - cleanup-resources
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: &ref_5
@@ -430,147 +428,147 @@ workflows:
                 - split-e2e
       - graphql-codegen-js-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - datastore-modelgen-flutter-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - add-codegen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - remove-codegen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - graphql-codegen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - datastore-modelgen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - remove-codegen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - graphql-codegen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - configure-codegen-js-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - push-codegen-js-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - feature-flags-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - configure-codegen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - push-codegen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - env-codegen-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - configure-codegen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - push-codegen-android-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - datastore-modelgen-js-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - add-codegen-js-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - pull-codegen-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - datastore-modelgen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
       - add-codegen-ios-e2e-test:
           context: *ref_4
-          os: linux_node15
+          os: linux_node12
           requires:
             - publish_to_local_registry
           post-steps: *ref_5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          - >-
+          key: >-
             amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum
             "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ workflows:
             - add-codegen-ios-e2e-test
       - remove-codegen-js-e2e-test:
           context: &ref_4
-            - clean_e2e_resources
+            - cleanup-resources
           os: linux_node15
           requires:
             - publish_to_local_registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,9 +367,11 @@ workflows:
           requires:
             - build-<< matrix.os >>
       - publish_to_local_registry:
-          os: linux_node15
+          matrix:
+            parameters:
+              os: linux_node15
           requires:
-            - build
+            - build-<< matrix.os >>
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
           requires:
             - build-<< matrix.os >>
       - publish_to_local_registry:
-          os: linux-node15
+          os: linux_node15
           requires:
             - build
           filters:
@@ -375,7 +375,7 @@ workflows:
               only:
                 - e2e-testing
       - deploy:
-          os: linux-node15
+          os: linux_node15
           requires:
             - build
             - test
@@ -386,7 +386,7 @@ workflows:
                 - release
                 - master
       - done_with_node_e2e_tests:
-          os: linux-node15
+          os: linux_node15
           requires:
             - feature-flags-e2e-test
             - pull-codegen-e2e-test
@@ -411,7 +411,7 @@ workflows:
             - datastore-modelgen-ios-e2e-test
             - add-codegen-ios-e2e-test
       - feature-flags-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: &ref_4
@@ -421,127 +421,127 @@ workflows:
               only:
                 - e2e-testing
       - pull-codegen-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - datastore-modelgen-flutter-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - add-codegen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - remove-codegen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - graphql-codegen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - datastore-modelgen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - remove-codegen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - graphql-codegen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - configure-codegen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - remove-codegen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - graphql-codegen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - configure-codegen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - push-codegen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - env-codegen-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - configure-codegen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - push-codegen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - datastore-modelgen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - add-codegen-js-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - push-codegen-android-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - datastore-modelgen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - add-codegen-ios-e2e-test:
-          os: linux-node15
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 executors:
-  linux_node12:
+  linux-node12:
     docker:
       - image: 'circleci/node:12'
     resource_class: large
-  linux_node15:
+  linux-node15:
     docker:
-      - image: circleci/node:15
+      - image: 'circleci/node:15'
     resource_class: large
   windows_node12:
     machine:
@@ -19,10 +19,9 @@ executors:
       shell: bash.exe
   macos_node12:
     macos:
-      xcode: "11.2.1"
+      xcode: 11.2.1
       resource_class: large
-
-defaults: &defaults
+defaults:
   working_directory: ~/repo
   parameters: &ref_0
     os:
@@ -40,7 +39,7 @@ install_cli_with_local_codegen: &ref_1
     amplify-app --version
     unsetNpmRegistryUrl
   working_directory: ~/repo
-clean_up_e2e_resources:
+clean_up_e2e_resources: &ref_3
   name: Clean up e2e resources
   command: |
     pwd
@@ -58,11 +57,13 @@ jobs:
       - run: yarn cache clean --force
       - run: yarn run production-build
       - save_cache:
-          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: >-
+            amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum
+            "yarn.lock" }}
           paths:
             - ~/.cache
       - save_cache:
-          key: amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}
+          key: 'amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}'
           paths:
             - ~/.ssh
       - persist_to_workspace:
@@ -76,7 +77,9 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: >-
+            amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum
+            "yarn.lock" }}
       - run:
           name: Lint
           command: yarn lint
@@ -95,8 +98,10 @@ jobs:
           at: ./
       - restore_cache:
           keys:
-            - amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}
-            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - 'amplify-codegen-ssh-deps-{{ arch }}-{{ .Branch }}'
+            - >-
+              amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum
+              "yarn.lock" }}
       - run:
           name: Authenticate with npm
           command: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc'
@@ -118,7 +123,9 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-            - amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          - >-
+            amplify-codegen-yarn-deps-{{ arch }}-{{ .Branch }}-{{ checksum
+            "yarn.lock" }}
       - run:
           name: Publish to verdaccio
           command: |
@@ -343,48 +350,32 @@ workflows:
           name: build-<< matrix.os >>
           matrix:
             parameters:
-<<<<<<< HEAD
-              os: [linux_node15, linux_node12, windows_node12, macos_node12]
-=======
               os:
-                - linux-node15
-                - linux-node10
->>>>>>> 951f8a3... test: add split e2e test script
+                - linux_node15
+                - linux_node12
+                - windows_node12
+                - macos_node12
       - test:
           name: test-<< matrix.os >>
           matrix:
             parameters:
-<<<<<<< HEAD
-              os: [linux_node15, linux_node12, windows_node12, macos_node12]
-          requires:
-            - build-<< matrix.os >>
-      - e2e-test:
-          name: e2e-test-<< matrix.os >>
-          matrix:
-            parameters:
-              os: [linux_node15, linux_node12]
-          requires:
-            - build-<< matrix.os >>
-            - test-<< matrix.os >>
-          post-steps:
-            - run: *cleanup_e2e
-=======
               os:
-                - linux-node15
-                - linux-node10
+                - linux_node15
+                - linux_node12
+                - windows_node12
+                - macos_node12
           requires:
             - build-<< matrix.os >>
       - publish_to_local_registry:
           os: linux-node15
           requires:
             - build
->>>>>>> 951f8a3... test: add split e2e test script
           filters:
             branches:
               only:
                 - e2e-testing
       - deploy:
-          os: linux_node15
+          os: linux-node15
           requires:
             - build
             - test
@@ -423,7 +414,9 @@ workflows:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: &ref_3
+          post-steps: &ref_4
+            - run: *ref_3
+          filters: &ref_5
             branches:
               only:
                 - e2e-testing
@@ -431,104 +424,125 @@ workflows:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - datastore-modelgen-flutter-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - add-codegen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - remove-codegen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - graphql-codegen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - datastore-modelgen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - remove-codegen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - graphql-codegen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - configure-codegen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - remove-codegen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - graphql-codegen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - configure-codegen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - push-codegen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - env-codegen-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - configure-codegen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - push-codegen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - datastore-modelgen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - add-codegen-js-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - push-codegen-android-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - datastore-modelgen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5
       - add-codegen-ios-e2e-test:
           os: linux-node15
           requires:
             - publish_to_local_registry
-          filters: *ref_3
+          post-steps: *ref_4
+          filters: *ref_5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 executors:
-  linux-node12:
+  linux_node12:
     docker:
-      - image: circleci/node:12
+      - image: 'circleci/node:12'
     resource_class: large
-  linux-node15:
+  linux_node15:
     docker:
-      - image: circleci/node:15
+      - image: 'circleci/node:15'
     resource_class: large
   windows_node12:
     machine:
@@ -19,7 +19,7 @@ executors:
       shell: bash.exe
   macos_node12:
     macos:
-      xcode: "11.2.1"
+      xcode: 11.2.1
       resource_class: large
 defaults:
   working_directory: ~/repo
@@ -350,7 +350,11 @@ workflows:
           name: build-<< matrix.os >>
           matrix:
             parameters:
-              os: [linux_node15, linux_node12, windows_node12, macos_node12]
+              os:
+                - linux_node15
+                - linux_node12
+                - windows_node12
+                - macos_node12
       - test:
           name: test-<< matrix.os >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,7 @@ jobs:
           command: |
             cd packages/amplify-codegen-e2e-tests
             yarn run e2e --maxWorkers=3 $TEST_SUITE
+          no_output_timeout: 20m
       - store_test_results:
           path: packages/amplify-codegen-e2e-tests/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,14 +166,6 @@ jobs:
     executor: << parameters.os >>
     steps:
       - run: echo 'Done with Node CLI E2E Tests'
-  feature-flags-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: us-east-2
   remove-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -181,7 +173,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: us-east-2
   remove-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -189,7 +181,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: us-west-2
   remove-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -197,7 +189,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: eu-west-2
   push-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -205,7 +197,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/push-codegen-js.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: eu-central-1
   push-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -213,7 +205,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/push-codegen-ios.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-northeast-1
   push-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -221,7 +213,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/push-codegen-android.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: ap-southeast-1
   pull-codegen-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -229,7 +221,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/pull-codegen.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: ap-southeast-2
   graphql-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -237,7 +229,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
-      CLI_REGION: us-west-2
+      CLI_REGION: us-east-2
   graphql-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -245,7 +237,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: us-west-2
   graphql-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -253,6 +245,14 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
+      CLI_REGION: eu-west-2
+  feature-flags-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: eu-central-1
   env-codegen-e2e-test:
     working_directory: ~/repo
@@ -374,6 +374,7 @@ workflows:
             branches:
               only:
                 - e2e-testing
+                - split-e2e
       - deploy:
           os: linux_node15
           requires:
@@ -388,29 +389,29 @@ workflows:
       - done_with_node_e2e_tests:
           os: linux_node15
           requires:
-            - feature-flags-e2e-test
-            - pull-codegen-e2e-test
-            - datastore-modelgen-flutter-e2e-test
-            - add-codegen-android-e2e-test
             - remove-codegen-js-e2e-test
             - graphql-codegen-js-e2e-test
-            - datastore-modelgen-android-e2e-test
+            - datastore-modelgen-flutter-e2e-test
+            - add-codegen-android-e2e-test
             - remove-codegen-ios-e2e-test
             - graphql-codegen-ios-e2e-test
-            - configure-codegen-js-e2e-test
+            - datastore-modelgen-android-e2e-test
             - remove-codegen-android-e2e-test
             - graphql-codegen-android-e2e-test
-            - configure-codegen-ios-e2e-test
+            - configure-codegen-js-e2e-test
             - push-codegen-js-e2e-test
+            - feature-flags-e2e-test
+            - configure-codegen-ios-e2e-test
+            - push-codegen-ios-e2e-test
             - env-codegen-e2e-test
             - configure-codegen-android-e2e-test
-            - push-codegen-ios-e2e-test
+            - push-codegen-android-e2e-test
             - datastore-modelgen-js-e2e-test
             - add-codegen-js-e2e-test
-            - push-codegen-android-e2e-test
+            - pull-codegen-e2e-test
             - datastore-modelgen-ios-e2e-test
             - add-codegen-ios-e2e-test
-      - feature-flags-e2e-test:
+      - remove-codegen-js-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
@@ -420,7 +421,8 @@ workflows:
             branches:
               only:
                 - e2e-testing
-      - pull-codegen-e2e-test:
+                - split-e2e
+      - graphql-codegen-js-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
@@ -438,24 +440,6 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
-      - remove-codegen-js-e2e-test:
-          os: linux_node15
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
-      - graphql-codegen-js-e2e-test:
-          os: linux_node15
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
-      - datastore-modelgen-android-e2e-test:
-          os: linux_node15
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
       - remove-codegen-ios-e2e-test:
           os: linux_node15
           requires:
@@ -468,7 +452,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
-      - configure-codegen-js-e2e-test:
+      - datastore-modelgen-android-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
@@ -486,13 +470,31 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
-      - configure-codegen-ios-e2e-test:
+      - configure-codegen-js-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
       - push-codegen-js-e2e-test:
+          os: linux_node15
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_4
+          filters: *ref_5
+      - feature-flags-e2e-test:
+          os: linux_node15
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_4
+          filters: *ref_5
+      - configure-codegen-ios-e2e-test:
+          os: linux_node15
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_4
+          filters: *ref_5
+      - push-codegen-ios-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
@@ -510,7 +512,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
-      - push-codegen-ios-e2e-test:
+      - push-codegen-android-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry
@@ -528,7 +530,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_4
           filters: *ref_5
-      - push-codegen-android-e2e-test:
+      - pull-codegen-e2e-test:
           os: linux_node15
           requires:
             - publish_to_local_registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,139 +415,162 @@ workflows:
             - datastore-modelgen-ios-e2e-test
             - add-codegen-ios-e2e-test
       - remove-codegen-js-e2e-test:
+          context: &ref_4
+            - clean_e2e_resources
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: &ref_4
+          post-steps: &ref_5
             - run: *ref_3
-          filters: &ref_5
+          filters: &ref_6
             branches:
               only:
                 - e2e-testing
                 - split-e2e
       - graphql-codegen-js-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - datastore-modelgen-flutter-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - add-codegen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - remove-codegen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - graphql-codegen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - datastore-modelgen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - remove-codegen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - graphql-codegen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - configure-codegen-js-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - push-codegen-js-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - feature-flags-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - configure-codegen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - push-codegen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - env-codegen-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - configure-codegen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - push-codegen-android-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - datastore-modelgen-js-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - add-codegen-js-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - pull-codegen-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - datastore-modelgen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6
       - add-codegen-ios-e2e-test:
+          context: *ref_4
           os: linux_node15
           requires:
             - publish_to_local_registry
-          post-steps: *ref_4
-          filters: *ref_5
+          post-steps: *ref_5
+          filters: *ref_6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,11 +350,7 @@ workflows:
           name: build-<< matrix.os >>
           matrix:
             parameters:
-              os:
-                - linux_node15
-                - linux_node12
-                - windows_node12
-                - macos_node12
+              os: [linux_node15, linux_node12, windows_node12, macos_node12]
       - test:
           name: test-<< matrix.os >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,38 +165,6 @@ jobs:
     executor: << parameters.os >>
     steps:
       - run: echo 'Done with Node CLI E2E Tests'
-  remove-codegen-js-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
-      CLI_REGION: us-east-2
-  remove-codegen-ios-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
-      CLI_REGION: us-west-2
-  remove-codegen-android-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
-      CLI_REGION: eu-west-2
-  push-codegen-js-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/push-codegen-js.test.ts
-      CLI_REGION: eu-central-1
   push-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -204,7 +172,15 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/push-codegen-ios.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: us-east-2
+  push-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/push-codegen-js.test.ts
+      CLI_REGION: us-west-2
   push-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -212,7 +188,7 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/push-codegen-android.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: eu-west-2
   pull-codegen-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -220,38 +196,6 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/pull-codegen.test.ts
-      CLI_REGION: ap-southeast-2
-  graphql-codegen-js-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
-      CLI_REGION: us-east-2
-  graphql-codegen-ios-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
-      CLI_REGION: us-west-2
-  graphql-codegen-android-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
-      CLI_REGION: eu-west-2
-  feature-flags-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: eu-central-1
   env-codegen-e2e-test:
     working_directory: ~/repo
@@ -260,62 +204,6 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/env-codegen.test.ts
-      CLI_REGION: ap-northeast-1
-  datastore-modelgen-js-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/datastore-modelgen-js.test.ts
-      CLI_REGION: ap-southeast-1
-  datastore-modelgen-ios-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/datastore-modelgen-ios.test.ts
-      CLI_REGION: ap-southeast-2
-  datastore-modelgen-flutter-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/datastore-modelgen-flutter.test.ts
-      CLI_REGION: us-east-2
-  datastore-modelgen-android-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/datastore-modelgen-android.test.ts
-      CLI_REGION: us-west-2
-  configure-codegen-js-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/configure-codegen-js.test.ts
-      CLI_REGION: eu-west-2
-  configure-codegen-ios-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/configure-codegen-ios.test.ts
-      CLI_REGION: eu-central-1
-  configure-codegen-android-e2e-test:
-    working_directory: ~/repo
-    parameters: *ref_0
-    executor: << parameters.os >>
-    steps: *ref_2
-    environment:
-      TEST_SUITE: src/__tests__/configure-codegen-android.test.ts
       CLI_REGION: ap-northeast-1
   add-codegen-js-e2e-test:
     working_directory: ~/repo
@@ -340,6 +228,118 @@ jobs:
     steps: *ref_2
     environment:
       TEST_SUITE: src/__tests__/add-codegen-android.test.ts
+      CLI_REGION: us-east-2
+  datastore-modelgen-flutter-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-flutter.test.ts
+      CLI_REGION: us-west-2
+  datastore-modelgen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-ios.test.ts
+      CLI_REGION: eu-west-2
+  datastore-modelgen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-android.test.ts
+      CLI_REGION: eu-central-1
+  datastore-modelgen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/datastore-modelgen-js.test.ts
+      CLI_REGION: ap-northeast-1
+  remove-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
+      CLI_REGION: ap-southeast-1
+  remove-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
+      CLI_REGION: ap-southeast-2
+  remove-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
+      CLI_REGION: us-east-2
+  feature-flags-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/feature-flags.test.ts
+      CLI_REGION: us-west-2
+  configure-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-ios.test.ts
+      CLI_REGION: eu-west-2
+  configure-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-android.test.ts
+      CLI_REGION: eu-central-1
+  configure-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/configure-codegen-js.test.ts
+      CLI_REGION: ap-northeast-1
+  graphql-codegen-android-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
+      CLI_REGION: ap-southeast-1
+  graphql-codegen-js-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
+      CLI_REGION: ap-southeast-2
+  graphql-codegen-ios-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_2
+    environment:
+      TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
       CLI_REGION: us-east-2
 workflows:
   version: 2
@@ -391,29 +391,29 @@ workflows:
       - done_with_node_e2e_tests:
           os: linux_node15
           requires:
-            - remove-codegen-js-e2e-test
-            - graphql-codegen-js-e2e-test
-            - datastore-modelgen-flutter-e2e-test
+            - push-codegen-ios-e2e-test
             - add-codegen-android-e2e-test
-            - remove-codegen-ios-e2e-test
+            - remove-codegen-js-e2e-test
             - graphql-codegen-ios-e2e-test
+            - push-codegen-js-e2e-test
+            - datastore-modelgen-flutter-e2e-test
+            - feature-flags-e2e-test
+            - push-codegen-android-e2e-test
+            - datastore-modelgen-ios-e2e-test
+            - configure-codegen-ios-e2e-test
+            - pull-codegen-e2e-test
             - datastore-modelgen-android-e2e-test
+            - configure-codegen-android-e2e-test
+            - env-codegen-e2e-test
+            - datastore-modelgen-js-e2e-test
+            - configure-codegen-js-e2e-test
+            - add-codegen-js-e2e-test
             - remove-codegen-android-e2e-test
             - graphql-codegen-android-e2e-test
-            - configure-codegen-js-e2e-test
-            - push-codegen-js-e2e-test
-            - feature-flags-e2e-test
-            - configure-codegen-ios-e2e-test
-            - push-codegen-ios-e2e-test
-            - env-codegen-e2e-test
-            - configure-codegen-android-e2e-test
-            - push-codegen-android-e2e-test
-            - datastore-modelgen-js-e2e-test
-            - add-codegen-js-e2e-test
-            - pull-codegen-e2e-test
-            - datastore-modelgen-ios-e2e-test
             - add-codegen-ios-e2e-test
-      - remove-codegen-js-e2e-test:
+            - remove-codegen-ios-e2e-test
+            - graphql-codegen-js-e2e-test
+      - push-codegen-ios-e2e-test:
           context: &ref_4
             - cleanup-resources
           os: linux_node12
@@ -426,20 +426,6 @@ workflows:
               only:
                 - e2e-testing
                 - split-e2e
-      - graphql-codegen-js-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - datastore-modelgen-flutter-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
       - add-codegen-android-e2e-test:
           context: *ref_4
           os: linux_node12
@@ -447,7 +433,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
-      - remove-codegen-ios-e2e-test:
+      - remove-codegen-js-e2e-test:
           context: *ref_4
           os: linux_node12
           requires:
@@ -461,7 +447,91 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
+      - push-codegen-js-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - datastore-modelgen-flutter-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - feature-flags-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - push-codegen-android-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - datastore-modelgen-ios-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - configure-codegen-ios-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - pull-codegen-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
       - datastore-modelgen-android-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - configure-codegen-android-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - env-codegen-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - datastore-modelgen-js-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - configure-codegen-js-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - add-codegen-js-e2e-test:
           context: *ref_4
           os: linux_node12
           requires:
@@ -482,91 +552,21 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_5
           filters: *ref_6
-      - configure-codegen-js-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - push-codegen-js-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - feature-flags-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - configure-codegen-ios-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - push-codegen-ios-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - env-codegen-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - configure-codegen-android-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - push-codegen-android-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - datastore-modelgen-js-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - add-codegen-js-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - pull-codegen-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
-      - datastore-modelgen-ios-e2e-test:
-          context: *ref_4
-          os: linux_node12
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_5
-          filters: *ref_6
       - add-codegen-ios-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - remove-codegen-ios-e2e-test:
+          context: *ref_4
+          os: linux_node12
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_5
+          filters: *ref_6
+      - graphql-codegen-js-e2e-test:
           context: *ref_4
           os: linux_node12
           requires:

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -1,6 +1,7 @@
   #!/bin/bash
 
 default_verdaccio_package=verdaccio@4.5.1
+custom_registry_url=http://localhost:4873
 
 function startLocalRegistry {
   # Start local registry
@@ -13,7 +14,7 @@ function startLocalRegistry {
 
 function loginToLocalRegistry {
   # Login so we can publish packages
-  (cd && sudo npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$1")
+  (cd && sudo npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
 }
 
 function unsetNpmRegistryUrl {
@@ -22,13 +23,8 @@ function unsetNpmRegistryUrl {
   yarn config set registry "https://registry.npmjs.org/"
 }
 
-function changeNpmGlobalPath {
-  mkdir -p $1
-  npm config set prefix "$1"
-}
-
 function setNpmRegistryUrlToLocal {
   # Set registry to local registry
-  npm set registry "$1"
-  yarn config set registry "$1"
+  npm set registry "$custom_registry_url"
+  yarn config set registry "$custom_registry_url"
 }

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -14,7 +14,7 @@ function startLocalRegistry {
 
 function loginToLocalRegistry {
   # Login so we can publish packages
-  (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
+  (cd && npm_config_yes=true npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
 }
 
 function unsetNpmRegistryUrl {

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -14,7 +14,7 @@ function startLocalRegistry {
 
 function loginToLocalRegistry {
   # Login so we can publish packages
-  (cd && sudo npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
+  (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
 }
 
 function unsetNpmRegistryUrl {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "verdaccio-stop": "kill -9 $(lsof -n -t -iTCP:4873 -sTCP:LISTEN)",
     "setup-dev": "yarn && lerna run build",
     "commit": "git-cz",
-    "coverage": "codecov || exit 0"
+    "coverage": "codecov || exit 0",
+    "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .circleci/config.yml"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-codegen/issues"
@@ -40,7 +41,7 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-push": "npm run lint && npm run test-changed",
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "yarn split-e2e-tests && pretty-quick --staged"
     }
   },
   "author": "Amazon Web Services",

--- a/packages/amplify-codegen-e2e-core/src/utils/graphql-config-helper.ts
+++ b/packages/amplify-codegen-e2e-core/src/utils/graphql-config-helper.ts
@@ -18,7 +18,7 @@ export function constructGraphQLConfig(
             docsFilePath: '',
             generatedFileName: '',
             maxDepth: maxDepth ? maxDepth : 2,
-            region: region ? region : 'us-east-1'
+            region: region
         }
     };
 

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/configure-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/configure-codegen.ts
@@ -32,7 +32,7 @@ export async function testConfigureCodegen(config: AmplifyFrontendConfig, projec
     expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
 
     // graphql configuration should be updated to with MaxStatementDepth=4
-    testValidGraphQLConfig(projectRoot, config, 4, null, true);
+    testValidGraphQLConfig(projectRoot, config, 4, true);
     const updatedCodegenConfiguration = readFileSync(getGraphQLConfigFilePath(projectRoot)).toString();
     // the codegen configuration is updated
     expect(addedCodegenConfiguration).not.toMatch(updatedCodegenConfiguration);

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
@@ -41,7 +41,7 @@ export async function testValidGraphQLConfig(
     projectRoot: string,
     config: AmplifyFrontendConfig,
     maxDepth?: number,
-    region: string = REGION,
+    region: string = process.env.CLI_REGION || REGION,
     isConfigured: boolean = false) {
     // graphql codegen configuration should exist
     expect(existsSync(getGraphQLConfigFilePath(projectRoot))).toBe(true);

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
@@ -41,8 +41,9 @@ export async function testValidGraphQLConfig(
     projectRoot: string,
     config: AmplifyFrontendConfig,
     maxDepth?: number,
-    region: string = process.env.CLI_REGION || REGION,
-    isConfigured: boolean = false) {
+    isConfigured: boolean = false,
+    region: string = process.env.CLI_REGION || REGION
+) {
     // graphql codegen configuration should exist
     expect(existsSync(getGraphQLConfigFilePath(projectRoot))).toBe(true);
 

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -18,8 +18,32 @@ const AWS_REGIONS_TO_RUN_TESTS = [
 // or when a test suite changes drastically
 
 const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
-//TODO: add test suites in ascending order based on total time
-// eg: 'src/__tests__/add-codegen-android'
+  // <7m
+  'src/__tests__/graphql-codegen-ios.test.ts',
+  'src/__tests__/graphql-codegen-js.test.ts',
+  'src/__tests__/graphql-codegen-android.test.ts',
+  'src/__tests__/configure-codegen-js.test.ts',
+  'src/__tests__/configure-codegen-android.test.ts',
+  'src/__tests__/configure-codegen-ios.test.ts',
+  'src/__tests__/feature-flags.test.ts',
+  'src/__tests__/remove-codegen-js.test.ts',
+  'src/__tests__/remove-codegen-ios.test.ts',
+  'src/__tests__/remove-codegen-android.test.ts',
+  'src/__tests__/datastore-modelgen-js.test.ts',
+  'src/__tests__/datastore-modelgen-android.test.ts',
+  'src/__tests__/datastore-modelgen-ios.test.ts',
+  'src/__tests__/datastore-modelgen-flutter.test.ts',
+  'src/__tests__/add-codegen-android.test.ts',
+  'src/__tests__/add-codegen-ios.test.ts',
+  // <11m
+  'src/__tests__/add-codegen-js.test.ts',
+  'src/__tests__/env-codegen.test.ts',
+  // <12m
+  'src/__tests__/pull-codegen.test.ts',
+  // <14m
+  'src/__tests__/push-codegen-android.test.ts',
+  'src/__tests__/push-codegen-js.test.ts',
+  'src/__tests__/push-codegen-ios.test.ts',
 ];
 
 /**

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -1,0 +1,319 @@
+import * as yaml from 'js-yaml';
+import * as glob from 'glob';
+import { join } from 'path';
+import * as fs from 'fs-extra';
+const CONCURRENCY = 4;
+// Ensure to update packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts is also updated this gets updated
+const AWS_REGIONS_TO_RUN_TESTS = [
+  'us-east-2',
+  'us-west-2',
+  'eu-west-2',
+  'eu-central-1',
+  'ap-northeast-1',
+  'ap-southeast-1',
+  'ap-southeast-2',
+];
+
+// This array needs to be update periodically when new tests suites get added
+// or when a test suite changes drastically
+
+const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
+  //<10m
+  'src/__tests__/plugin.test.ts',
+  'src/__tests__/init-special-case.test.ts',
+  'src/__tests__/datastore-modelgen.test.ts',
+  'src/__tests__/amplify-configure.test.ts',
+  'src/__tests__/init.test.ts',
+  'src/__tests__/tags.test.ts',
+  'src/__tests__/notifications.test.ts',
+  //<15m
+  'src/__tests__/schema-versioned.test.ts',
+  'src/__tests__/schema-data-access-patterns.test.ts',
+  'src/__tests__/interactions.test.ts',
+  'src/__tests__/schema-predictions.test.ts',
+  'src/__tests__/amplify-app.test.ts',
+  'src/__tests__/hosting.test.ts',
+  'src/__tests__/analytics.test.ts',
+  'src/__tests__/feature-flags.test.ts',
+  'src/__tests__/schema-iterative-update-2.test.ts',
+  'src/__tests__/containers-api.test.ts',
+  //<20m
+  'src/__tests__/predictions.test.ts',
+  'src/__tests__/hostingPROD.test.ts',
+  //<25m
+  'src/__tests__/schema-auth-10.test.ts',
+  'src/__tests__/schema-key.test.ts',
+  'src/__tests__/auth_1.test.ts',
+  'src/__tests__/auth_5.test.ts',
+  'src/__tests__/function_3.test.ts',
+  'src/__tests__/schema-iterative-update-1.test.ts',
+  //<30m
+  'src/__tests__/schema-auth-3.test.ts',
+  'src/__tests__/delete.test.ts',
+  'src/__tests__/function_2.test.ts',
+  'src/__tests__/auth_3.test.ts',
+  'src/__tests__/layer.test.ts',
+  //<35m
+  'src/__tests__/migration/api.key.migration1.test.ts',
+  'src/__tests__/auth_4.test.ts',
+  'src/__tests__/schema-auth-7.test.ts',
+  'src/__tests__/schema-auth-8.test.ts',
+  'src/__tests__/schema-searchable.test.ts',
+  'src/__tests__/schema-auth-4.test.ts',
+  'src/__tests__/api_3.test.ts',
+  'src/__tests__/import_auth_1.test.ts',
+  'src/__tests__/import_auth_2.test.ts',
+  'src/__tests__/import_s3_1.test.ts',
+  'src/__tests__/import_dynamodb_1.test.ts',
+  'src/__tests__/schema-iterative-rollback-1.test.ts',
+  //<40m
+  'src/__tests__/schema-iterative-rollback-2.test.ts',
+  'src/__tests__/env.test.ts',
+  'src/__tests__/auth_2.test.ts',
+  'src/__tests__/schema-auth-9.test.ts',
+  'src/__tests__/schema-auth-11.test.ts',
+  'src/__tests__/migration/api.key.migration2.test.ts',
+  'src/__tests__/function_1.test.ts',
+  'src/__tests__/schema-auth-1.test.ts',
+  'src/__tests__/function_4.test.ts',
+  //<45m
+  'src/__tests__/schema-function.test.ts',
+  'src/__tests__/schema-model.test.ts',
+  'src/__tests__/migration/api.connection.migration.test.ts',
+  'src/__tests__/schema-connection.test.ts',
+  'src/__tests__/schema-auth-6.test.ts',
+  'src/__tests__/schema-iterative-update-3.test.ts',
+  //<50m
+  'src/__tests__/schema-auth-2.test.ts',
+  'src/__tests__/api_1.test.ts',
+  'src/__tests__/schema-auth-5.test.ts',
+  //<55m
+  'src/__tests__/storage.test.ts',
+  'src/__tests__/api_2.test.ts',
+  'src/__tests__/schema-iterative-update-4.test.ts',
+];
+
+/**
+ * Sorts the test suite in ascending order. If the test is not included in known
+ * tests it would be inserted at the begining of the array
+ * @param tesSuites an array of test suites
+ */
+function sortTestsBasedOnTime(tesSuites: string[]): string[] {
+  return tesSuites.sort((a, b) => {
+    const aIndx = KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME.indexOf(a);
+    const bIndx = KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME.indexOf(b);
+    return aIndx - bIndx;
+  });
+}
+
+export type WorkflowJob =
+  | {
+      [name: string]: {
+        requires?: string[];
+      };
+    }
+  | string;
+
+export type CircleCIConfig = {
+  jobs: {
+    [name: string]: {
+      steps: Record<string, any>;
+      environment: Record<string, string>;
+    };
+  };
+  workflows: {
+    [workflowName: string]: {
+      jobs: WorkflowJob[];
+    };
+  };
+};
+
+function getTestFiles(dir: string, pattern = 'src/**/*.test.ts'): string[] {
+  return sortTestsBasedOnTime(glob.sync(pattern, { cwd: dir })).reverse();
+}
+
+function generateJobName(baseName: string, testSuitePath: string): string {
+  return `${testSuitePath
+    .replace('src/', '')
+    .replace('__tests__/', '')
+    .replace(/test\.ts$/, '')
+    .replace(/\//g, '-')
+    .replace(/\./g, '-')}${baseName}`;
+}
+
+/**
+ * Takes a CircleCI config and converts each test inside that job into a separate
+ * job.
+ * @param config - CircleCI config
+ * @param jobName - job that should be split
+ * @param workflowName - workflow name where this job is run
+ * @param jobRootDir - Directory to scan for test files
+ * @param concurrency - Number of parallel jobs to run
+ */
+function splitTests(
+  config: Readonly<CircleCIConfig>,
+  jobName: string,
+  workflowName: string,
+  jobRootDir: string,
+  concurrency: number = CONCURRENCY,
+): CircleCIConfig {
+  const output: CircleCIConfig = { ...config };
+  const jobs = { ...config.jobs };
+  const job = jobs[jobName];
+  const testSuites = getTestFiles(jobRootDir);
+
+  const newJobs = testSuites.reduce((acc, suite, index) => {
+    const testRegion = AWS_REGIONS_TO_RUN_TESTS[index % AWS_REGIONS_TO_RUN_TESTS.length];
+    const newJob = {
+      ...job,
+      environment: {
+        ...job.environment,
+        TEST_SUITE: suite,
+        CLI_REGION: testRegion,
+      },
+    };
+    const newJobName = generateJobName(jobName, suite);
+    return { ...acc, [newJobName]: newJob };
+  }, {});
+
+  // Spilt jobs by region
+  const jobByRegion = Object.entries(newJobs).reduce((acc, entry: [string, any]) => {
+    const [jobName, job] = entry;
+    const region = job?.environment?.CLI_REGION;
+    const regionJobs = { ...acc[region], [jobName]: job };
+    return { ...acc, [region]: regionJobs };
+  }, {});
+
+  const workflows = { ...config.workflows };
+
+  if (workflows[workflowName]) {
+    const workflow = workflows[workflowName];
+
+    const workflowJob = workflow.jobs.find(j => {
+      if (typeof j === 'string') {
+        return j === jobName;
+      } else {
+        const name = Object.keys(j)[0];
+        return name === jobName;
+      }
+    });
+
+    if (workflowJob) {
+      Object.values(jobByRegion).forEach(regionJobs => {
+        const newJobNames = Object.keys(regionJobs);
+        const jobs = newJobNames.map((newJobName, index) => {
+          const requires = getRequiredJob(newJobNames, index, concurrency);
+          if (typeof workflowJob === 'string') {
+            return newJobName;
+          } else {
+            return {
+              [newJobName]: {
+                ...Object.values(workflowJob)[0],
+                requires: [...(requires ? [requires] : workflowJob[jobName].requires || [])],
+              },
+            };
+          }
+        });
+        workflow.jobs = [...workflow.jobs, ...jobs];
+      });
+
+      const lastJobBatch = Object.values(jobByRegion)
+        .map(regionJobs => getLastBatchJobs(Object.keys(regionJobs), concurrency))
+        .reduce((acc, val) => acc.concat(val), []);
+      const filteredJobs = replaceWorkflowDependency(removeWorkflowJob(workflow.jobs, jobName), jobName, lastJobBatch);
+      workflow.jobs = filteredJobs;
+    }
+    output.workflows = workflows;
+  }
+  output.jobs = {
+    ...output.jobs,
+    ...newJobs,
+  };
+  return output;
+}
+
+/**
+ * CircleCI workflow can have multiple jobs. This helper function removes the jobName from the workflow
+ * @param jobs - All the jobs in workflow
+ * @param jobName - job that needs to be removed from workflow
+ */
+function removeWorkflowJob(jobs: WorkflowJob[], jobName: string): WorkflowJob[] {
+  return jobs.filter(j => {
+    if (typeof j === 'string') {
+      return j !== jobName;
+    } else {
+      const name = Object.keys(j)[0];
+      return name !== jobName;
+    }
+  });
+}
+
+/**
+ *
+ * @param jobs array of job names
+ * @param concurrency number of concurrent jobs
+ */
+function getLastBatchJobs(jobs: string[], concurrency: number): string[] {
+  const lastBatchJobLength = Math.min(concurrency, jobs.length);
+  const lastBatchJobNames = jobs.slice(jobs.length - lastBatchJobLength);
+  return lastBatchJobNames;
+}
+
+/**
+ * A job in workflow can require some other job in the workflow to be finished before executing
+ * This helper method finds and replaces jobName with jobsToReplacesWith
+ * @param jobs - Workflow jobs
+ * @param jobName - job to remove from requires
+ * @param jobsToReplaceWith - jobs to add to requires
+ */
+function replaceWorkflowDependency(jobs: WorkflowJob[], jobName: string, jobsToReplaceWith: string[]): WorkflowJob[] {
+  return jobs.map(j => {
+    if (typeof j === 'string') return j;
+    const [currentJobName, jobObj] = Object.entries(j)[0];
+    const requires = jobObj.requires || [];
+    if (requires.includes(jobName)) {
+      jobObj.requires = [...requires.filter(r => r !== jobName), ...jobsToReplaceWith];
+    }
+    return {
+      [currentJobName]: jobObj,
+    };
+  });
+}
+
+/**
+ * Helper function that creates requires block for jobs to limit the concurrency of jobs in circle ci
+ * @param jobNames - An array of jobs
+ * @param index - current index of the job
+ * @param concurrency - number of parallel jobs allowed
+ */
+function getRequiredJob(jobNames: string[], index: number, concurrency: number = 4): string | void {
+  const mod = index % concurrency;
+  const mult = Math.floor(index / concurrency);
+  if (mult > 0) {
+    const prevIndex = (mult - 1) * concurrency + mod;
+    return jobNames[prevIndex];
+  }
+}
+
+function loadConfig(): CircleCIConfig {
+  const configFile = join(process.cwd(), '.circleci', 'config.base.yml');
+  return <CircleCIConfig>yaml.load(fs.readFileSync(configFile, 'utf8'));
+}
+
+function saveConfig(config: CircleCIConfig): void {
+  const configFile = join(process.cwd(), '.circleci', 'config.yml');
+  const output = ['# auto generated file. Edit config.base.yaml if you want to change', yaml.dump(config)];
+  fs.writeFileSync(configFile, output.join('\n'));
+}
+function main(): void {
+  const config = loadConfig();
+  const splitNodeTests = splitTests(
+    config,
+    'e2e-test',
+    'build_test_deploy',
+    join(process.cwd(), 'packages', 'amplify-codegen-e2e-tests'),
+    CONCURRENCY,
+  );
+  saveConfig(splitNodeTests);
+}
+main();

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -18,79 +18,8 @@ const AWS_REGIONS_TO_RUN_TESTS = [
 // or when a test suite changes drastically
 
 const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
-  //<10m
-  'src/__tests__/plugin.test.ts',
-  'src/__tests__/init-special-case.test.ts',
-  'src/__tests__/datastore-modelgen.test.ts',
-  'src/__tests__/amplify-configure.test.ts',
-  'src/__tests__/init.test.ts',
-  'src/__tests__/tags.test.ts',
-  'src/__tests__/notifications.test.ts',
-  //<15m
-  'src/__tests__/schema-versioned.test.ts',
-  'src/__tests__/schema-data-access-patterns.test.ts',
-  'src/__tests__/interactions.test.ts',
-  'src/__tests__/schema-predictions.test.ts',
-  'src/__tests__/amplify-app.test.ts',
-  'src/__tests__/hosting.test.ts',
-  'src/__tests__/analytics.test.ts',
-  'src/__tests__/feature-flags.test.ts',
-  'src/__tests__/schema-iterative-update-2.test.ts',
-  'src/__tests__/containers-api.test.ts',
-  //<20m
-  'src/__tests__/predictions.test.ts',
-  'src/__tests__/hostingPROD.test.ts',
-  //<25m
-  'src/__tests__/schema-auth-10.test.ts',
-  'src/__tests__/schema-key.test.ts',
-  'src/__tests__/auth_1.test.ts',
-  'src/__tests__/auth_5.test.ts',
-  'src/__tests__/function_3.test.ts',
-  'src/__tests__/schema-iterative-update-1.test.ts',
-  //<30m
-  'src/__tests__/schema-auth-3.test.ts',
-  'src/__tests__/delete.test.ts',
-  'src/__tests__/function_2.test.ts',
-  'src/__tests__/auth_3.test.ts',
-  'src/__tests__/layer.test.ts',
-  //<35m
-  'src/__tests__/migration/api.key.migration1.test.ts',
-  'src/__tests__/auth_4.test.ts',
-  'src/__tests__/schema-auth-7.test.ts',
-  'src/__tests__/schema-auth-8.test.ts',
-  'src/__tests__/schema-searchable.test.ts',
-  'src/__tests__/schema-auth-4.test.ts',
-  'src/__tests__/api_3.test.ts',
-  'src/__tests__/import_auth_1.test.ts',
-  'src/__tests__/import_auth_2.test.ts',
-  'src/__tests__/import_s3_1.test.ts',
-  'src/__tests__/import_dynamodb_1.test.ts',
-  'src/__tests__/schema-iterative-rollback-1.test.ts',
-  //<40m
-  'src/__tests__/schema-iterative-rollback-2.test.ts',
-  'src/__tests__/env.test.ts',
-  'src/__tests__/auth_2.test.ts',
-  'src/__tests__/schema-auth-9.test.ts',
-  'src/__tests__/schema-auth-11.test.ts',
-  'src/__tests__/migration/api.key.migration2.test.ts',
-  'src/__tests__/function_1.test.ts',
-  'src/__tests__/schema-auth-1.test.ts',
-  'src/__tests__/function_4.test.ts',
-  //<45m
-  'src/__tests__/schema-function.test.ts',
-  'src/__tests__/schema-model.test.ts',
-  'src/__tests__/migration/api.connection.migration.test.ts',
-  'src/__tests__/schema-connection.test.ts',
-  'src/__tests__/schema-auth-6.test.ts',
-  'src/__tests__/schema-iterative-update-3.test.ts',
-  //<50m
-  'src/__tests__/schema-auth-2.test.ts',
-  'src/__tests__/api_1.test.ts',
-  'src/__tests__/schema-auth-5.test.ts',
-  //<55m
-  'src/__tests__/storage.test.ts',
-  'src/__tests__/api_2.test.ts',
-  'src/__tests__/schema-iterative-update-4.test.ts',
+//TODO: add test suites in ascending order based on total time
+// eg: 'src/__tests__/add-codegen-android'
 ];
 
 /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adding scripts for splitting e2e tests into individual circleCI jobs so that they can be run in parallel.

- There are 7 regions(buckets) for integration test usage with a concurrency of 4 in each region(in total 28 parallel jobs)
- Use greedy algorithm to reduce the total time of test suites
- Add new job `publish-to-verdaccio` and relevant changes to publishing scripts

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.