### PR TITLE
fix(appsync-modelgen-plugin): include auth rule provider in the Java …

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -25,7 +25,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the customClaim type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"customClaims\\", authRules = {
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"user_id\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"user_id\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
@@ -241,7 +241,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the customClaim type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"customClaims\\", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"user_groups\\", groups = { \\"Moderator\\" }, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"user_groups\\", groups = { \\"Moderator\\" }, provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class customClaim implements Model {
   public static final QueryField ID = field(\\"customClaim\\", \\"id\\");
@@ -457,8 +457,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the Employee type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"Employees\\", authRules = {
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admins\\" }, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admins\\" }, provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class Employee implements Model {
   public static final QueryField ID = field(\\"Employee\\", \\"id\\");
@@ -469,7 +469,7 @@ public final class Employee implements Model {
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
   private final @ModelField(targetType=\\"String\\", authRules = {
-    @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+    @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
   }) String ssn;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -713,7 +713,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the dynamicGroups type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"dynamicGroups\\", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groupsField = \\"groups\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groupsField = \\"groups\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class dynamicGroups implements Model {
   public static final QueryField ID = field(\\"dynamicGroups\\", \\"id\\");
@@ -904,6 +904,262 @@ public final class dynamicGroups implements Model {
 "
 `;
 
+exports[`AppSyncModelVisitor Model with Auth should generate class with non-default providers 1`] = `
+"package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.AuthStrategy;
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.ModelOperation;
+import com.amplifyframework.core.model.annotations.AuthRule;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the Employee type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"Employees\\", authRules = {
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ }),
+  @AuthRule(allow = AuthStrategy.PRIVATE, provider = \\"iam\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+})
+public final class Employee implements Model {
+  public static final QueryField ID = field(\\"Employee\\", \\"id\\");
+  public static final QueryField NAME = field(\\"Employee\\", \\"name\\");
+  public static final QueryField ADDRESS = field(\\"Employee\\", \\"address\\");
+  public static final QueryField SSN = field(\\"Employee\\", \\"ssn\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
+  private final @ModelField(targetType=\\"String\\", isRequired = true) String address;
+  private final @ModelField(targetType=\\"String\\", authRules = {
+    @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admins\\" }, provider = \\"oidc\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  }) String ssn;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  public String getId() {
+      return id;
+  }
+  
+  public String getName() {
+      return name;
+  }
+  
+  public String getAddress() {
+      return address;
+  }
+  
+  public String getSsn() {
+      return ssn;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private Employee(String id, String name, String address, String ssn) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.ssn = ssn;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      Employee employee = (Employee) obj;
+      return ObjectsCompat.equals(getId(), employee.getId()) &&
+              ObjectsCompat.equals(getName(), employee.getName()) &&
+              ObjectsCompat.equals(getAddress(), employee.getAddress()) &&
+              ObjectsCompat.equals(getSsn(), employee.getSsn()) &&
+              ObjectsCompat.equals(getCreatedAt(), employee.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), employee.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getName())
+      .append(getAddress())
+      .append(getSsn())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"Employee {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"name=\\" + String.valueOf(getName()) + \\", \\")
+      .append(\\"address=\\" + String.valueOf(getAddress()) + \\", \\")
+      .append(\\"ssn=\\" + String.valueOf(getSsn()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static NameStep builder() {
+      return new Builder();
+  }
+  
+  /** 
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   * @throws IllegalArgumentException Checks that ID is in the proper format
+   */
+  public static Employee justId(String id) {
+    try {
+      UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+    } catch (Exception exception) {
+      throw new IllegalArgumentException(
+              \\"Model IDs must be unique in the format of UUID. This method is for creating instances \\" +
+              \\"of an existing object with only its ID field for sending as a mutation parameter. When \\" +
+              \\"creating a new object, use the standard builder method and leave the ID field blank.\\"
+      );
+    }
+    return new Employee(
+      id,
+      null,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      name,
+      address,
+      ssn);
+  }
+  public interface NameStep {
+    AddressStep name(String name);
+  }
+  
+
+  public interface AddressStep {
+    BuildStep address(String address);
+  }
+  
+
+  public interface BuildStep {
+    Employee build();
+    BuildStep id(String id) throws IllegalArgumentException;
+    BuildStep ssn(String ssn);
+  }
+  
+
+  public static class Builder implements NameStep, AddressStep, BuildStep {
+    private String id;
+    private String name;
+    private String address;
+    private String ssn;
+    @Override
+     public Employee build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new Employee(
+          id,
+          name,
+          address,
+          ssn);
+    }
+    
+    @Override
+     public AddressStep name(String name) {
+        Objects.requireNonNull(name);
+        this.name = name;
+        return this;
+    }
+    
+    @Override
+     public BuildStep address(String address) {
+        Objects.requireNonNull(address);
+        this.address = address;
+        return this;
+    }
+    
+    @Override
+     public BuildStep ssn(String ssn) {
+        this.ssn = ssn;
+        return this;
+    }
+    
+    /** 
+     * WARNING: Do not set ID when creating a new object. Leave this blank and one will be auto generated for you.
+     * This should only be set when referring to an already existing object.
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     * @throws IllegalArgumentException Checks that ID is in the proper format
+     */
+    public BuildStep id(String id) throws IllegalArgumentException {
+        this.id = id;
+        
+        try {
+            UUID.fromString(id); // Check that ID is in the UUID format - if not an exception is thrown
+        } catch (Exception exception) {
+          throw new IllegalArgumentException(\\"Model IDs must be unique in the format of UUID.\\",
+                    exception);
+        }
+        
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String name, String address, String ssn) {
+      super.id(id);
+      super.name(name)
+        .address(address)
+        .ssn(ssn);
+    }
+    
+    @Override
+     public CopyOfBuilder name(String name) {
+      return (CopyOfBuilder) super.name(name);
+    }
+    
+    @Override
+     public CopyOfBuilder address(String address) {
+      return (CopyOfBuilder) super.address(address);
+    }
+    
+    @Override
+     public CopyOfBuilder ssn(String ssn) {
+      return (CopyOfBuilder) super.ssn(ssn);
+    }
+  }
+  
+}
+"
+`;
+
 exports[`AppSyncModelVisitor Model with Auth should generate class with owner auth 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 
@@ -929,7 +1185,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the simpleOwnerAuth type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"simpleOwnerAuths\\", authRules = {
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class simpleOwnerAuth implements Model {
   public static final QueryField ID = field(\\"simpleOwnerAuth\\", \\"id\\");
@@ -1145,7 +1401,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the allowRead type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"allowReads\\", authRules = {
-  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", operations = { ModelOperation.CREATE, ModelOperation.DELETE, ModelOperation.UPDATE })
+  @AuthRule(allow = AuthStrategy.OWNER, ownerField = \\"owner\\", identityClaim = \\"cognito:username\\", provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.DELETE, ModelOperation.UPDATE })
 })
 public final class allowRead implements Model {
   public static final QueryField ID = field(\\"allowRead\\", \\"id\\");
@@ -2011,7 +2267,7 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 /** This is an auto generated class representing the staticGroups type in your schema. */
 @SuppressWarnings(\\"all\\")
 @ModelConfig(pluralName = \\"staticGroups\\", authRules = {
-  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admin\\" }, operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
+  @AuthRule(allow = AuthStrategy.GROUPS, groupClaim = \\"cognito:groups\\", groups = { \\"Admin\\" }, provider = \\"userPools\\", operations = { ModelOperation.CREATE, ModelOperation.UPDATE, ModelOperation.DELETE, ModelOperation.READ })
 })
 public final class staticGroups implements Model {
   public static final QueryField ID = field(\\"staticGroups\\", \\"id\\");

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -290,6 +290,21 @@ describe('AppSyncModelVisitor', () => {
       expect(generatedCode).toMatchSnapshot();
     });
 
+    it('should generate class with non-default providers', () => {
+      const schema = /* GraphQL */ `
+        type Employee @model @auth(rules: [{ allow: owner }, { allow: private, provider:"iam" } ]) {
+          id: ID!
+          name: String!
+          address: String!
+          ssn: String @auth(rules: [{ allow: groups, provider:"oidc", groups: ["Admins"] }])
+        }
+      `;
+      const visitor = getVisitor(schema, 'Employee');
+      const generatedCode = visitor.generate();
+      expect(() => validateJava(generatedCode)).not.toThrow();
+      expect(generatedCode).toMatchSnapshot();
+    });
+
     it('should generate class with private authorization and field auth', () => {
       const schema = /* GraphQL */ `
         type privateType @model @auth(rules: [{ allow: private }]) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -808,6 +808,9 @@ export class AppSyncModelJavaVisitor<
             printWarning(`Model has auth with authStrategy ${rule.allow} of which is not yet supported`);
             return;
         }
+        if (rule.provider != null) {
+            authRule.push(`provider = "${rule.provider}"`)
+        }
         authRule.push(`operations = { ${rule.operations?.map(op => operationMapping[op]).join(', ')} }`);
         rules.push(`@AuthRule(${authRule.join(', ')})`);
       });


### PR DESCRIPTION
**NOTE** This PR should not be merged until [PR 1313](https://github.com/aws-amplify/amplify-android/pull/1313) in amplify-android is merged and released. 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Currently, models generated for Android don't have the provider attribute of the @auth rule directive. This PR adds this attribute as a string property of the annotation. It defaults to ""(empty string).

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.