### PR TITLE
fix(modelgen): iOS - skip internal initializer based on feature flag

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -55,7 +55,7 @@ async function generateModels(context) {
 
   let isTimestampFieldsAdded = false;
   try {
-    isTimestampFieldsAdded = FeatureFlags.getBoolean('addTimestampFields');
+    isTimestampFieldsAdded = FeatureFlags.getBoolean('codegen.addTimestampFields');
   } catch (err) {
     isTimestampFieldsAdded = false;
   }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -87,28 +87,30 @@ export class AppSyncSwiftVisitor<
         'public',
         {},
       );
-      //internal constructor
-      structBlock.addClassMethod(
-        'init',
-        null,
-        this.getInitBody(obj.fields),
-        obj.fields.map(field => {
-          const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
-          return {
-            name: this.getFieldName(field),
-            type: this.getNativeType(field),
-            value: field.name === 'id' ? 'UUID().uuidString' : undefined,
-            flags: {
-              optional: field.isNullable,
-              isList: field.isList,
-              isEnum: this.isEnumType(field),
-              listType: field.isList ? listType : undefined,
-            },
-          };
-        }),
-        'internal',
-        {},
-      );
+      // internal constructor to support timestamp fields
+      if (this.config.isTimestampFieldsAdded) {
+        structBlock.addClassMethod(
+          'init',
+          null,
+          this.getInitBody(obj.fields),
+          obj.fields.map(field => {
+            const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
+            return {
+              name: this.getFieldName(field),
+              type: this.getNativeType(field),
+              value: field.name === 'id' ? 'UUID().uuidString' : undefined,
+              flags: {
+                optional: field.isNullable,
+                isList: field.isList,
+                isEnum: this.isEnumType(field),
+                listType: field.isList ? listType : undefined,
+              },
+            };
+          }),
+          'internal',
+          {},
+        );
+      }
       result.push(structBlock.string);
     });
     return result.join('\n');


### PR DESCRIPTION
#### Description of changes
This PR fixes an issue where a duplicate internal constructor is generated in Swift models.
If the `addTimestampFields` is not set or false, the internal initializer used to deserialize Swift models should not be generated as will result in an `invalid redeclaration` error because will have the exact same set of parameters of the public initializer.

![invalid-redeclaration-error](https://user-images.githubusercontent.com/748632/119045983-01593a80-b971-11eb-8fb5-06418cbb0969.png)


#### Description of how you validated changes
- `yarn test`
- `amplify-dev codegen models` in an iOS project with and without the `addTimestampFields` feature flag


#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.