### PR TITLE
fix(appsync-modelgen-plugin): restore the old init if timestamp disabled

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -48,14 +48,13 @@ async function generateModels(context) {
   const outputPath = path.join(projectRoot, getModelOutputPath(context));
   const schema = parse(schemaContent);
   const projectConfig = context.amplify.getProjectConfig();
-
+  //get modelgen package
   const modelgenPackageMigrationflag = 'codegen.useAppSyncModelgenPlugin';
-
   const appSyncDataStoreCodeGen = getModelgenPackage(FeatureFlags.getBoolean(modelgenPackageMigrationflag));
-
+  //get timestamp config value
   let isTimestampFieldsAdded = false;
   try {
-    isTimestampFieldsAdded = FeatureFlags.getBoolean('addTimestampFields');
+    isTimestampFieldsAdded = FeatureFlags.getBoolean('codegen.addTimestampFields');
   } catch (err) {
     isTimestampFieldsAdded = false;
   }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -65,50 +65,75 @@ export class AppSyncSwiftVisitor<
           })
           .join(',\n'),
       ).trim()})`;
-      //public constructor
-      structBlock.addClassMethod(
-        'init',
-        null,
-        initImpl,
-        initParams.map(field => {
-          const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
-          return {
-            name: this.getFieldName(field),
-            type: this.getNativeType(field),
-            value: field.name === 'id' ? 'UUID().uuidString' : undefined,
-            flags: {
-              optional: field.isNullable,
-              isList: field.isList,
-              isEnum: this.isEnumType(field),
-              listType: field.isList ? listType : undefined,
-            },
-          };
-        }),
-        'public',
-        {},
-      );
-      //internal constructor
-      structBlock.addClassMethod(
-        'init',
-        null,
-        this.getInitBody(obj.fields),
-        obj.fields.map(field => {
-          const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
-          return {
-            name: this.getFieldName(field),
-            type: this.getNativeType(field),
-            value: field.name === 'id' ? 'UUID().uuidString' : undefined,
-            flags: {
-              optional: field.isNullable,
-              isList: field.isList,
-              isEnum: this.isEnumType(field),
-              listType: field.isList ? listType : undefined,
-            },
-          };
-        }),
-        'internal',
-        {},
-      );
+      if (this.config.isTimestampFieldsAdded) {
+        //public constructor
+        structBlock.addClassMethod(
+          'init',
+          null,
+          initImpl,
+          initParams.map(field => {
+            const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
+            return {
+              name: this.getFieldName(field),
+              type: this.getNativeType(field),
+              value: field.name === 'id' ? 'UUID().uuidString' : undefined,
+              flags: {
+                optional: field.isNullable,
+                isList: field.isList,
+                isEnum: this.isEnumType(field),
+                listType: field.isList ? listType : undefined,
+              },
+            };
+          }),
+          'public',
+          {},
+        );
+        //internal constructor
+        structBlock.addClassMethod(
+          'init',
+          null,
+          this.getInitBody(obj.fields),
+          obj.fields.map(field => {
+            const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
+            return {
+              name: this.getFieldName(field),
+              type: this.getNativeType(field),
+              value: field.name === 'id' ? 'UUID().uuidString' : undefined,
+              flags: {
+                optional: field.isNullable,
+                isList: field.isList,
+                isEnum: this.isEnumType(field),
+                listType: field.isList ? listType : undefined,
+              },
+            };
+          }),
+          'internal',
+          {},
+        );
+      } else {
+        //old constructor
+        structBlock.addClassMethod(
+          'init',
+          null,
+          this.getInitBody(obj.fields),
+          obj.fields.map(field => {
+            const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
+            return {
+              name: this.getFieldName(field),
+              type: this.getNativeType(field),
+              value: field.name === 'id' ? 'UUID().uuidString' : undefined,
+              flags: {
+                optional: field.isNullable,
+                isList: field.isList,
+                isEnum: this.isEnumType(field),
+                listType: field.isList ? listType : undefined,
+              },
+            };
+          }),
+          'public',
+          {},
+        );
+      }
       result.push(structBlock.string);
     });
     return result.join('\n');


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Re #173 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
`yarn test` and `amplify-dev codegen models` in an amplify ios app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.