### PR TITLE
fix(appsync-modelgen-plugin): skip query/mutation/sub types

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -93,7 +93,7 @@ async function generateModels(context) {
 
   generateEslintIgnore(context);
 
-  context.print.info(`Successfully generated models... Generated models can be found in ${outputPath}`);
+  context.print.info(`Successfully generated models. Generated models can be found in ${outputPath}`);
 }
 
 async function validateSchema(context) {

--- a/packages/appsync-modelgen-plugin/src/preset.ts
+++ b/packages/appsync-modelgen-plugin/src/preset.ts
@@ -220,9 +220,11 @@ const generateDartPreset = (
 export const preset: Types.OutputPreset<AppSyncModelCodeGenPresetConfig> = {
   buildGeneratesSection: (options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>): Types.GenerateOptions[] => {
     const codeGenTarget = options.config.target;
-
+    const typesToSkip: string[] = ['Query', 'Mutation', 'Subscription'];
     const models: TypeDefinitionNode[] = options.schema.definitions.filter(
-      t => t.kind === 'ObjectTypeDefinition' || (t.kind === 'EnumTypeDefinition' && !t.name.value.startsWith('__')),
+      t =>
+        (t.kind === 'ObjectTypeDefinition' && !typesToSkip.includes(t.name.value)) ||
+        (t.kind === 'EnumTypeDefinition' && !t.name.value.startsWith('__')),
     ) as any;
 
     switch (codeGenTarget) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Skip the types for `Query` `Mutation` and `Subscription` when processing the preset of modelgen

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #158 


#### Description of how you validated changes
`amplify-dev codegen models` in amplify ios, android, js and flutter app


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.