### PR TITLE
feat(appsync-modelgen-plugin): add read only timestamps in dart

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -3346,3 +3346,160 @@ class _authorBookModelType extends ModelType<authorBook> {
 }
 "
 `;
+
+exports[`AppSync Dart Visitor read-only field tests should generate the read-only timestamp fields when isTimestampFields is true 1`] = `
+"/*
+* Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the SimpleModel type in your schema. */
+@immutable
+class SimpleModel extends Model {
+  static const classType = const _SimpleModelModelType();
+  final String id;
+  final String name;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  const SimpleModel._internal(
+      {@required this.id, this.name, this.createdAt, this.updatedAt});
+
+  factory SimpleModel(
+      {String id,
+      String name,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return SimpleModel._internal(
+        id: id == null ? UUID.getUUID() : id,
+        name: name,
+        createdAt: createdAt,
+        updatedAt: updatedAt);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleModel &&
+        id == other.id &&
+        name == other.name &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write(\\"SimpleModel {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+
+    return buffer.toString();
+  }
+
+  SimpleModel copyWith(
+      {String id,
+      String name,
+      TemporalDateTime createdAt,
+      TemporalDateTime updatedAt}) {
+    return SimpleModel(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt);
+  }
+
+  SimpleModel.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
+
+  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField NAME = QueryField(fieldName: \\"name\\");
+  static final QueryField CREATEDAT = QueryField(fieldName: \\"createdAt\\");
+  static final QueryField UPDATEDAT = QueryField(fieldName: \\"updatedAt\\");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"SimpleModel\\";
+    modelSchemaDefinition.pluralName = \\"SimpleModels\\";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.NAME,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.CREATEDAT,
+        isRequired: false,
+        isReadOnly: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.UPDATEDAT,
+        isRequired: false,
+        isReadOnly: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+  });
+}
+
+class _SimpleModelModelType extends ModelType<SimpleModel> {
+  const _SimpleModelModelType();
+
+  @override
+  SimpleModel fromJson(Map<String, dynamic> jsonData) {
+    return SimpleModel.fromJson(jsonData);
+  }
+}
+"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -8,12 +8,17 @@ const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
 };
 
-const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code) => {
+const getVisitor = (
+  schema: string,
+  selectedType?: string,
+  generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code,
+  isTimestampFieldsAdded: boolean = false,
+) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncModelDartVisitor(
     builtSchema,
-    { directives, target: 'dart', scalars: DART_SCALAR_MAP },
+    { directives, target: 'dart', scalars: DART_SCALAR_MAP, isTimestampFieldsAdded },
     { selectedType, generate },
   );
   visit(ast, { leave: visitor });
@@ -38,7 +43,7 @@ describe('AppSync Dart Visitor', () => {
     it('should generate a class for a model with all optional fields except id field', () => {
       const schema = /* GraphQL */ `
         type SimpleModel @model {
-          id: ID!,
+          id: ID!
           name: String
           bar: String
         }
@@ -263,9 +268,9 @@ describe('AppSync Dart Visitor', () => {
           id: ID!
           status: Status
         }
-        enum Status { 
-          yes,
-          no,
+        enum Status {
+          yes
+          no
           maybe
         }
       `;
@@ -274,7 +279,7 @@ describe('AppSync Dart Visitor', () => {
         const generatedCode = getVisitor(schema, model).generate();
         expect(generatedCode).toMatchSnapshot();
       });
-    })
+    });
   });
 
   describe('Field tests', () => {
@@ -299,17 +304,17 @@ describe('AppSync Dart Visitor', () => {
       const schema = /* GraphQL */ `
         type TestEnumModel @model {
           id: ID!
-        
+
           enumVal: TestEnum!
-        
+
           nullableEnumVal: TestEnum
-        
+
           enumList: [TestEnum!]!
           enumNullableList: [TestEnum!]
           nullableEnumList: [TestEnum]!
           nullableEnumNullableList: [TestEnum]
         }
-        
+
         enum TestEnum {
           VALUE_ONE
           VALUE_TWO
@@ -339,7 +344,6 @@ describe('AppSync Dart Visitor', () => {
       const generatedCode = visitor.generate();
       expect(generatedCode).toMatchSnapshot();
     });
-
   });
 
   describe('Dart Specific Tests', () => {
@@ -371,7 +375,7 @@ describe('AppSync Dart Visitor', () => {
     it('should throw error when a reserved word of dart is used in graphql schema type name', () => {
       const schema = /* GraphQL */ `
         type class @model {
-          id: ID!,
+          id: ID!
           name: String!
         }
       `;
@@ -379,6 +383,20 @@ describe('AppSync Dart Visitor', () => {
       expect(visitor.generate).toThrowErrorMatchingInlineSnapshot(
         `"Type name 'class' is a reserved word in dart. Please use a non-reserved name instead."`,
       );
+    });
+  });
+
+  describe('read-only field tests', () => {
+    it('should generate the read-only timestamp fields when isTimestampFields is true', () => {
+      const schema = /* GraphQL */ `
+        type SimpleModel @model {
+          id: ID!
+          name: String
+        }
+      `;
+      const visitor = getVisitor(schema, undefined, CodeGenGenerateEnum.code, true);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchSnapshot();
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -523,10 +523,6 @@ export class AppSyncModelVisitor<
     if (!this.config.isTimestampFieldsAdded) {
       return;
     }
-    const target = this.config.target;
-    if (target === 'dart') {
-      return;
-    }
     if (directive.name !== 'model') {
       return;
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add read-only timestamp fields in dart modelgen

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.