### PR TITLE
feat(appsync-modelgen-plugin): expose readonly labels to model ts output

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -116,8 +116,8 @@ describe('Javascript visitor', () => {
           readonly foo?: Bar[];
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
         }
 
         export declare class Bar {
@@ -125,8 +125,8 @@ describe('Javascript visitor', () => {
           readonly createdAt?: string;
           readonly updatedAt?: string;
           readonly simpleModelFooId?: string;
-          constructor(init: ModelInit<Bar>);
-          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
+          constructor(init: ModelInit<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): Bar;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -239,8 +239,8 @@ describe('Javascript visitor with default owner auth', () => {
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -310,8 +310,8 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -383,8 +383,8 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -440,8 +440,8 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly ssn?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<Employee>);
-          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
+          constructor(init: ModelInit<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
+          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): Employee;
         }"
       `);
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -109,6 +109,14 @@ describe('Javascript visitor', () => {
           constructor(init: ModelInit<SimpleNonModelType>);
         }
 
+        type SimpleModelMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
+        type BarMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
         export declare class SimpleModel {
           readonly id: string;
           readonly name?: string;
@@ -116,8 +124,8 @@ describe('Javascript visitor', () => {
           readonly foo?: Bar[];
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }
 
         export declare class Bar {
@@ -125,8 +133,8 @@ describe('Javascript visitor', () => {
           readonly createdAt?: string;
           readonly updatedAt?: string;
           readonly simpleModelFooId?: string;
-          constructor(init: ModelInit<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<Bar, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): Bar;
+          constructor(init: ModelInit<Bar, BarMetaData>);
+          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar, BarMetaData>) => MutableModel<Bar, BarMetaData> | void): Bar;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -233,14 +241,18 @@ describe('Javascript visitor with default owner auth', () => {
           constructor(init: ModelInit<SimpleNonModelType>);
         }
 
+        type SimpleModelMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
         export declare class SimpleModel {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -304,14 +316,18 @@ describe('Javascript visitor with custom owner field auth', () => {
           constructor(init: ModelInit<SimpleNonModelType>);
         }
 
+        type SimpleModelMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
         export declare class SimpleModel {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -377,14 +393,18 @@ describe('Javascript visitor with multiple owner field auth', () => {
           constructor(init: ModelInit<SimpleNonModelType>);
         }
 
+        type SimpleModelMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
         export declare class SimpleModel {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<SimpleModel, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -433,6 +453,10 @@ describe('Javascript visitor with auth directives in field level', () => {
 
 
 
+        type EmployeeMetaData = {
+          readOnlyFields: 'createdAt' | 'updatedAt';
+        }
+
         export declare class Employee {
           readonly id: string;
           readonly name: string;
@@ -440,8 +464,8 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly ssn?: string;
           readonly createdAt?: string;
           readonly updatedAt?: string;
-          constructor(init: ModelInit<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}>);
-          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}>) => MutableModel<Employee, {readOnlyFields: 'createdAt' | 'updatedAt'}> | void): Employee;
+          constructor(init: ModelInit<Employee, EmployeeMetaData>);
+          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee, EmployeeMetaData>) => MutableModel<Employee, EmployeeMetaData> | void): Employee;
         }"
       `);
 

--- a/packages/appsync-modelgen-plugin/src/languages/typescript-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/typescript-declaration-block.ts
@@ -66,7 +66,7 @@ export type Method = {
 export type EnumValues = {
   [name: string]: string;
 };
-export type DeclarationKind = 'class' | 'enum' | 'interface';
+export type DeclarationKind = 'class' | 'enum' | 'interface' | 'type';
 export type DeclarationFlags = {
   isDeclaration?: boolean;
   shouldExport?: boolean;
@@ -149,7 +149,7 @@ export class TypeScriptDeclarationBlock {
     args: MethodArguments[] = [],
     access: Access = 'DEFAULT',
     flags: MethodFlag = {},
-    comment: string = ''
+    comment: string = '',
   ): void {
     if (this._kind === 'enum') {
       throw new Error('Can not add method to enum kind');
@@ -173,6 +173,8 @@ export class TypeScriptDeclarationBlock {
         return this.generateClass();
       case 'enum':
         return this.generateEnum();
+      case 'type':
+        return this.generateType();
     }
   }
 
@@ -255,6 +257,23 @@ export class TypeScriptDeclarationBlock {
   protected generateInterface(): string {
     throw new Error('Not implemented yet');
   }
+
+  protected generateType(): string {
+    const header: string[] = [
+      this._flags.shouldExport ? 'export' : '',
+      this._flags.isDeclaration ? 'declare' : '',
+      'type',
+      this._name,
+      '= {',
+    ];
+    if (this._extends.length) {
+      header.push(['extends', this._extends.join(', ')].join(' '));
+    }
+    const body: string[] = [this.generateProperties()];
+
+    return [`${header.filter(h => h).join(' ')}`, indentMultiline(body.join('\n')), '}'].join('\n');
+  }
+
   protected generatePropertyName(property: Property): string {
     let propertyName: string = property.name;
     if (property.flags.optional) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -52,6 +52,10 @@ export class AppSyncModelJavascriptVisitor<
         .map(enumObj => this.generateEnumDeclarations(enumObj, true))
         .join('\n\n');
 
+      const modelMetaData = Object.values(this.modelMap)
+        .map(typeObj => this.generateModelMetaData(typeObj))
+        .join('\n\n');
+
       const modelDeclarations = Object.values(this.modelMap)
         .map(typeObj => this.generateModelDeclaration(typeObj, true))
         .join('\n\n');
@@ -60,7 +64,7 @@ export class AppSyncModelJavascriptVisitor<
         .map(typeObj => this.generateModelDeclaration(typeObj, true))
         .join('\n\n');
 
-      return [imports, enumDeclarations, nonModelDeclarations, modelDeclarations].join('\n\n');
+      return [imports, enumDeclarations, nonModelDeclarations, modelMetaData, modelDeclarations].join('\n\n');
     } else {
       const imports = this.generateImportsJavaScriptImplementation();
       const enumDeclarations = Object.values(this.enumMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -52,10 +52,6 @@ export class AppSyncModelJavascriptVisitor<
         .map(enumObj => this.generateEnumDeclarations(enumObj, true))
         .join('\n\n');
 
-      const modelMetaData = Object.values(this.modelMap)
-        .map(typeObj => this.generateModelMetaData(typeObj))
-        .join('\n\n');
-
       const modelDeclarations = Object.values(this.modelMap)
         .map(typeObj => this.generateModelDeclaration(typeObj, true))
         .join('\n\n');
@@ -64,7 +60,15 @@ export class AppSyncModelJavascriptVisitor<
         .map(typeObj => this.generateModelDeclaration(typeObj, true))
         .join('\n\n');
 
-      return [imports, enumDeclarations, nonModelDeclarations, modelMetaData, modelDeclarations].join('\n\n');
+      if (!this.config.isTimestampFieldsAdded) {
+        return [imports, enumDeclarations, nonModelDeclarations, modelDeclarations].join('\n\n');
+      } else {
+        const modelMetaData = Object.values(this.modelMap)
+          .map(typeObj => this.generateModelMetaData(typeObj))
+          .join('\n\n');
+
+        return [imports, enumDeclarations, nonModelDeclarations, modelMetaData, modelDeclarations].join('\n\n');
+      }
     } else {
       const imports = this.generateImportsJavaScriptImplementation();
       const enumDeclarations = Object.values(this.enumMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -104,8 +104,8 @@ export class AppSyncModelTypeScriptVisitor<
 
     const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
     let readOnlyFieldNames: string[] = [];
-    let readOnlyTypesFormatted: string | undefined;
-    let readOnlyTypeLabels: string = '';
+    let modelMetaDataFormatted: string | undefined;
+    let modelMetaDataDeclaration: string = '';
 
     modelObj.fields.forEach((field: CodeGenField) => {
       modelDeclarations.addProperty(this.getFieldName(field), this.getNativeType(field), undefined, 'DEFAULT', {
@@ -118,8 +118,8 @@ export class AppSyncModelTypeScriptVisitor<
     });
 
     if (isTimestampFeatureFlagEnabled) {
-      readOnlyTypesFormatted = `, ${modelName}MetaData`;
-      readOnlyTypeLabels = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : '';
+      modelMetaDataFormatted = `, ${modelName}MetaData`;
+      modelMetaDataDeclaration = readOnlyFieldNames.length > 0 ? modelMetaDataFormatted : '';
     }
 
     // Constructor
@@ -130,7 +130,7 @@ export class AppSyncModelTypeScriptVisitor<
       [
         {
           name: 'init',
-          type: `ModelInit<${modelName}${readOnlyTypeLabels}>`,
+          type: `ModelInit<${modelName}${modelMetaDataDeclaration}>`,
         },
       ],
       'DEFAULT',

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -95,7 +95,7 @@ export class AppSyncModelTypeScriptVisitor<
     });
 
     const readOnlyTypesFormatted: string = `, {readOnlyFields: ${readOnlyFieldNames.join(' | ')}}`;
-    const readOnlyTypeLabels: string | null = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : null;
+    const readOnlyTypeLabels: string = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : '';
 
     // Constructor
     modelDeclarations.addClassMethod(
@@ -105,7 +105,7 @@ export class AppSyncModelTypeScriptVisitor<
       [
         {
           name: 'init',
-          type: `ModelInit<${modelName}${readOnlyTypeLabels ? readOnlyTypeLabels : ''}>`,
+          type: `ModelInit<${modelName}${readOnlyTypeLabels}>`,
         },
       ],
       'DEFAULT',
@@ -125,9 +125,7 @@ export class AppSyncModelTypeScriptVisitor<
           },
           {
             name: 'mutator',
-            type: `(draft: MutableModel<${modelName}${readOnlyTypeLabels ? readOnlyTypeLabels : ''}>) => MutableModel<${modelName}${
-              readOnlyTypeLabels ? readOnlyTypeLabels : ''
-            }> | void`,
+            type: `(draft: MutableModel<${modelName}${readOnlyTypeLabels}>) => MutableModel<${modelName}${readOnlyTypeLabels}> | void`,
           },
         ],
         'DEFAULT',

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -150,7 +150,7 @@ export class AppSyncModelTypeScriptVisitor<
           },
           {
             name: 'mutator',
-            type: `(draft: MutableModel<${modelName}${readOnlyTypeLabels}>) => MutableModel<${modelName}${readOnlyTypeLabels}> | void`,
+            type: `(draft: MutableModel<${modelName}${modelMetaDataDeclaration}>) => MutableModel<${modelName}${modelMetaDataDeclaration}> | void`,
           },
         ],
         'DEFAULT',

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -82,20 +82,25 @@ export class AppSyncModelTypeScriptVisitor<
       .withName(modelName)
       .export(true);
 
+    const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
     let readOnlyFieldNames: string[] = [];
+    let readOnlyTypesFormatted: string | undefined;
+    let readOnlyTypeLabels: string = '';
 
     modelObj.fields.forEach((field: CodeGenField) => {
       modelDeclarations.addProperty(this.getFieldName(field), this.getNativeType(field), undefined, 'DEFAULT', {
         readonly: true,
         optional: field.isList ? field.isListNullable : field.isNullable,
       });
-      if (field.isReadOnly) {
+      if (isTimestampFeatureFlagEnabled && field.isReadOnly) {
         readOnlyFieldNames.push(`'${field.name}'`);
       }
     });
 
-    const readOnlyTypesFormatted: string = `, {readOnlyFields: ${readOnlyFieldNames.join(' | ')}}`;
-    const readOnlyTypeLabels: string = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : '';
+    if (isTimestampFeatureFlagEnabled) {
+      readOnlyTypesFormatted = `, {readOnlyFields: ${readOnlyFieldNames.join(' | ')}}`;
+      readOnlyTypeLabels = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : '';
+    }
 
     // Constructor
     modelDeclarations.addClassMethod(

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -69,6 +69,26 @@ export class AppSyncModelTypeScriptVisitor<
     return enumDeclarations.string;
   }
 
+  protected generateModelMetaData(modelObj: CodeGenModel): string {
+    const modelName = this.generateModelTypeDeclarationName(modelObj);
+    const modelDeclarations = new TypeScriptDeclarationBlock()
+      .asKind('type')
+      .withName(`${modelName}MetaData`)
+      .export(false);
+
+    const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
+    let readOnlyFieldNames: string[] = [];
+
+    modelObj.fields.forEach((field: CodeGenField) => {
+      if (isTimestampFeatureFlagEnabled && field.isReadOnly) {
+        readOnlyFieldNames.push(`'${field.name}'`);
+      }
+    });
+    modelDeclarations.addProperty('readOnlyFields', readOnlyFieldNames.join(' | '));
+
+    return modelDeclarations.string;
+  }
+
   /**
    *
    * @param modelObj CodeGenModel object
@@ -98,7 +118,7 @@ export class AppSyncModelTypeScriptVisitor<
     });
 
     if (isTimestampFeatureFlagEnabled) {
-      readOnlyTypesFormatted = `, {readOnlyFields: ${readOnlyFieldNames.join(' | ')}}`;
+      readOnlyTypesFormatted = `, ${modelName}MetaData`;
       readOnlyTypeLabels = readOnlyFieldNames.length > 0 ? readOnlyTypesFormatted : '';
     }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This allows us to omit the readonly fields (only if the `config.isTimestampFieldsAdded` flag is enabled in the `cli.json` within a user's project) from being suggested by Intellisense. The associated tests were updated automatically via running `jest --updateSnapshot`.

**_Additionally_**, I've extended the `typescript-declaration-block.ts` file with a new method to dynamically generate `type` blocks which get output in the `index.d.ts` file in user projects. I'm updating the `types.ts` in JS Datastore to reflect this new second parameter passed in to the constructor/copyOf (as seen in the generated snapshots in the test file).


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
None


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.