### PR TITLE
fix(appsync-modelgen-plugin): fix init when no read-only fields found

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2146,7 +2146,7 @@ describe('AppSyncSwiftVisitor', () => {
         }"
       `);
     });
-    it('should keep the original init method if timestamp is enabled but no read-only fields found', () => {
+    it('should keep the original init method if timestamp ff is enabled and schema has explicit timestamp fields', () => {
       const schema = /* GraphQL */ `
         type SimpleModel @model {
           id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -15,13 +15,21 @@ const getVisitor = (
   isTimestampFieldsAdded: boolean = true,
   emitAuthProvider: boolean = true,
   generateIndexRules: boolean = true,
-  handleListNullabilityTransparently: boolean = true
+  handleListNullabilityTransparently: boolean = true,
 ) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncSwiftVisitor(
     builtSchema,
-    { directives, target: 'swift', scalars: SWIFT_SCALAR_MAP, isTimestampFieldsAdded, emitAuthProvider, generateIndexRules, handleListNullabilityTransparently },
+    {
+      directives,
+      target: 'swift',
+      scalars: SWIFT_SCALAR_MAP,
+      isTimestampFieldsAdded,
+      emitAuthProvider,
+      generateIndexRules,
+      handleListNullabilityTransparently,
+    },
     { selectedType, generate },
   );
   visit(ast, { leave: visitor });
@@ -2063,14 +2071,14 @@ describe('AppSyncSwiftVisitor', () => {
   });
 
   describe('timestamp fields', () => {
-    const schema = /* GraphQL */ `
-      type SimpleModel @model {
-        id: ID!
-        name: String
-        bar: String
-      }
-    `;
     it('should generate timestamp fields if timestamp is enabled', () => {
+      const schema = /* GraphQL */ `
+        type SimpleModel @model {
+          id: ID!
+          name: String
+          bar: String
+        }
+      `;
       const visitor = getVisitor(schema, 'SimpleModel', CodeGenGenerateEnum.code, true);
       const generatedCode = visitor.generate();
       expect(generatedCode).toMatchInlineSnapshot(`
@@ -2109,6 +2117,13 @@ describe('AppSyncSwiftVisitor', () => {
       `);
     });
     it('should keep the original init method if timestamp is disabled', () => {
+      const schema = /* GraphQL */ `
+        type SimpleModel @model {
+          id: ID!
+          name: String
+          bar: String
+        }
+      `;
       const visitor = getVisitor(schema, 'SimpleModel', CodeGenGenerateEnum.code, false);
       const generatedCode = visitor.generate();
       expect(generatedCode).toMatchInlineSnapshot(`
@@ -2127,6 +2142,36 @@ describe('AppSyncSwiftVisitor', () => {
               self.id = id
               self.name = name
               self.bar = bar
+          }
+        }"
+      `);
+    });
+    it('should keep the original init method if timestamp is enabled but no read-only fields found', () => {
+      const schema = /* GraphQL */ `
+        type SimpleModel @model {
+          id: ID!
+          createdAt: AWSDateTime
+          updatedAt: AWSDateTime
+        }
+      `;
+      const visitor = getVisitor(schema, 'SimpleModel', CodeGenGenerateEnum.code, true);
+      const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchInlineSnapshot(`
+        "// swiftlint:disable all
+        import Amplify
+        import Foundation
+
+        public struct SimpleModel: Model {
+          public let id: String
+          public var createdAt: Temporal.DateTime?
+          public var updatedAt: Temporal.DateTime?
+          
+          public init(id: String = UUID().uuidString,
+              createdAt: Temporal.DateTime? = nil,
+              updatedAt: Temporal.DateTime? = nil) {
+              self.id = id
+              self.createdAt = createdAt
+              self.updatedAt = updatedAt
           }
         }"
       `);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use the old init method if no read-only fields found, which is typically for the case where explicit timestamp fields are defined and feature flag value is true (the timestamps are not read-only here)

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #201


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.