### PR TITLE
fix(graphql-types-generator): add wrapperr for sub response in angular

### DIFF
--- a/packages/graphql-types-generator/src/angular/index.ts
+++ b/packages/graphql-types-generator/src/angular/index.ts
@@ -60,7 +60,7 @@ function generateSubscriptionResponseWrapper(generator: CodeGenerator) {
   generator.printNewline();
 }
 function generateSubscriptionOperationTypes(generator: CodeGenerator, context: LegacyCompilerContext) {
-  const typeName = 'Subscription';
+  const typeName = '__SubscriptionContainer';
   const properties: Property[] = [];
   Object.values(context.operations)
     .filter(operation => operation.operationType === 'subscription')
@@ -75,7 +75,7 @@ function generateSubscriptionOperationTypes(generator: CodeGenerator, context: L
       }
     });
   if (properties.length) {
-    generator.printOnNewline('export type Subscription = ');
+    generator.printOnNewline(`export type ${typeName} = `);
     generator.pushScope({ typeName });
     generator.withinBlock(() => propertyDeclarations(generator, properties), '{', '}');
     generator.popScope();
@@ -133,7 +133,7 @@ function getReturnTypeName(generator: CodeGenerator, op: LegacyOperation): Strin
   } else {
     let returnType = interfaceNameFromOperation({ operationName, operationType });
     if (op.operationType === 'subscription' && op.fields.length) {
-      returnType = `Pick<Subscription, "${op.fields[0].responseName}">`;
+      returnType = `Pick<__SubscriptionContainer, "${op.fields[0].responseName}">`;
     }
     if (isList(type)) {
       returnType = `Array<${returnType}>`;

--- a/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -1114,6 +1114,10 @@ export interface SubscriptionResponse<T> {
   value: GraphQLResult<T>;
 }
 
+export type Subscription = {
+  onCreateRestaurant: OnCreateRestaurantSubscription;
+};
+
 export type Restaurant = {
   __typename: \\"Restaurant\\";
   id: string;
@@ -1135,7 +1139,7 @@ export type OnCreateRestaurantSubscription = {
 })
 export class APIService {
   OnCreateRestaurantListener: Observable<
-    SubscriptionResponse<OnCreateRestaurantSubscription>
+    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
   > = API.graphql(
     graphqlOperation(
       \`subscription OnCreateRestaurant {
@@ -1148,7 +1152,9 @@ export class APIService {
         }
       }\`
     )
-  ) as Observable<SubscriptionResponse<OnCreateRestaurantSubscription>>;
+  ) as Observable<
+    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+  >;
 }
 "
 `;
@@ -1164,6 +1170,10 @@ import { Observable } from \\"zen-observable-ts\\";
 export interface SubscriptionResponse<T> {
   value: GraphQLResult<T>;
 }
+
+export type Subscription = {
+  onCreateRestaurant: OnCreateRestaurantSubscription;
+};
 
 export type Restaurant = {
   __typename: \\"Restaurant\\";
@@ -1193,7 +1203,9 @@ export type OnCreateRestaurantSubscription = {
 export class APIService {
   OnCreateRestaurantListener(
     owner: string
-  ): Observable<SubscriptionResponse<OnCreateRestaurantSubscription>> {
+  ): Observable<
+    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+  > {
     const statement = \`subscription OnCreateRestaurant($owner: String!) {
         onCreateRestaurant(owner: $owner) {
           __typename
@@ -1211,7 +1223,9 @@ export class APIService {
     };
     return API.graphql(
       graphqlOperation(statement, gqlAPIServiceArguments)
-    ) as Observable<SubscriptionResponse<OnCreateRestaurantSubscription>>;
+    ) as Observable<
+      SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+    >;
   }
 }
 "

--- a/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -1114,7 +1114,7 @@ export interface SubscriptionResponse<T> {
   value: GraphQLResult<T>;
 }
 
-export type Subscription = {
+export type __SubscriptionContainer = {
   onCreateRestaurant: OnCreateRestaurantSubscription;
 };
 
@@ -1139,7 +1139,7 @@ export type OnCreateRestaurantSubscription = {
 })
 export class APIService {
   OnCreateRestaurantListener: Observable<
-    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+    SubscriptionResponse<Pick<__SubscriptionContainer, \\"onCreateRestaurant\\">>
   > = API.graphql(
     graphqlOperation(
       \`subscription OnCreateRestaurant {
@@ -1153,7 +1153,7 @@ export class APIService {
       }\`
     )
   ) as Observable<
-    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+    SubscriptionResponse<Pick<__SubscriptionContainer, \\"onCreateRestaurant\\">>
   >;
 }
 "
@@ -1171,7 +1171,7 @@ export interface SubscriptionResponse<T> {
   value: GraphQLResult<T>;
 }
 
-export type Subscription = {
+export type __SubscriptionContainer = {
   onCreateRestaurant: OnCreateRestaurantSubscription;
 };
 
@@ -1204,7 +1204,7 @@ export class APIService {
   OnCreateRestaurantListener(
     owner: string
   ): Observable<
-    SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+    SubscriptionResponse<Pick<__SubscriptionContainer, \\"onCreateRestaurant\\">>
   > {
     const statement = \`subscription OnCreateRestaurant($owner: String!) {
         onCreateRestaurant(owner: $owner) {
@@ -1224,7 +1224,7 @@ export class APIService {
     return API.graphql(
       graphqlOperation(statement, gqlAPIServiceArguments)
     ) as Observable<
-      SubscriptionResponse<Pick<Subscription, \\"onCreateRestaurant\\">>
+      SubscriptionResponse<Pick<__SubscriptionContainer, \\"onCreateRestaurant\\">>
     >;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add `Subscription` type in angular type-gen and the corresponding `Pick` wrapper in subscription response

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #207


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.