### PR TITLE
fix(appsync-modelgen-plugin): dart model internal constructor with no internal fields

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -3355,6 +3355,105 @@ class _authorBookModelType extends ModelType<authorBook> {
 "
 `;
 
+exports[`AppSync Dart Visitor Null Safety Tests should generate correct internal constructor for a model has only ID field 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+
+/** This is an auto generated class representing the TestModel type in your schema. */
+@immutable
+class TestModel extends Model {
+  static const classType = const _TestModelModelType();
+  final String id;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  const TestModel._internal({required this.id});
+  
+  factory TestModel({String? id}) {
+    return TestModel._internal(
+      id: id == null ? UUID.getUUID() : id);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TestModel &&
+      id == other.id;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"TestModel {\\");
+    buffer.write(\\"id=\\" + \\"$id\\");
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  TestModel copyWith({String? id}) {
+    return TestModel(
+      id: id ?? this.id);
+  }
+  
+  TestModel.fromJson(Map<String, dynamic> json)  
+    : id = json['id'];
+  
+  Map<String, dynamic> toJson() => {
+    'id': id
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"TestModel\\";
+    modelSchemaDefinition.pluralName = \\"TestModels\\";
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+  });
+}
+
+class _TestModelModelType extends ModelType<TestModel> {
+  const _TestModelModelType();
+  
+  @override
+  TestModel fromJson(Map<String, dynamic> jsonData) {
+    return TestModel.fromJson(jsonData);
+  }
+}"
+`;
+
 exports[`AppSync Dart Visitor Null Safety Tests should generate correct model files if the null safety is enabled 1`] = `
 "/*
 * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -430,5 +430,15 @@ describe('AppSync Dart Visitor', () => {
       const generatedCode = getVisitor(schema, 'TestModel', CodeGenGenerateEnum.code, true).generate();
       expect(generatedCode).toMatchSnapshot();
     });
+
+    it('should generate correct internal constructor for a model has only ID field', () => {
+      const schema = /* GraphQL */ `
+        type TestModel @model {
+          id: ID!
+        }
+      `;
+      const generatedCode = getVisitor(schema, 'TestModel', CodeGenGenerateEnum.code, true).generate();
+      expect(generatedCode).toMatchSnapshot();
+    })
   });
 });

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -298,11 +298,13 @@ export class AppSyncModelDartVisitor<
           .map(f => `${this.isFieldRequired(f) ? 'required ' : ''}${this.getFieldName(f) === 'id' ? 'this.' : ''}${this.getFieldName(f)}`)
           .join(', ')}}`
       : `{${model.fields.map(f => `${this.isFieldRequired(f) ? '@required ' : ''}this.${this.getFieldName(f)}`).join(', ')}}`;
+    const internalFields = model.fields.filter(f => this.getFieldName(f) !== 'id');
     const internalImpl = this.isNullSafety()
-      ? `: ${model.fields
-          .filter(f => this.getFieldName(f) !== 'id')
+      ? internalFields.length ? `: ${
+        internalFields
           .map(f => `_${this.getFieldName(f)} = ${this.getFieldName(f)}`)
-          .join(', ')};`
+          .join(', ')
+      };` : ';'
       : ';';
     declarationBlock.addClassMethod(`${this.getModelName(model)}._internal`, '', [{ name: args }], internalImpl, {
       const: true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

amplify-flutter [#759](https://github.com/aws-amplify/amplify-flutter/issues/759)

#### Description of how you validated changes

1.  Ran `yarn setup-dev`
2. Tested to generate model in Dart with below schema
3. Generated model should have internal constructor as below example

```graphql
type IDOnlyModel @model {
  id: ID!
}
```

Generated model internal constructor
```dart
// Before the fix
const IDOnlyModel._internal({required this.id}): ;

// After the fix
const IDOnlyModel._internal({required this.id});
```
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.