### PR TITLE
primaryKey/index directives

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -72,6 +72,7 @@ async function generateModels(context) {
 
   const generateIndexRules = readFeatureFlag('codegen.generateIndexRules');
   const emitAuthProvider = readFeatureFlag('codegen.emitAuthProvider');
+  const usePipelinedTransformer = readFeatureFlag('graphQLTransformer.useExperimentalPipelinedTransformer')
 
   let enableDartNullSafety = readFeatureFlag('codegen.enableDartNullSafety');
 
@@ -101,7 +102,8 @@ async function generateModels(context) {
       emitAuthProvider,
       generateIndexRules,
       enableDartNullSafety,
-      handleListNullabilityTransparently
+      handleListNullabilityTransparently,
+      usePipelinedTransformer
     },
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -8,6 +8,11 @@ import {
   getConnectedField,
 } from '../../utils/process-connections';
 import { CodeGenModelMap, CodeGenModel } from '../../visitors/appsync-visitor';
+import { beforeEach } from 'jest-circus';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
@@ -461,6 +466,137 @@ describe('process connection', () => {
       const employeeModel = modelMap.Employee;
       expect(getConnectedField(supervisorField, employeeModel, employeeModel)).toEqual(subordinateField);
       expect(getConnectedField(subordinateField, employeeModel, employeeModel)).toEqual(supervisorField);
+    });
+  });
+
+  describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
+    let modelMap: CodeGenModelMap;
+    let v2ModelMap: CodeGenModelMap;
+
+    beforeEach(() => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+        }
+
+        type Comment @model @key(name: "byPost", fields: ["postID", "content"]) {
+          postID: ID!
+          content: String!
+          post: Post @connection(fields:['postID'])
+        }
+      `;
+
+      const v2Schema = /* GraphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+        }
+        
+        type Comment @model {
+          postID: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          post: Post @connection(fields:["postID"])
+        }
+      `;
+      modelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [{ name: 'key', arguments: { name: 'byPost', fields: ['postID', 'content'] } }],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
+
+      v2ModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'primaryKey', arguments: { name: 'byPost', sortKeyFields: ['content'] } }],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
+    });
+
+    describe('Has many comparison', () => {
+      it('should support connection with @primaryKey on BELONGS_TO side', () => {
+        const postField = v2ModelMap.Comment.fields[2];
+        const connectionInfo = (processConnections(postField, v2ModelMap.Post, v2ModelMap) as any) as CodeGenFieldConnectionBelongsTo;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
+        expect(connectionInfo.targetName).toEqual(v2ModelMap.Comment.fields[0].name);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -8,14 +8,16 @@ import {
   getConnectedField,
 } from '../../utils/process-connections';
 import { CodeGenModelMap, CodeGenModel } from '../../visitors/appsync-visitor';
-import { beforeEach } from 'jest-circus';
 import { FeatureFlags } from 'amplify-cli-core';
 
 jest.mock("amplify-cli-core");
 const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
+
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One:Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -153,6 +155,8 @@ describe('process connection', () => {
     });
   });
   describe('Uni-directional connection (unnamed connection)', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -224,6 +228,8 @@ describe('process connection', () => {
   });
 
   describe('connection v2', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
 
     beforeEach(() => {
@@ -299,6 +305,8 @@ describe('process connection', () => {
     });
   });
   describe('getConnectedField', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One to Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -418,6 +426,8 @@ describe('process connection', () => {
   });
 
   describe('self referencing models', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -472,6 +482,7 @@ describe('process connection', () => {
   describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
     let modelMap: CodeGenModelMap;
     let v2ModelMap: CodeGenModelMap;
+    let v2IndexModelMap: CodeGenModelMap;
 
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -497,6 +508,18 @@ describe('process connection', () => {
           post: Post @connection(fields:["postID"])
         }
       `;
+
+      const v2IndexSchema = /* graphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byContent", fields: ["id"])
+        }
+        
+        type Comment @model {
+          postID: ID! @primaryKey
+          content: String! @index(name: "byContent")
+          post: Post @connection(fields: ["postID"])
+      `;
+
       modelMap = {
         Post: {
           name: 'Post',
@@ -553,7 +576,7 @@ describe('process connection', () => {
               isNullable: true,
               isList: true,
               name: 'comments',
-              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+              directives: [{ name: 'connection', arguments: { fields: ['id'] } }],
             },
           ],
         },
@@ -567,7 +590,7 @@ describe('process connection', () => {
               isNullable: false,
               isList: false,
               name: 'postID',
-              directives: [{name: 'primaryKey', arguments: { name: 'byPost', sortKeyFields: ['content'] } }],
+              directives: [{name: 'primaryKey', arguments: { sortKeyFields: ['content'] } }],
             },
             {
               type: 'String',
@@ -586,10 +609,57 @@ describe('process connection', () => {
           ],
         },
       };
+
+      v2IndexModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byContent', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'primaryKey', arguments: {} }],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [{name: 'index', arguments: { name: 'byContent' }}],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
     });
 
     describe('Has many comparison', () => {
       it('should support connection with @primaryKey on BELONGS_TO side', () => {
+        // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
         const postField = v2ModelMap.Comment.fields[2];
         const connectionInfo = (processConnections(postField, v2ModelMap.Post, v2ModelMap) as any) as CodeGenFieldConnectionBelongsTo;
         expect(connectionInfo).toBeDefined();
@@ -597,6 +667,27 @@ describe('process connection', () => {
         expect(connectionInfo.targetName).toEqual(v2ModelMap.Comment.fields[0].name);
         expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
+
+      it('should support connection with @primaryKey on HAS_MANY side', () => {
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return true; });
+        const commentsField = v2ModelMap.Post.fields[0];
+        const connectionInfo = (processConnections(commentsField, v2ModelMap.Comment, v2ModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2ModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
+
+      it('Should support connection with @index on BELONGS_TO side', () => {
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return true; });
+        const commentsField = v2ModelMap.Post.fields[0];
+        const connectionInfo = (processConnections(commentsField, v2ModelMap.Comment, v2ModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2ModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
     });
+
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -3,6 +3,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelDartVisitor } from '../../visitors/appsync-dart-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { DART_SCALAR_MAP } from '../../scalars';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -26,6 +30,8 @@ const getVisitor = (
 };
 
 describe('AppSync Dart Visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   describe('Model Directive', () => {
     it('should generate a class for a Simple Model', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -193,8 +193,9 @@ describe('AppSyncModelVisitor', () => {
     expect(generatedCode).toMatchSnapshot();
   });
 
-  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
+  describe('vNext transformer feature parity tests', () => {
+    it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
       type authorBook @model @key(fields: ["author_id"]) {
         id: ID!
         author_id: ID!
@@ -203,7 +204,7 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    const schemaV2 = /* GraphQL */ `
+      const schemaV2 = /* GraphQL */ `
       type authorBook @model {
         id: ID!
         author_id: ID! @primaryKey
@@ -212,21 +213,21 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+        return false;
+      }).mockImplementationOnce((flagName: String): boolean => {
+        return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      });
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitor(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
+
+      expect(version1Code).toMatch(version2Code);
     });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
 
-    expect(version1Code).toMatch(version2Code);
-  });
-
-  it('should produce the same result for @index as the secondary index variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
+    it('should produce the same result for @index as the secondary index variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
       type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
         id: ID!
         author_id: ID!
@@ -235,7 +236,7 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    const schemaV2 = /* GraphQL */ `
+      const schemaV2 = /* GraphQL */ `
       type authorBook @model {
         id: ID! @primaryKey
         author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
@@ -244,17 +245,18 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
+      FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+        return false;
+      }).mockImplementationOnce((flagName: String): boolean => {
+        return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      });
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitor(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
 
-    expect(version1Code).toMatch(version2Code);
+      expect(version1Code).toMatch(version2Code);
+    });
   });
 
   it('Should handle nullability of lists appropriately', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -193,6 +193,70 @@ describe('AppSyncModelVisitor', () => {
     expect(generatedCode).toMatchSnapshot();
   });
 
+  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
   it('Should handle nullability of lists appropriately', () => {
     const schema = /* GraphQL */ `
       enum StatusEnum {
@@ -425,70 +489,6 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
-  });
-
-  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
-      type authorBook @model @key(fields: ["author_id"]) {
-        id: ID!
-        author_id: ID!
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    const schemaV2 = /* GraphQL */ `
-      type authorBook @model {
-        id: ID!
-        author_id: ID! @primaryKey
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
-
-    expect(version1Code).toMatch(version2Code);
-  });
-
-  it('should produce the same result for @index as the secondary index variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
-      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
-        id: ID!
-        author_id: ID!
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    const schemaV2 = /* GraphQL */ `
-      type authorBook @model {
-        id: ID! @primaryKey
-        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
-
-    expect(version1Code).toMatch(version2Code);
   });
 
   describe('connection', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -4,6 +4,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavaVisitor } from '../../visitors/appsync-java-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { JAVA_SCALAR_MAP } from '../../scalars';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -421,6 +425,70 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
+  });
+
+  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
   });
 
   describe('connection', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -3,6 +3,10 @@ import { validateTs } from '@graphql-codegen/testing';
 import { TYPESCRIPT_SCALAR_MAP } from '../../scalars';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavascriptVisitor } from '../../visitors/appsync-javascript-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -25,6 +29,8 @@ const getVisitor = (
 };
 
 describe('Javascript visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -9,6 +9,10 @@ import {
 } from '../../utils/process-connections';
 import { AppSyncJSONVisitor, AssociationHasMany, JSONSchemaNonModel } from '../../visitors/appsync-json-metadata-visitor';
 import { CodeGenEnum, CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -27,6 +31,9 @@ const getVisitor = (schema: string, target: 'typescript' | 'javascript' | 'typeD
 };
 
 describe('Metadata visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
+
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -3,6 +3,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { SWIFT_SCALAR_MAP } from '../../scalars';
 import { AppSyncSwiftVisitor } from '../../visitors/appsync-swift-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -366,6 +370,70 @@ describe('AppSyncSwiftVisitor', () => {
           }
       }"
     `);
+  });
+
+  it('Should produce same result for @primaryKey as when @key is used for a primary key', () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
   });
 
   it('Should handle nullability of lists appropriately', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -2,6 +2,10 @@ import { buildSchema, parse, visit } from 'graphql';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { CodeGenConnectionType, CodeGenFieldConnectionBelongsTo, CodeGenFieldConnectionHasMany } from '../../utils/process-connections';
 import { AppSyncModelVisitor, CodeGenField, CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String) => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -21,6 +25,8 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
 
   it('should support schema with id', () => {
     const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -133,6 +133,11 @@ export const directives = /* GraphQL */ `
   }
 
   directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+  
+  # GraphQL vNext Directives
+  # primaryKey directive
+  directive @primaryKey(sortKeyFields: [String!], queryField: String) on FIELD_DEFINITION
+  directive @index(name: String!, sortKeyFields: [String], queryField: String) on FIELD_DEFINITION
 `;
 
 export const scalars = [

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -1,4 +1,4 @@
-import { CodeGenModel, CodeGenModelMap, CodeGenField, CodeGenDirective } from '../visitors/appsync-visitor';
+import { CodeGenModel, CodeGenModelMap, CodeGenField, CodeGenDirective, CodeGenFieldDirective } from '../visitors/appsync-visitor';
 import { camelCase } from 'change-case';
 import { FeatureFlags } from 'amplify-cli-core';
 
@@ -41,6 +41,21 @@ export function makeConnectionAttributeName(type: string, field?: string) {
   // Make sure the logic gets update in that package
   return field ? camelCase([type, field, 'id'].join('_')) : camelCase([type, 'id'].join('_'));
 }
+export function usingV2Transformer(): boolean {
+  return FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
+}
+
+function flattenFieldDirectives(model: CodeGenModel) {
+  let totalDirectives: CodeGenFieldDirective[] = new Array<CodeGenFieldDirective>();
+  model.fields.forEach(field => {
+    field.directives.forEach(dir => {
+      let fieldDir = dir as CodeGenFieldDirective;
+      fieldDir.fieldName = field.name;
+      totalDirectives.push(fieldDir);
+    })
+  });
+  return totalDirectives;
+}
 
 export function getConnectedField(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel): CodeGenField {
   const connectionInfo = getDirective(field)('connection');
@@ -48,13 +63,7 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
     throw new Error(`The ${field.name} on model ${model.name} is not connected`);
   }
   // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-  let usePipelinedTransformer: Boolean;
-  try {
-    usePipelinedTransformer = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
-  }
-  catch (e) {
-    usePipelinedTransformer = false;
-  }
+  let usePipelinedTransformer: Boolean = usingV2Transformer();
 
   const connectionName = connectionInfo.arguments.name;
   const keyName = connectionInfo.arguments.keyName;
@@ -62,22 +71,36 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
   if (connectionFields) {
     let keyDirective;
     if (keyName) {
-      keyDirective = connectedModel.directives.find(dir => {
-        return usePipelinedTransformer ? (dir.name === 'index' && dir.arguments.name === keyName) : dir.name === 'key' && dir.arguments.name === keyName;
-      });
+      if (usePipelinedTransformer) {
+        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+          return dir.name === 'index' && dir.arguments.name === keyName;
+        });
+      }
+      else {
+        keyDirective = connectedModel.directives.find(dir => {
+          return dir.name === 'key' && dir.arguments.name === keyName;
+        });
+      }
       if (!keyDirective) {
         throw new Error(
           `Error processing @connection directive on ${model.name}.${field.name}, @key directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
         );
       }
     } else {
-      keyDirective = connectedModel.directives.find(dir => {
-        return usePipelinedTransformer ? (dir.name === 'primaryKey') : dir.name === 'key' && typeof dir.arguments.name === 'undefined';
-      });
+      if (usePipelinedTransformer) {
+        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+          return dir.name === 'primaryKey';
+        });
+      }
+      else {
+        keyDirective = connectedModel.directives.find(dir => {
+          return dir.name === 'key' && typeof dir.arguments.name === 'undefined';
+        });
+      }
     }
 
     // when there is a fields argument in the connection
-    const connectedFieldName = keyDirective ? keyDirective.arguments.fields[0] : DEFAULT_HASH_KEY_FIELD;
+    const connectedFieldName = keyDirective ? (usePipelinedTransformer ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective) : keyDirective.arguments.fields[0]) : DEFAULT_HASH_KEY_FIELD;
 
     // Find a field on the other side which connected by a @connection and has the same fields[0] as keyName field
     const otherSideConnectedField = connectedModel.fields.find(f => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -12,11 +12,19 @@ import {
 } from '../configs/java-config';
 import { JAVA_TYPE_IMPORT_MAP } from '../scalars';
 import { JavaDeclarationBlock } from '../languages/java-declaration-block';
-import { AppSyncModelVisitor, CodeGenField, CodeGenModel, ParsedAppSyncModelConfig, RawAppSyncModelConfig } from './appsync-visitor';
+import {
+  AppSyncModelVisitor,
+  CodeGenDirective,
+  CodeGenField,
+  CodeGenModel,
+  ParsedAppSyncModelConfig,
+  RawAppSyncModelConfig,
+} from './appsync-visitor';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { validateFieldName } from '../utils/validate-field-name';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export class AppSyncModelJavaVisitor<
   TRawConfig extends RawAppSyncModelConfig = RawAppSyncModelConfig,
@@ -754,6 +762,8 @@ export class AppSyncModelJavaVisitor<
   }
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {
+    // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
+    let usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     const annotations: string[] = model.directives.map(directive => {
       switch (directive.name) {
         case 'model':
@@ -767,16 +777,53 @@ export class AppSyncModelJavaVisitor<
           }
           return `ModelConfig(${modelArgs.join(', ')})`;
         case 'key':
-          const keyArgs: string[] = [];
-          keyArgs.push(`name = "${directive.arguments.name}"`);
-          keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
-          return `Index(${keyArgs.join(', ')})`;
-
+          if (!usePipelinedTransformer) {
+            const keyArgs: string[] = [];
+            keyArgs.push(`name = "${directive.arguments.name}"`);
+            keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+            return `Index(${keyArgs.join(', ')})`;
+          }
+          break;
         default:
           break;
       }
       return '';
     });
+
+    var modelLevelFieldAnnotations: string[] = new Array<string>();
+    model.fields.forEach(field => {
+      field.directives.forEach(directive => {
+        switch(directive.name) {
+          case 'primaryKey':
+            if (usePipelinedTransformer) {
+              const keyArgs: string[] = [];
+              keyArgs.push(`name = "undefined"`);
+              if(!directive.arguments.sortKeyFields) {
+                directive.arguments.sortKeyFields = new Array<string>();
+              }
+              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
+              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
+            }
+            break;
+          case 'index':
+            if (usePipelinedTransformer) {
+              const keyArgs: string[] = [];
+              keyArgs.push(`name = "${directive.arguments.name}"`);
+              if(!directive.arguments.sortKeyFields) {
+                directive.arguments.sortKeyFields = new Array<string>();
+              }
+              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
+              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
+            }
+            break;
+          default:
+            break;
+        }
+      })
+    })
+    annotations.push(...modelLevelFieldAnnotations);
     return ['SuppressWarnings("all")', ...annotations].filter(annotation => annotation);
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -763,7 +763,7 @@ export class AppSyncModelJavaVisitor<
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {
     // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-    let usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
+    const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     const annotations: string[] = model.directives.map(directive => {
       switch (directive.name) {
         case 'model':

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -442,6 +442,7 @@ export class AppSyncSwiftVisitor<
   }
 
   protected generateKeyRules(model: CodeGenModel): string[] {
+    // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
     const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     let keyDirectives: string[];
 
@@ -457,7 +458,7 @@ export class AppSyncSwiftVisitor<
       });
 
       keyDirectives = fieldDirectiveList
-        .filter(directiveObj => directiveObj.directive.name === "primaryKey" || directiveObj.directive.name === "index")
+        .filter(directiveObj => directiveObj.directive.name === 'primaryKey' || directiveObj.directive.name === 'index')
         .map(directiveObj => {
           switch(directiveObj.directive.name) {
             case 'primaryKey':

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -125,6 +125,10 @@ export type CodeGenDirective = {
   arguments: CodeGenArgumentsMap;
 };
 
+export type CodeGenFieldDirective = CodeGenDirective & {
+  fieldName: string;
+}
+
 export type CodeGenDirectives = CodeGenDirective[];
 export type CodeGenField = TypeInfo & {
   name: string;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -27,6 +27,7 @@ import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } fro
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
 import { processAuthDirective } from '../utils/process-auth';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',
@@ -407,11 +408,13 @@ export class AppSyncModelVisitor<
   }
 
   protected computeVersion(): string {
+    // TODO: Remove v2 transformer feature flag after release
+    const usePipelinedTransformer: boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     // Sort types
     const typeArr: any[] = [];
     Object.values({ ...this.modelMap, ...this.nonModelMap }).forEach((obj: CodeGenModel) => {
       // include only key directive as we don't care about others for versioning
-      const directives = obj.directives.filter(dir => dir.name === 'key');
+      const directives = usePipelinedTransformer ? obj.directives.filter(dir => dir.name === 'primaryKey' || dir.name === 'index') : obj.directives.filter(dir => dir.name === 'key');
       const fields = obj.fields
         .map((field: CodeGenField) => {
           // include only connection field and type

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -109,6 +109,12 @@ export interface RawAppSyncModelConfig extends RawConfig {
    * @descriptions optional boolean which generates the list types to respect the nullability as defined in the schema
    */
    handleListNullabilityTransparently?: boolean;
+  /**
+   * @name usePipelinedTransformer
+   * @type boolean
+   * @descriptions optional boolean which determines whether to use the new pipelined GraphQL transformer
+   */
+  usePipelinedTransformer?: boolean;
 }
 
 // Todo: need to figure out how to share config
@@ -118,6 +124,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   target?: string;
   isTimestampFieldsAdded?: boolean;
   handleListNullabilityTransparently?: boolean;
+  usePipelinedTransformer?: boolean;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -188,7 +195,8 @@ export class AppSyncModelVisitor<
       scalars: buildScalars(_schema, rawConfig.scalars || '', defaultScalars),
       target: rawConfig.target,
       isTimestampFieldsAdded: rawConfig.isTimestampFieldsAdded,
-      handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently
+      handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently,
+      usePipelinedTransformer: rawConfig.usePipelinedTransformer,
     });
 
     const typesUsedInDirectives: string[] = [];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
This adds codegen support for the new `@primaryKey` and `@index` directives added by the vNext transformer, it duplicates the existing functionality of `@key` and splits it into two separate directives. The new directives are hidden behind a feature flag. Schemas without the feature flag won't error out with the new directives, but they won't be processed.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit testing, existing and new written to verify that old and new match, creating schemas with the directives for CLI testing



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.