### PR TITLE
fix(appsync-modelgen-plugin): add type cast for float fromJson

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -874,8 +874,8 @@ class TestModel extends Model {
 
   TestModel.fromJson(Map<String, dynamic> json)
       : id = json['id'],
-        floatVal = json['floatVal'],
-        floatNullableVal = json['floatNullableVal'],
+        floatVal = (json['floatVal'] as num?)?.toDouble(),
+        floatNullableVal = (json['floatNullableVal'] as num?)?.toDouble(),
         floatList = json['floatList']?.cast<double>(),
         floatNullableList = json['floatNullableList']?.cast<double>(),
         nullableFloatList = json['nullableFloatList']?.cast<double>(),
@@ -4053,8 +4053,8 @@ class TestModel extends Model {
   
   TestModel.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
-      _floatVal = json['floatVal'],
-      _floatNullableVal = json['floatNullableVal'],
+      _floatVal = (json['floatVal'] as num?)?.toDouble(),
+      _floatNullableVal = (json['floatNullableVal'] as num?)?.toDouble(),
       _floatList = json['floatList']?.cast<double>(),
       _floatNullableList = json['floatNullableList']?.cast<double>(),
       _nullableFloatList = json['nullableFloatList']?.cast<double>(),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add the following change to the float type in `fromJson` method of flutter modelgen generated code
```Dart
floatVal = (json['floatlVal'] as num?)?.toDouble();
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #202 


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.