### PR TITLE
fix(appsync-modelgen-plugin): remove unnecessary null-aware operators

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -356,21 +356,21 @@ class TemporalTimeModel extends Model {
         timestamp = json['timestamp'] != null
             ? TemporalTimestamp.fromSeconds(json['timestamp'])
             : null,
-        dateList = (json['dateList'] as List)
+        dateList = (json['dateList'] as List?)
             ?.map((e) => TemporalDate.fromString(e))
-            ?.toList(),
-        timeList = (json['timeList'] as List)
+            .toList(),
+        timeList = (json['timeList'] as List?)
             ?.map((e) => TemporalTime.fromString(e))
-            ?.toList(),
-        dateTimeList = (json['dateTimeList'] as List)
+            .toList(),
+        dateTimeList = (json['dateTimeList'] as List?)
             ?.map((e) => TemporalDateTime.fromString(e))
-            ?.toList(),
-        timestampList = (json['timestampList'] as List)
+            .toList(),
+        timestampList = (json['timestampList'] as List?)
             ?.map((e) => TemporalTimestamp.fromSeconds(e))
-            ?.toList(),
-        intList = (json['intList'] as List<dynamic>)
-            ?.map((dynamic e) => e is double ? e.toInt() : e as int)
-            ?.toList();
+            .toList(),
+        intList = (json['intList'] as List?)
+            ?.map((e) => e is double ? e.toInt() : e as int)
+            .toList();
 
   Map<String, dynamic> toJson() => {
         'id': id,
@@ -646,13 +646,13 @@ class TestEnumModel extends Model {
         'id': id,
         'enumVal': enumToString(enumVal),
         'nullableEnumVal': enumToString(nullableEnumVal),
-        'enumList': enumList?.map((e) => enumToString(e))?.toList(),
+        'enumList': enumList?.map((e) => enumToString(e)).toList(),
         'enumNullableList':
-            enumNullableList?.map((e) => enumToString(e))?.toList(),
+            enumNullableList?.map((e) => enumToString(e)).toList(),
         'nullableEnumList':
-            nullableEnumList?.map((e) => enumToString(e))?.toList(),
+            nullableEnumList?.map((e) => enumToString(e)).toList(),
         'nullableEnumNullableList':
-            nullableEnumNullableList?.map((e) => enumToString(e))?.toList()
+            nullableEnumNullableList?.map((e) => enumToString(e)).toList()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"testEnumModel.id\\");
@@ -2606,7 +2606,7 @@ class Todo extends Model {
             : null;
 
   Map<String, dynamic> toJson() =>
-      {'id': id, 'tasks': tasks?.map((e) => e?.toJson())?.toList()};
+      {'id': id, 'tasks': tasks?.map((Task? e) => e?.toJson()).toList()};
 
   static final QueryField ID = QueryField(fieldName: \\"todo.id\\");
   static final QueryField TASKS = QueryField(
@@ -2853,7 +2853,7 @@ class Blog extends Model {
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
-        'posts': posts?.map((e) => e?.toJson())?.toList(),
+        'posts': posts?.map((Post? e) => e?.toJson()).toList(),
         'test': test
       };
 
@@ -3138,7 +3138,7 @@ class Post extends Model {
         'id': id,
         'title': title,
         'blog': blog?.toJson(),
-        'comments': comments?.map((e) => e?.toJson())?.toList()
+        'comments': comments?.map((Comment? e) => e?.toJson()).toList()
       };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");
@@ -3561,7 +3561,7 @@ class Blog extends Model {
         : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'name': _name, 'posts': _posts?.map((e) => e?.toJson())?.toList()
+    'id': id, 'name': _name, 'posts': _posts?.map((Post? e) => e?.toJson()).toList()
   };
 
   static final QueryField ID = QueryField(fieldName: \\"blog.id\\");
@@ -3862,7 +3862,7 @@ class Post extends Model {
         : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((e) => e?.toJson())?.toList()
+    'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
   static final QueryField ID = QueryField(fieldName: \\"post.id\\");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
This PR removes unnecessary null-aware operators from generated Dart models
* remove null-aware operator from toList() where already short-circuited
* update time and int scalar type lists to be cast as nullable
* specify has many element as nullable when mapping to JSON

```dart
// current generated model
Map<String, dynamic> toJson() => {
  'id': id, 'todos': _todos?.map((e) => e?.toJson())?.toList(), 'name': _name
};      //                               ^          ^
        // assumes element is not nullable          unnecessary due to short-circuiting
```
```dart
Map<String, dynamic> toJson() => {
  'id': id, 'todos': _todos?.map((Todo? e) => e?.toJson()).toList(), 'name': _name
};
```

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
https://github.com/aws-amplify/amplify-flutter/issues/801
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
* Verified that snapshot errors caused by changes were intentional
* Verified that updated snapshots are correct
* Made sure `yarn build` and `yarn test` ran successfully
* Tested relevant schemas in a Flutter app locally


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.