### PR TITLE
hasOne, hasMany, and belongsTo directive support

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -72,6 +72,7 @@ async function generateModels(context) {
 
   const generateIndexRules = readFeatureFlag('codegen.generateIndexRules');
   const emitAuthProvider = readFeatureFlag('codegen.emitAuthProvider');
+  const usePipelinedTransformer = readFeatureFlag('graphQLTransformer.useExperimentalPipelinedTransformer')
 
   let enableDartNullSafety = readFeatureFlag('codegen.enableDartNullSafety');
 
@@ -101,7 +102,8 @@ async function generateModels(context) {
       emitAuthProvider,
       generateIndexRules,
       enableDartNullSafety,
-      handleListNullabilityTransparently
+      handleListNullabilityTransparently,
+      usePipelinedTransformer
     },
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -8,6 +8,11 @@ import {
   getConnectedField,
 } from '../../utils/process-connections';
 import { CodeGenModelMap, CodeGenModel } from '../../visitors/appsync-visitor';
+import { beforeEach } from 'jest-circus';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
@@ -461,6 +466,137 @@ describe('process connection', () => {
       const employeeModel = modelMap.Employee;
       expect(getConnectedField(supervisorField, employeeModel, employeeModel)).toEqual(subordinateField);
       expect(getConnectedField(subordinateField, employeeModel, employeeModel)).toEqual(supervisorField);
+    });
+  });
+
+  describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
+    let modelMap: CodeGenModelMap;
+    let v2ModelMap: CodeGenModelMap;
+
+    beforeEach(() => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+        }
+
+        type Comment @model @key(name: "byPost", fields: ["postID", "content"]) {
+          postID: ID!
+          content: String!
+          post: Post @connection(fields:['postID'])
+        }
+      `;
+
+      const v2Schema = /* GraphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byPost", fields: ["id"])
+        }
+        
+        type Comment @model {
+          postID: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          post: Post @connection(fields:["postID"])
+        }
+      `;
+      modelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [{ name: 'key', arguments: { name: 'byPost', fields: ['postID', 'content'] } }],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
+
+      v2ModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'primaryKey', arguments: { name: 'byPost', sortKeyFields: ['content'] } }],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
+    });
+
+    describe('Has many comparison', () => {
+      it('should support connection with @primaryKey on BELONGS_TO side', () => {
+        const postField = v2ModelMap.Comment.fields[2];
+        const connectionInfo = (processConnections(postField, v2ModelMap.Post, v2ModelMap) as any) as CodeGenFieldConnectionBelongsTo;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
+        expect(connectionInfo.targetName).toEqual(v2ModelMap.Comment.fields[0].name);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -8,14 +8,16 @@ import {
   getConnectedField,
 } from '../../utils/process-connections';
 import { CodeGenModelMap, CodeGenModel } from '../../visitors/appsync-visitor';
-import { beforeEach } from 'jest-circus';
 import { FeatureFlags } from 'amplify-cli-core';
 
 jest.mock("amplify-cli-core");
 const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
+
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One:Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -153,6 +155,8 @@ describe('process connection', () => {
     });
   });
   describe('Uni-directional connection (unnamed connection)', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -224,6 +228,8 @@ describe('process connection', () => {
   });
 
   describe('connection v2', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
 
     beforeEach(() => {
@@ -299,6 +305,8 @@ describe('process connection', () => {
     });
   });
   describe('getConnectedField', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One to Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -418,6 +426,8 @@ describe('process connection', () => {
   });
 
   describe('self referencing models', () => {
+    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -472,6 +482,7 @@ describe('process connection', () => {
   describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
     let modelMap: CodeGenModelMap;
     let v2ModelMap: CodeGenModelMap;
+    let v2IndexModelMap: CodeGenModelMap;
 
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -497,6 +508,18 @@ describe('process connection', () => {
           post: Post @connection(fields:["postID"])
         }
       `;
+
+      const v2IndexSchema = /* graphQL */ `
+        type Post @model {
+          comments: [Comment] @connection(keyName: "byContent", fields: ["id"])
+        }
+        
+        type Comment @model {
+          postID: ID! @primaryKey
+          content: String! @index(name: "byContent")
+          post: Post @connection(fields: ["postID"])
+      `;
+
       modelMap = {
         Post: {
           name: 'Post',
@@ -553,7 +576,7 @@ describe('process connection', () => {
               isNullable: true,
               isList: true,
               name: 'comments',
-              directives: [{ name: 'connection', arguments: { keyName: 'byPost', fields: ['id'] } }],
+              directives: [{ name: 'connection', arguments: { fields: ['id'] } }],
             },
           ],
         },
@@ -567,7 +590,7 @@ describe('process connection', () => {
               isNullable: false,
               isList: false,
               name: 'postID',
-              directives: [{name: 'primaryKey', arguments: { name: 'byPost', sortKeyFields: ['content'] } }],
+              directives: [{name: 'primaryKey', arguments: { sortKeyFields: ['content'] } }],
             },
             {
               type: 'String',
@@ -586,10 +609,57 @@ describe('process connection', () => {
           ],
         },
       };
+
+      v2IndexModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'connection', arguments: { keyName: 'byContent', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'primaryKey', arguments: {} }],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [{name: 'index', arguments: { name: 'byContent' }}],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'connection', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
     });
 
     describe('Has many comparison', () => {
       it('should support connection with @primaryKey on BELONGS_TO side', () => {
+        // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
         const postField = v2ModelMap.Comment.fields[2];
         const connectionInfo = (processConnections(postField, v2ModelMap.Post, v2ModelMap) as any) as CodeGenFieldConnectionBelongsTo;
         expect(connectionInfo).toBeDefined();
@@ -597,6 +667,27 @@ describe('process connection', () => {
         expect(connectionInfo.targetName).toEqual(v2ModelMap.Comment.fields[0].name);
         expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
+
+      it('should support connection with @primaryKey on HAS_MANY side', () => {
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return true; });
+        const commentsField = v2ModelMap.Post.fields[0];
+        const connectionInfo = (processConnections(commentsField, v2ModelMap.Comment, v2ModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2ModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
+
+      it('Should support connection with @index on BELONGS_TO side', () => {
+        FeatureFlags_mock.getBoolean.mockImplementation(() => { return true; });
+        const commentsField = v2ModelMap.Post.fields[0];
+        const connectionInfo = (processConnections(commentsField, v2ModelMap.Comment, v2ModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2ModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
     });
+
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -474,7 +474,8 @@ describe('process connection', () => {
     beforeEach(() => {
       const hasOneWithFieldsSchema = /* GraphQL */ `
         type BatteryCharger @model {
-          powerSource: PowerSource @hasOne(fields: ["sourceID"])
+          chargerID: ID!
+          powerSource: PowerSource @hasOne(fields: ["chargerID"])
         }
 
         type PowerSource @model {
@@ -529,11 +530,18 @@ describe('process connection', () => {
           directives: [],
           fields: [
             {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'chargerID',
+              directives: []
+            },
+            {
               type: 'PowerSource',
               isNullable: true,
               isList: false,
               name: 'powerSource',
-              directives: [{ name: 'hasOne', arguments: { fields: ['sourceID'] } }],
+              directives: [{ name: 'hasOne', arguments: { fields: ['chargerID'] } }],
             },
           ],
         },
@@ -756,7 +764,7 @@ describe('process connection', () => {
         expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
       });
       it('Should support @hasOne with an explicit primary key', () => {
-        const powerSourceField = hasOneWithFieldsModelMap.BatteryCharger.fields[0];
+        const powerSourceField = hasOneWithFieldsModelMap.BatteryCharger.fields[1];
         const connectionInfo = (processConnectionsV2(powerSourceField, hasOneWithFieldsModelMap.PowerSource, hasOneWithFieldsModelMap)) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -12,8 +12,6 @@ import { processConnectionsV2 } from '../../utils/process-connections-v2';
 
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
-    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
-    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One:Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -151,8 +149,6 @@ describe('process connection', () => {
     });
   });
   describe('Uni-directional connection (unnamed connection)', () => {
-    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
-    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -224,8 +220,6 @@ describe('process connection', () => {
   });
 
   describe('connection v2', () => {
-    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
-    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
 
     beforeEach(() => {
@@ -301,8 +295,6 @@ describe('process connection', () => {
     });
   });
   describe('getConnectedField', () => {
-    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
-    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     describe('One to Many', () => {
       let modelMap: CodeGenModelMap;
       beforeEach(() => {
@@ -422,8 +414,6 @@ describe('process connection', () => {
   });
 
   describe('self referencing models', () => {
-    // TODO: We don't need to leave this mock in place once the V2 transformer is fully released
-    FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
     let modelMap: CodeGenModelMap;
     beforeEach(() => {
       const schema = /* GraphQL */ `
@@ -487,7 +477,7 @@ describe('process connection', () => {
         }
 
         type PowerSource @model {
-          sourceID: ID!
+          sourceID: ID! @primaryKey
           amps: Float!
           volts: Float!
         }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -3,10 +3,6 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelDartVisitor } from '../../visitors/appsync-dart-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { DART_SCALAR_MAP } from '../../scalars';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -30,8 +26,6 @@ const getVisitor = (
 };
 
 describe('AppSync Dart Visitor', () => {
-  // TODO: On release of v2 transformer, this mock is no longer needed
-  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   describe('Model Directive', () => {
     it('should generate a class for a Simple Model', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -3,6 +3,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelDartVisitor } from '../../visitors/appsync-dart-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { DART_SCALAR_MAP } from '../../scalars';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -26,6 +30,8 @@ const getVisitor = (
 };
 
 describe('AppSync Dart Visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   describe('Model Directive', () => {
     it('should generate a class for a Simple Model', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -193,8 +193,9 @@ describe('AppSyncModelVisitor', () => {
     expect(generatedCode).toMatchSnapshot();
   });
 
-  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
+  describe('vNext transformer feature parity tests', () => {
+    it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
       type authorBook @model @key(fields: ["author_id"]) {
         id: ID!
         author_id: ID!
@@ -203,7 +204,7 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    const schemaV2 = /* GraphQL */ `
+      const schemaV2 = /* GraphQL */ `
       type authorBook @model {
         id: ID!
         author_id: ID! @primaryKey
@@ -212,21 +213,21 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+        return false;
+      }).mockImplementationOnce((flagName: String): boolean => {
+        return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      });
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitor(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
+
+      expect(version1Code).toMatch(version2Code);
     });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
 
-    expect(version1Code).toMatch(version2Code);
-  });
-
-  it('should produce the same result for @index as the secondary index variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
+    it('should produce the same result for @index as the secondary index variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
       type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
         id: ID!
         author_id: ID!
@@ -235,7 +236,7 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    const schemaV2 = /* GraphQL */ `
+      const schemaV2 = /* GraphQL */ `
       type authorBook @model {
         id: ID! @primaryKey
         author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
@@ -244,17 +245,18 @@ describe('AppSyncModelVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
+      FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+        return false;
+      }).mockImplementationOnce((flagName: String): boolean => {
+        return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+      });
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitor(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
 
-    expect(version1Code).toMatch(version2Code);
+      expect(version1Code).toMatch(version2Code);
+    });
   });
 
   it('Should handle nullability of lists appropriately', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -193,6 +193,70 @@ describe('AppSyncModelVisitor', () => {
     expect(generatedCode).toMatchSnapshot();
   });
 
+  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
   it('Should handle nullability of lists appropriately', () => {
     const schema = /* GraphQL */ `
       enum StatusEnum {
@@ -425,70 +489,6 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
-  });
-
-  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
-      type authorBook @model @key(fields: ["author_id"]) {
-        id: ID!
-        author_id: ID!
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    const schemaV2 = /* GraphQL */ `
-      type authorBook @model {
-        id: ID!
-        author_id: ID! @primaryKey
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
-
-    expect(version1Code).toMatch(version2Code);
-  });
-
-  it('should produce the same result for @index as the secondary index variant of @key', async () => {
-    const schemaV1 = /* GraphQL */ `
-      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
-        id: ID!
-        author_id: ID!
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    const schemaV2 = /* GraphQL */ `
-      type authorBook @model {
-        id: ID! @primaryKey
-        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
-        book_id: ID!
-        author: String
-        book: String
-      }
-    `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
-    const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
-    const version1Code = visitorV1.generate();
-    const version2Code = visitorV2.generate();
-
-    expect(version1Code).toMatch(version2Code);
   });
 
   describe('connection', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -4,6 +4,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavaVisitor } from '../../visitors/appsync-java-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { JAVA_SCALAR_MAP } from '../../scalars';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -421,6 +425,70 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
+  });
+
+  it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
   });
 
   describe('connection', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -4,10 +4,6 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavaVisitor } from '../../visitors/appsync-java-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { JAVA_SCALAR_MAP } from '../../scalars';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -3,10 +3,6 @@ import { validateTs } from '@graphql-codegen/testing';
 import { TYPESCRIPT_SCALAR_MAP } from '../../scalars';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavascriptVisitor } from '../../visitors/appsync-javascript-visitor';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -29,8 +25,6 @@ const getVisitor = (
 };
 
 describe('Javascript visitor', () => {
-  // TODO: On release of v2 transformer, this mock is no longer needed
-  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -3,6 +3,10 @@ import { validateTs } from '@graphql-codegen/testing';
 import { TYPESCRIPT_SCALAR_MAP } from '../../scalars';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavascriptVisitor } from '../../visitors/appsync-javascript-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -25,6 +29,8 @@ const getVisitor = (
 };
 
 describe('Javascript visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -9,6 +9,10 @@ import {
 } from '../../utils/process-connections';
 import { AppSyncJSONVisitor, AssociationHasMany, JSONSchemaNonModel } from '../../visitors/appsync-json-metadata-visitor';
 import { CodeGenEnum, CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -27,6 +31,9 @@ const getVisitor = (schema: string, target: 'typescript' | 'javascript' | 'typeD
 };
 
 describe('Metadata visitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
+
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -9,10 +9,6 @@ import {
 } from '../../utils/process-connections';
 import { AppSyncJSONVisitor, AssociationHasMany, JSONSchemaNonModel } from '../../visitors/appsync-json-metadata-visitor';
 import { CodeGenEnum, CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -31,8 +27,6 @@ const getVisitor = (schema: string, target: 'typescript' | 'javascript' | 'typeD
 };
 
 describe('Metadata visitor', () => {
-  // TODO: On release of v2 transformer, this mock is no longer needed
-  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
 
   const schema = /* GraphQL */ `
     type SimpleModel @model {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -9,10 +9,6 @@ import {
 } from '../../utils/process-connections';
 import { AppSyncJSONVisitor, AssociationHasMany, JSONSchemaNonModel } from '../../visitors/appsync-json-metadata-visitor';
 import { CodeGenEnum, CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -3,7 +3,6 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { SWIFT_SCALAR_MAP } from '../../scalars';
 import { AppSyncSwiftVisitor } from '../../visitors/appsync-swift-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
-import { emit } from 'cluster';
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -3,6 +3,10 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { SWIFT_SCALAR_MAP } from '../../scalars';
 import { AppSyncSwiftVisitor } from '../../visitors/appsync-swift-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -366,6 +370,70 @@ describe('AppSyncSwiftVisitor', () => {
           }
       }"
     `);
+  });
+
+  it('Should produce same result for @primaryKey as when @key is used for a primary key', () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
+  });
+
+  it('should produce the same result for @index as the secondary index variant of @key', async () => {
+    const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
+      return false;
+    }).mockImplementationOnce((flagName: String): boolean => {
+      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
+    });
+    const visitorV1 = getVisitor(schemaV1, 'authorBook');
+    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const version1Code = visitorV1.generate();
+    const version2Code = visitorV2.generate();
+
+    expect(version1Code).toMatch(version2Code);
   });
 
   it('Should handle nullability of lists appropriately', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -3,10 +3,7 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { SWIFT_SCALAR_MAP } from '../../scalars';
 import { AppSyncSwiftVisitor } from '../../visitors/appsync-swift-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
+import { emit } from 'cluster';
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -20,6 +17,7 @@ const getVisitor = (
   emitAuthProvider: boolean = true,
   generateIndexRules: boolean = true,
   handleListNullabilityTransparently: boolean = true,
+  usePipelinedTransformer: boolean = false
 ) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
@@ -33,12 +31,25 @@ const getVisitor = (
       emitAuthProvider,
       generateIndexRules,
       handleListNullabilityTransparently,
+      usePipelinedTransformer: usePipelinedTransformer
     },
     { selectedType, generate },
   );
   visit(ast, { leave: visitor });
   return visitor;
 };
+
+const getVisitorPipelinedTransformer = (
+  schema: string,
+  selectedType?: string,
+  generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code,
+  isTimestampFieldsAdded: boolean = true,
+  emitAuthProvider: boolean = true,
+  generateIndexRules: boolean = true,
+  handleListNullabilityTransparently: boolean = true
+) => {
+  return getVisitor(schema, selectedType, generate, isTimestampFieldsAdded, emitAuthProvider, generateIndexRules, handleListNullabilityTransparently, true);
+}
 
 describe('AppSyncSwiftVisitor', () => {
   it('Should generate a class for a Model', () => {
@@ -391,13 +402,8 @@ describe('AppSyncSwiftVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
     const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const visitorV2 = getVisitorPipelinedTransformer(schemaV2, 'authorBook');
     const version1Code = visitorV1.generate();
     const version2Code = visitorV2.generate();
 
@@ -423,13 +429,8 @@ describe('AppSyncSwiftVisitor', () => {
         book: String
       }
     `;
-    FeatureFlags_mock.getBoolean.mockImplementationOnce((flagName: String): boolean => {
-      return false;
-    }).mockImplementationOnce((flagName: String): boolean => {
-      return "graphQLTransformer.useExperimentalPipelinedTransformer" == flagName;
-    });
     const visitorV1 = getVisitor(schemaV1, 'authorBook');
-    const visitorV2 = getVisitor(schemaV2, 'authorBook');
+    const visitorV2 = getVisitorPipelinedTransformer(schemaV2, 'authorBook');
     const version1Code = visitorV1.generate();
     const version2Code = visitorV2.generate();
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -2,10 +2,6 @@ import { buildSchema, parse, visit } from 'graphql';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { CodeGenConnectionType, CodeGenFieldConnectionBelongsTo, CodeGenFieldConnectionHasMany } from '../../utils/process-connections';
 import { AppSyncModelVisitor, CodeGenField, CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
-import { FeatureFlags } from 'amplify-cli-core';
-
-jest.mock("amplify-cli-core");
-const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String) => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -25,8 +21,6 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
-  // TODO: On release of v2 transformer, this mock is no longer needed
-  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
 
   it('should support schema with id', () => {
     const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -2,6 +2,10 @@ import { buildSchema, parse, visit } from 'graphql';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { CodeGenConnectionType, CodeGenFieldConnectionBelongsTo, CodeGenFieldConnectionHasMany } from '../../utils/process-connections';
 import { AppSyncModelVisitor, CodeGenField, CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+import { FeatureFlags } from 'amplify-cli-core';
+
+jest.mock("amplify-cli-core");
+const FeatureFlags_mock = FeatureFlags as jest.Mocked<typeof FeatureFlags>;
 
 const buildSchemaWithDirectives = (schema: String) => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -21,6 +25,8 @@ const createAndGenerateVisitor = (schema: string) => {
 };
 
 describe('AppSyncModelVisitor', () => {
+  // TODO: On release of v2 transformer, this mock is no longer needed
+  FeatureFlags_mock.getBoolean.mockImplementation(() => { return false; });
 
   it('should support schema with id', () => {
     const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -138,6 +138,12 @@ export const directives = /* GraphQL */ `
   # primaryKey directive
   directive @primaryKey(sortKeyFields: [String!], queryField: String) on FIELD_DEFINITION
   directive @index(name: String!, sortKeyFields: [String], queryField: String) on FIELD_DEFINITION
+
+  directive @hasOne(fields: [String!]) on FIELD_DEFINITION
+  directive @hasMany(indexName: String, fields: [String], limit: Int = 100) on FIELD_DEFINITION
+  directive @belongsTo(fields: [String]) on FIELD_DEFINITION
+  directive @manyToMany(relationName: String!) on FIELD_DEFINITION
+
 `;
 
 export const scalars = [

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -133,6 +133,11 @@ export const directives = /* GraphQL */ `
   }
 
   directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+  
+  # GraphQL vNext Directives
+  # primaryKey directive
+  directive @primaryKey(sortKeyFields: [String!], queryField: String) on FIELD_DEFINITION
+  directive @index(name: String!, sortKeyFields: [String], queryField: String) on FIELD_DEFINITION
 `;
 
 export const scalars = [

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -2,9 +2,7 @@ import { CodeGenDirective, CodeGenField, CodeGenFieldDirective, CodeGenModel, Co
 import {
   CodeGenConnectionType,
   CodeGenFieldConnection,
-  DEFAULT_HASH_KEY_FIELD,
   flattenFieldDirectives,
-  getDirective,
   makeConnectionAttributeName,
 } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -1,8 +1,7 @@
-import { CodeGenDirective, CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
 import {
   CodeGenConnectionType,
   CodeGenFieldConnection,
-  flattenFieldDirectives,
   makeConnectionAttributeName,
 } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';
@@ -22,8 +21,6 @@ export function processBelongsToConnection(
     // Todo: Move to a common function and update the error message
     throw new Error('DataStore only support one key in field');
   }
-
-  const isNewField = !otherSide.fields.includes(otherSideField);
 
   // if a type is connected using name, then graphql-connection-transformer adds a field to
   //  track the connection and that field is not part of the selection set

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -9,7 +9,8 @@ import {
 } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';
 
-export function processHasOneConnection(
+
+export function processBelongsToConnection(
   field: CodeGenField,
   model: CodeGenModel,
   modelMap: CodeGenModelMap,
@@ -19,28 +20,58 @@ export function processHasOneConnection(
   const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
   const connectionFields = connectionDirective.arguments.fields || [];
 
-  // TODO: Update comment, graphql-connection-transformer is the v1 package and this file is created for vNext
+  if (connectionFields.length > 1) {
+    // Todo: Move to a common function and update the error message
+    throw new Error('DataStore only support one key in field');
+  }
+
+  const isNewField = !otherSide.fields.includes(otherSideField);
+
   // if a type is connected using name, then graphql-connection-transformer adds a field to
   //  track the connection and that field is not part of the selection set
   // but if the field are connected using fields argument in connection directive
   // we are reusing the field and it should be preserved in selection set
   const isConnectingFieldAutoCreated = connectionFields.length === 0;
 
-  if (!field.isList && !otherSideField.isList) {
-    if (field.isNullable && !otherSideField.isNullable) {
+  if (!field.isList && otherSideField.isList) {
+    if (connectionFields.length > 1) {
+      //  One to Many
       return {
-        kind: CodeGenConnectionType.HAS_ONE,
-        associatedWith: otherSideField,
+        kind: CodeGenConnectionType.BELONGS_TO,
+        connectedModel: otherSide,
+        isConnectingFieldAutoCreated,
+        targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+      };
+    }
+  }
+  else if (!field.isList && !otherSideField.isList) {
+    if (!field.isNullable && otherSideField.isNullable) {
+      return {
+        kind: CodeGenConnectionType.BELONGS_TO,
         connectedModel: otherSide,
         isConnectingFieldAutoCreated,
         targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
       };
     }
     else {
-      throw new Error("A hasOne relationship should be optional on the owning side and not optional on the owned side");
+      throw new Error(
+        `DataStore does not support 1 to 1 connection with both sides of connection as optional field: ${model.name}.${field.name}`,
+      );
     }
   }
   else {
-    throw new Error("A hasOne relationship should be 1:1, no lists");
+    if (!field.isList) {
+      return {
+        kind: CodeGenConnectionType.BELONGS_TO,
+        connectedModel: otherSide,
+        isConnectingFieldAutoCreated,
+        targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+      };
+    }
+    else {
+      throw new Error(
+        `A list field does not support the 'belongsTo' relation`
+      );
+    }
   }
 }

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -34,15 +34,13 @@ export function processBelongsToConnection(
   const isConnectingFieldAutoCreated = connectionFields.length === 0;
 
   if (!field.isList && otherSideField.isList) {
-    if (connectionFields.length > 1) {
       //  One to Many
-      return {
-        kind: CodeGenConnectionType.BELONGS_TO,
-        connectedModel: otherSide,
-        isConnectingFieldAutoCreated,
-        targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
-      };
-    }
+    return {
+      kind: CodeGenConnectionType.BELONGS_TO,
+      connectedModel: otherSide,
+      isConnectingFieldAutoCreated,
+      targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+    };
   }
   else if (!field.isList && !otherSideField.isList) {
     if (!field.isNullable && otherSideField.isNullable) {

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -1,0 +1,103 @@
+import { CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import {
+  CodeGenFieldConnection, DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives,
+  getDirective,
+  makeConnectionAttributeName,
+} from './process-connections';
+import { processHasOneConnection } from './process-has-one';
+import { processBelongsToConnection } from './process-belongs-to';
+import { processHasManyConnection } from './process-has-many';
+
+// TODO: This file holds several references to utility functions in the v1 process connections file, those functions need to go here before that file is removed
+
+export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel, directiveName: string): CodeGenField {
+  const connectionInfo = getDirective(field)(directiveName);
+  if (!connectionInfo) {
+    throw new Error(`The ${field.name} on model ${model.name} is not connected`);
+  }
+
+  const connectionName = connectionInfo.arguments.name;
+  const keyName = connectionInfo.arguments.keyName;
+  const connectionFields = connectionInfo.arguments.fields;
+  if (connectionFields) {
+    let keyDirective;
+    if (keyName) {
+      keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+        return dir.name === 'index' && dir.arguments.name === keyName;
+      });
+      if (!keyDirective) {
+        throw new Error(
+          `Error processing @${connectionInfo.name} directive on ${model.name}.${field.name}, @index directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
+        );
+      }
+    } else {
+      keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+        return dir.name === 'primaryKey';
+      });
+    }
+
+    // when there is a fields argument in the connection
+    const connectedFieldName = keyDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective) : DEFAULT_HASH_KEY_FIELD;
+
+    // Find a field on the other side which connected by a @connection and has the same fields[0] as keyName field
+    const otherSideConnectedField = connectedModel.fields.find(f => {
+      return f.directives.find(d => {
+        return (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.fields && d.arguments.fields[0] === connectedFieldName;
+      });
+    });
+    if (otherSideConnectedField) {
+      return otherSideConnectedField;
+    }
+    // If there are no field with @connection with keyName then try to find a field that has same name as connection name
+    const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+
+    if (!connectedField) {
+      throw new Error(`Can not find key field ${connectedFieldName} in ${connectedModel}`);
+    }
+    return connectedField;
+  } else if (connectionName) {
+    // when the connection is named
+    const connectedField = connectedModel.fields.find(f =>
+      f.directives.find(d => (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.name === connectionName && f !== field),
+    );
+    if (!connectedField) {
+      throw new Error(`Can not find key field with connection name ${connectionName} in ${connectedModel}`);
+    }
+    return connectedField;
+  }
+  // un-named connection. Use an existing field or generate a new field
+  const connectedFieldName = makeConnectionAttributeName(model.name, field.name);
+  const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+  return connectedField
+    ? connectedField
+    : {
+      name: connectedFieldName,
+      directives: [],
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+    };
+}
+
+
+export function processConnectionsV2(
+  field: CodeGenField,
+  model: CodeGenModel,
+  modelMap: CodeGenModelMap,
+): CodeGenFieldConnection | undefined {
+  const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
+
+  if(connectionDirective) {
+
+    switch(connectionDirective.name) {
+      case 'hasOne':
+        return processHasOneConnection(field, model, modelMap, connectionDirective);
+      case 'belongsTo':
+        return processBelongsToConnection(field, model, modelMap, connectionDirective);
+      case 'hasMany':
+        return processHasManyConnection(field, model, modelMap, connectionDirective);
+      default:
+        break;
+    }
+  }
+}

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -17,17 +17,17 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
   }
 
   const connectionName = connectionInfo.arguments.name;
-  const keyName = connectionInfo.arguments.keyName;
+  const indexName = connectionInfo.arguments.indexName;
   const connectionFields = connectionInfo.arguments.fields;
   if (connectionFields) {
     let keyDirective;
-    if (keyName) {
+    if (indexName) {
       keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
-        return dir.name === 'index' && dir.arguments.name === keyName;
+        return dir.name === 'index' && dir.arguments.name === indexName;
       });
       if (!keyDirective) {
         throw new Error(
-          `Error processing @${connectionInfo.name} directive on ${model.name}.${field.name}, @index directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
+          `Error processing @${connectionInfo.name} directive on ${model.name}.${field.name}, @index directive with name ${indexName} was not found in connected model ${connectedModel.name}`,
         );
       }
     } else {
@@ -39,7 +39,7 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
     // when there is a fields argument in the connection
     const connectedFieldName = keyDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective) : DEFAULT_HASH_KEY_FIELD;
 
-    // Find a field on the other side which connected by a @connection and has the same fields[0] as keyName field
+    // Find a field on the other side which connected by a @connection and has the same fields[0] as indexName field
     const otherSideConnectedField = connectedModel.fields.find(f => {
       return f.directives.find(d => {
         return (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.fields && d.arguments.fields[0] === connectedFieldName;
@@ -48,7 +48,7 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
     if (otherSideConnectedField) {
       return otherSideConnectedField;
     }
-    // If there are no field with @connection with keyName then try to find a field that has same name as connection name
+    // If there are no field with @connection with indexName then try to find a field that has same name as connection name
     const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
 
     if (!connectedField) {

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -5,7 +5,6 @@ export enum CodeGenConnectionType {
   HAS_ONE = 'HAS_ONE',
   BELONGS_TO = 'BELONGS_TO',
   HAS_MANY = 'HAS_MANY',
-  MANY_TO_MANY = 'MANY_TO_MANY',
 }
 export const DEFAULT_HASH_KEY_FIELD = 'id';
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -41,18 +41,6 @@ export function makeConnectionAttributeName(type: string, field?: string) {
   return field ? camelCase([type, field, 'id'].join('_')) : camelCase([type, 'id'].join('_'));
 }
 
-function flattenFieldDirectives(model: CodeGenModel) {
-  let totalDirectives: CodeGenFieldDirective[] = new Array<CodeGenFieldDirective>();
-  model.fields.forEach(field => {
-    field.directives.forEach(dir => {
-      let fieldDir = dir as CodeGenFieldDirective;
-      fieldDir.fieldName = field.name;
-      totalDirectives.push(fieldDir);
-    })
-  });
-  return totalDirectives;
-}
-
 export function flattenFieldDirectives(model: CodeGenModel) {
   let totalDirectives: CodeGenFieldDirective[] = new Array<CodeGenFieldDirective>();
   model.fields.forEach(field => {
@@ -77,36 +65,22 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
   if (connectionFields) {
     let keyDirective;
     if (keyName) {
-      if (usePipelinedTransformer) {
-        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
-          return dir.name === 'index' && dir.arguments.name === keyName;
-        });
-      }
-      else {
-        keyDirective = connectedModel.directives.find(dir => {
-          return dir.name === 'key' && dir.arguments.name === keyName;
-        });
-      }
+      keyDirective = connectedModel.directives.find(dir => {
+        return dir.name === 'key' && dir.arguments.name === keyName;
+      });
       if (!keyDirective) {
         throw new Error(
           `Error processing @connection directive on ${model.name}.${field.name}, @key directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
         );
       }
     } else {
-      if (usePipelinedTransformer) {
-        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
-          return dir.name === 'primaryKey';
-        });
-      }
-      else {
-        keyDirective = connectedModel.directives.find(dir => {
-          return dir.name === 'key' && typeof dir.arguments.name === 'undefined';
-        });
-      }
+      keyDirective = connectedModel.directives.find(dir => {
+        return dir.name === 'key' && typeof dir.arguments.name === 'undefined';
+      });
     }
 
     // when there is a fields argument in the connection
-    const connectedFieldName = keyDirective ? (usePipelinedTransformer ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective) : keyDirective.arguments.fields[0]) : DEFAULT_HASH_KEY_FIELD;
+    const connectedFieldName = keyDirective ? keyDirective.arguments.fields[0] : DEFAULT_HASH_KEY_FIELD;
 
     // Find a field on the other side which connected by a @connection and has the same fields[0] as keyName field
     const otherSideConnectedField = connectedModel.fields.find(f => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -1,4 +1,4 @@
-import { CodeGenModel, CodeGenModelMap, CodeGenField, CodeGenDirective } from '../visitors/appsync-visitor';
+import { CodeGenModel, CodeGenModelMap, CodeGenField, CodeGenDirective, CodeGenFieldDirective } from '../visitors/appsync-visitor';
 import { camelCase } from 'change-case';
 import { FeatureFlags } from 'amplify-cli-core';
 
@@ -41,6 +41,21 @@ export function makeConnectionAttributeName(type: string, field?: string) {
   // Make sure the logic gets update in that package
   return field ? camelCase([type, field, 'id'].join('_')) : camelCase([type, 'id'].join('_'));
 }
+export function usingV2Transformer(): boolean {
+  return FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
+}
+
+function flattenFieldDirectives(model: CodeGenModel) {
+  let totalDirectives: CodeGenFieldDirective[] = new Array<CodeGenFieldDirective>();
+  model.fields.forEach(field => {
+    field.directives.forEach(dir => {
+      let fieldDir = dir as CodeGenFieldDirective;
+      fieldDir.fieldName = field.name;
+      totalDirectives.push(fieldDir);
+    })
+  });
+  return totalDirectives;
+}
 
 export function getConnectedField(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel): CodeGenField {
   const connectionInfo = getDirective(field)('connection');
@@ -48,13 +63,7 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
     throw new Error(`The ${field.name} on model ${model.name} is not connected`);
   }
   // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-  let usePipelinedTransformer: Boolean;
-  try {
-    usePipelinedTransformer = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
-  }
-  catch (e) {
-    usePipelinedTransformer = false;
-  }
+  let usePipelinedTransformer: Boolean = usingV2Transformer();
 
   const connectionName = connectionInfo.arguments.name;
   const keyName = connectionInfo.arguments.keyName;
@@ -62,22 +71,36 @@ export function getConnectedField(field: CodeGenField, model: CodeGenModel, conn
   if (connectionFields) {
     let keyDirective;
     if (keyName) {
-      keyDirective = connectedModel.directives.find(dir => {
-        return usePipelinedTransformer ? (dir.name === 'index' && dir.arguments.name === keyName) : dir.name === 'key' && dir.arguments.name === keyName;
-      });
+      if (usePipelinedTransformer) {
+        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+          return dir.name === 'index' && dir.arguments.name === keyName;
+        });
+      }
+      else {
+        keyDirective = connectedModel.directives.find(dir => {
+          return dir.name === 'key' && dir.arguments.name === keyName;
+        });
+      }
       if (!keyDirective) {
         throw new Error(
           `Error processing @connection directive on ${model.name}.${field.name}, @key directive with name ${keyName} was not found in connected model ${connectedModel.name}`,
         );
       }
     } else {
-      keyDirective = connectedModel.directives.find(dir => {
-        return usePipelinedTransformer ? (dir.name === 'primaryKey') : dir.name === 'key' && typeof dir.arguments.name === 'undefined';
-      });
+      if (usePipelinedTransformer) {
+        keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+          return dir.name === 'primaryKey';
+        });
+      }
+      else {
+        keyDirective = connectedModel.directives.find(dir => {
+          return dir.name === 'key' && typeof dir.arguments.name === 'undefined';
+        });
+      }
     }
 
     // when there is a fields argument in the connection
-    const connectedFieldName = keyDirective ? keyDirective.arguments.fields[0] : DEFAULT_HASH_KEY_FIELD;
+    const connectedFieldName = keyDirective ? (usePipelinedTransformer ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective) : keyDirective.arguments.fields[0]) : DEFAULT_HASH_KEY_FIELD;
 
     // Find a field on the other side which connected by a @connection and has the same fields[0] as keyName field
     const otherSideConnectedField = connectedModel.fields.find(f => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -6,6 +6,7 @@ export enum CodeGenConnectionType {
   HAS_ONE = 'HAS_ONE',
   BELONGS_TO = 'BELONGS_TO',
   HAS_MANY = 'HAS_MANY',
+  MANY_TO_MANY = 'MANY_TO_MANY',
 }
 export const DEFAULT_HASH_KEY_FIELD = 'id';
 
@@ -31,7 +32,7 @@ export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
 
 export type CodeGenFieldConnection = CodeGenFieldConnectionBelongsTo | CodeGenFieldConnectionHasOne | CodeGenFieldConnectionHasMany;
 
-function getDirective(fieldOrModel: CodeGenField | CodeGenModel) {
+export function getDirective(fieldOrModel: CodeGenField | CodeGenModel) {
   return (directiveName: string): CodeGenDirective | undefined => {
     return fieldOrModel.directives.find(d => d.name === directiveName);
   };
@@ -45,7 +46,7 @@ export function usingV2Transformer(): boolean {
   return FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
 }
 
-function flattenFieldDirectives(model: CodeGenModel) {
+export function flattenFieldDirectives(model: CodeGenModel) {
   let totalDirectives: CodeGenFieldDirective[] = new Array<CodeGenFieldDirective>();
   model.fields.forEach(field => {
     field.directives.forEach(dir => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -1,4 +1,4 @@
-import { CodeGenDirective, CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
 import {
   CodeGenConnectionType,
   CodeGenFieldConnection,

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -27,7 +27,7 @@ export function processHasOneConnection(
   const isConnectingFieldAutoCreated = connectionFields.length === 0;
 
   if (!field.isList && !otherSideField.isList) {
-    if (field.isNullable && !otherSideField.isNullable) {
+    if (field.isNullable && (!otherSideField.isNullable || connectionFields.length === 0)) {
       return {
         kind: CodeGenConnectionType.HAS_ONE,
         associatedWith: otherSideField,

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -1,10 +1,7 @@
-import { CodeGenDirective, CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
 import {
   CodeGenConnectionType,
   CodeGenFieldConnection,
-  DEFAULT_HASH_KEY_FIELD,
-  flattenFieldDirectives,
-  getDirective,
   makeConnectionAttributeName,
 } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -1,0 +1,39 @@
+import { CodeGenField, CodeGenFieldDirective, CodeGenModel } from '../visitors/appsync-visitor';
+import { DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives, getDirective, makeConnectionAttributeName } from './process-connections';
+
+
+export function getHasOneConnectedField(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel): CodeGenField {
+  const hasOneDirective = getDirective(field)('hasOne');
+  if (!hasOneDirective) {
+    throw new Error(`The ${field.name} on model ${model.name} is not connected`);
+  }
+
+  if (hasOneDirective.arguments.fields) {
+    const keyDirective = flattenFieldDirectives(connectedModel).find(dir => {
+      return dir.name === 'primaryKey';
+    });
+
+    // when there is a fields argument in the connection
+    const connectedFieldName = keyDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(keyDirective as CodeGenFieldDirective)
+                                            : DEFAULT_HASH_KEY_FIELD;
+
+    // If there are no field with @connection with keyName then try to find a field that has same name as connection name
+    const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+    if (!connectedField) {
+      throw new Error(`Can not find key field ${connectedFieldName} in ${connectedModel}`);
+    }
+    return connectedField;
+  }
+
+  const connectedFieldName = makeConnectionAttributeName(model.name, field.name);
+  const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+  return connectedField
+    ? connectedField
+    : {
+      name: connectedFieldName,
+      directives: [],
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+    };
+}

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -24,7 +24,6 @@ import { CodeGenConnectionType } from '../utils/process-connections';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { validateFieldName } from '../utils/validate-field-name';
-import { FeatureFlags } from 'amplify-cli-core';
 
 export class AppSyncModelJavaVisitor<
   TRawConfig extends RawAppSyncModelConfig = RawAppSyncModelConfig,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -12,11 +12,19 @@ import {
 } from '../configs/java-config';
 import { JAVA_TYPE_IMPORT_MAP } from '../scalars';
 import { JavaDeclarationBlock } from '../languages/java-declaration-block';
-import { AppSyncModelVisitor, CodeGenField, CodeGenModel, ParsedAppSyncModelConfig, RawAppSyncModelConfig } from './appsync-visitor';
+import {
+  AppSyncModelVisitor,
+  CodeGenDirective,
+  CodeGenField,
+  CodeGenModel,
+  ParsedAppSyncModelConfig,
+  RawAppSyncModelConfig,
+} from './appsync-visitor';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { validateFieldName } from '../utils/validate-field-name';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export class AppSyncModelJavaVisitor<
   TRawConfig extends RawAppSyncModelConfig = RawAppSyncModelConfig,
@@ -754,6 +762,8 @@ export class AppSyncModelJavaVisitor<
   }
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {
+    // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
+    let usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     const annotations: string[] = model.directives.map(directive => {
       switch (directive.name) {
         case 'model':
@@ -767,16 +777,53 @@ export class AppSyncModelJavaVisitor<
           }
           return `ModelConfig(${modelArgs.join(', ')})`;
         case 'key':
-          const keyArgs: string[] = [];
-          keyArgs.push(`name = "${directive.arguments.name}"`);
-          keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
-          return `Index(${keyArgs.join(', ')})`;
-
+          if (!usePipelinedTransformer) {
+            const keyArgs: string[] = [];
+            keyArgs.push(`name = "${directive.arguments.name}"`);
+            keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+            return `Index(${keyArgs.join(', ')})`;
+          }
+          break;
         default:
           break;
       }
       return '';
     });
+
+    var modelLevelFieldAnnotations: string[] = new Array<string>();
+    model.fields.forEach(field => {
+      field.directives.forEach(directive => {
+        switch(directive.name) {
+          case 'primaryKey':
+            if (usePipelinedTransformer) {
+              const keyArgs: string[] = [];
+              keyArgs.push(`name = "undefined"`);
+              if(!directive.arguments.sortKeyFields) {
+                directive.arguments.sortKeyFields = new Array<string>();
+              }
+              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
+              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
+            }
+            break;
+          case 'index':
+            if (usePipelinedTransformer) {
+              const keyArgs: string[] = [];
+              keyArgs.push(`name = "${directive.arguments.name}"`);
+              if(!directive.arguments.sortKeyFields) {
+                directive.arguments.sortKeyFields = new Array<string>();
+              }
+              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
+              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
+            }
+            break;
+          default:
+            break;
+        }
+      })
+    })
+    annotations.push(...modelLevelFieldAnnotations);
     return ['SuppressWarnings("all")', ...annotations].filter(annotation => annotation);
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -24,7 +24,6 @@ import { CodeGenConnectionType } from '../utils/process-connections';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { validateFieldName } from '../utils/validate-field-name';
-import { FeatureFlags } from 'amplify-cli-core';
 
 export class AppSyncModelJavaVisitor<
   TRawConfig extends RawAppSyncModelConfig = RawAppSyncModelConfig,
@@ -762,8 +761,6 @@ export class AppSyncModelJavaVisitor<
   }
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {
-    // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-    const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     const annotations: string[] = model.directives.map(directive => {
       switch (directive.name) {
         case 'model':
@@ -777,7 +774,7 @@ export class AppSyncModelJavaVisitor<
           }
           return `ModelConfig(${modelArgs.join(', ')})`;
         case 'key':
-          if (!usePipelinedTransformer) {
+          if (!this.config.usePipelinedTransformer) {
             const keyArgs: string[] = [];
             keyArgs.push(`name = "${directive.arguments.name}"`);
             keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
@@ -795,7 +792,7 @@ export class AppSyncModelJavaVisitor<
       field.directives.forEach(directive => {
         switch(directive.name) {
           case 'primaryKey':
-            if (usePipelinedTransformer) {
+            if (this.config.usePipelinedTransformer) {
               const keyArgs: string[] = [];
               keyArgs.push(`name = "undefined"`);
               if(!directive.arguments.sortKeyFields) {
@@ -807,7 +804,7 @@ export class AppSyncModelJavaVisitor<
             }
             break;
           case 'index':
-            if (usePipelinedTransformer) {
+            if (this.config.usePipelinedTransformer) {
               const keyArgs: string[] = [];
               keyArgs.push(`name = "${directive.arguments.name}"`);
               if(!directive.arguments.sortKeyFields) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -763,7 +763,7 @@ export class AppSyncModelJavaVisitor<
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {
     // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-    let usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
+    const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     const annotations: string[] = model.directives.map(directive => {
       switch (directive.name) {
         case 'model':

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -442,6 +442,7 @@ export class AppSyncSwiftVisitor<
   }
 
   protected generateKeyRules(model: CodeGenModel): string[] {
+    // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
     const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     let keyDirectives: string[];
 
@@ -457,7 +458,7 @@ export class AppSyncSwiftVisitor<
       });
 
       keyDirectives = fieldDirectiveList
-        .filter(directiveObj => directiveObj.directive.name === "primaryKey" || directiveObj.directive.name === "index")
+        .filter(directiveObj => directiveObj.directive.name === 'primaryKey' || directiveObj.directive.name === 'index')
         .map(directiveObj => {
           switch(directiveObj.directive.name) {
             case 'primaryKey':

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -16,7 +16,6 @@ import {
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { SWIFT_SCALAR_MAP } from '../scalars';
-import { FeatureFlags } from 'amplify-cli-core';
 
 export interface RawAppSyncModelSwiftConfig extends RawAppSyncModelConfig {
   /**

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -16,7 +16,6 @@ import {
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import { SWIFT_SCALAR_MAP } from '../scalars';
-import { FeatureFlags } from 'amplify-cli-core';
 
 export interface RawAppSyncModelSwiftConfig extends RawAppSyncModelConfig {
   /**
@@ -443,10 +442,9 @@ export class AppSyncSwiftVisitor<
 
   protected generateKeyRules(model: CodeGenModel): string[] {
     // TODO: Remove the use of the pipelined transformer feature flag once the new transformer is fully released
-    const usePipelinedTransformer: Boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     let keyDirectives: string[];
 
-    if (usePipelinedTransformer) {
+    if (this.config.usePipelinedTransformer) {
       let fieldDirectiveList: any[] = new Array<any>();
       model.fields.forEach(field => {
         field.directives.forEach(directive => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -125,6 +125,10 @@ export type CodeGenDirective = {
   arguments: CodeGenArgumentsMap;
 };
 
+export type CodeGenFieldDirective = CodeGenDirective & {
+  fieldName: string;
+}
+
 export type CodeGenDirectives = CodeGenDirective[];
 export type CodeGenField = TypeInfo & {
   name: string;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -418,7 +418,7 @@ export class AppSyncModelVisitor<
       const fields = obj.fields
         .map((field: CodeGenField) => {
           // include only connection field and type
-          const fieldDirectives = field.directives.filter(field => field.name === 'connection');
+          const fieldDirectives = usePipelinedTransformer ? field.directives.filter(field => field.name === 'hasOne' || field.name === 'belongsTo' || field.name === 'hasMany' || field.name === 'manyToMany') : field.directives.filter(field => field.name === 'connection');
           return {
             name: field.name,
             directives: fieldDirectives,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -27,7 +27,7 @@ import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } fro
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
 import { processAuthDirective } from '../utils/process-auth';
-import { FeatureFlags } from 'amplify-cli-core';
+import { processConnectionsV2 } from '../utils/process-connections-v2';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',
@@ -277,7 +277,12 @@ export class AppSyncModelVisitor<
     };
   }
   processDirectives() {
-    this.processConnectionDirective();
+    if (this.config.usePipelinedTransformer) {
+      this.processConnectionDirectivesV2()
+    }
+    else {
+      this.processConnectionDirective();
+    }
     this.processAuthDirectives();
   }
   generate(): string {
@@ -416,17 +421,15 @@ export class AppSyncModelVisitor<
   }
 
   protected computeVersion(): string {
-    // TODO: Remove v2 transformer feature flag after release
-    const usePipelinedTransformer: boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     // Sort types
     const typeArr: any[] = [];
     Object.values({ ...this.modelMap, ...this.nonModelMap }).forEach((obj: CodeGenModel) => {
       // include only key directive as we don't care about others for versioning
-      const directives = usePipelinedTransformer ? obj.directives.filter(dir => dir.name === 'primaryKey' || dir.name === 'index') : obj.directives.filter(dir => dir.name === 'key');
+      const directives = this.config.usePipelinedTransformer ? obj.directives.filter(dir => dir.name === 'primaryKey' || dir.name === 'index') : obj.directives.filter(dir => dir.name === 'key');
       const fields = obj.fields
         .map((field: CodeGenField) => {
           // include only connection field and type
-          const fieldDirectives = usePipelinedTransformer ? field.directives.filter(field => field.name === 'hasOne' || field.name === 'belongsTo' || field.name === 'hasMany' || field.name === 'manyToMany') : field.directives.filter(field => field.name === 'connection');
+          const fieldDirectives = this.config.usePipelinedTransformer ? field.directives.filter(field => field.name === 'hasOne' || field.name === 'belongsTo' || field.name === 'hasMany' || field.name === 'manyToMany') : field.directives.filter(field => field.name === 'connection');
           return {
             name: field.name,
             directives: fieldDirectives,
@@ -490,6 +493,39 @@ export class AppSyncModelVisitor<
     Object.values(this.modelMap).forEach(model => {
       model.fields.forEach(field => {
         const connectionInfo = processConnections(field, model, this.modelMap);
+        if (connectionInfo) {
+          if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+            // Need to update the other side of the connection even if there is no connection directive
+            addFieldToModel(connectionInfo.connectedModel, connectionInfo.associatedWith);
+          } else if (connectionInfo.targetName !== 'id') {
+            // Need to remove the field that is targetName
+            removeFieldFromModel(model, connectionInfo.targetName);
+          }
+          field.connectionInfo = connectionInfo;
+        }
+      });
+
+      // Should remove the fields that are of Model type and are not connected to ensure there are no phantom input fields
+      const modelTypes = Object.values(this.modelMap).map(model => model.name);
+      model.fields = model.fields.filter(field => {
+        const fieldType = field.type;
+        const connectionInfo = field.connectionInfo;
+        if (modelTypes.includes(fieldType) && connectionInfo === undefined) {
+          printWarning(
+            `Model ${model.name} has field ${field.name} of type ${field.type} but its not connected. Add a @connection directive if want to connect them.`,
+          );
+          return false;
+        }
+        return true;
+      });
+    });
+  }
+
+  protected processConnectionDirectivesV2(): void {
+    // This function is identical to its predecessor for now but may gain changes with future additions to the transformer, like manyToMany
+    Object.values(this.modelMap).forEach(model => {
+      model.fields.forEach(field => {
+        const connectionInfo = processConnectionsV2(field, model, this.modelMap);
         if (connectionInfo) {
           if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             // Need to update the other side of the connection even if there is no connection directive

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -27,6 +27,7 @@ import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } fro
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
 import { processAuthDirective } from '../utils/process-auth';
+import { FeatureFlags } from 'amplify-cli-core';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',
@@ -407,11 +408,13 @@ export class AppSyncModelVisitor<
   }
 
   protected computeVersion(): string {
+    // TODO: Remove v2 transformer feature flag after release
+    const usePipelinedTransformer: boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     // Sort types
     const typeArr: any[] = [];
     Object.values({ ...this.modelMap, ...this.nonModelMap }).forEach((obj: CodeGenModel) => {
       // include only key directive as we don't care about others for versioning
-      const directives = obj.directives.filter(dir => dir.name === 'key');
+      const directives = usePipelinedTransformer ? obj.directives.filter(dir => dir.name === 'primaryKey' || dir.name === 'index') : obj.directives.filter(dir => dir.name === 'key');
       const fields = obj.fields
         .map((field: CodeGenField) => {
           // include only connection field and type

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -421,8 +421,6 @@ export class AppSyncModelVisitor<
   }
 
   protected computeVersion(): string {
-    // TODO: Remove v2 transformer feature flag after release
-    const usePipelinedTransformer: boolean = FeatureFlags.getBoolean('graphQLTransformer.useExperimentalPipelinedTransformer');
     // Sort types
     const typeArr: any[] = [];
     Object.values({ ...this.modelMap, ...this.nonModelMap }).forEach((obj: CodeGenModel) => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -109,6 +109,12 @@ export interface RawAppSyncModelConfig extends RawConfig {
    * @descriptions optional boolean which generates the list types to respect the nullability as defined in the schema
    */
    handleListNullabilityTransparently?: boolean;
+  /**
+   * @name usePipelinedTransformer
+   * @type boolean
+   * @descriptions optional boolean which determines whether to use the new pipelined GraphQL transformer
+   */
+  usePipelinedTransformer?: boolean;
 }
 
 // Todo: need to figure out how to share config
@@ -118,6 +124,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   target?: string;
   isTimestampFieldsAdded?: boolean;
   handleListNullabilityTransparently?: boolean;
+  usePipelinedTransformer?: boolean;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -188,7 +195,8 @@ export class AppSyncModelVisitor<
       scalars: buildScalars(_schema, rawConfig.scalars || '', defaultScalars),
       target: rawConfig.target,
       isTimestampFieldsAdded: rawConfig.isTimestampFieldsAdded,
-      handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently
+      handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently,
+      usePipelinedTransformer: rawConfig.usePipelinedTransformer,
     });
 
     const typesUsedInDirectives: string[] = [];

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -426,7 +426,7 @@ export class AppSyncModelVisitor<
       const fields = obj.fields
         .map((field: CodeGenField) => {
           // include only connection field and type
-          const fieldDirectives = field.directives.filter(field => field.name === 'connection');
+          const fieldDirectives = usePipelinedTransformer ? field.directives.filter(field => field.name === 'hasOne' || field.name === 'belongsTo' || field.name === 'hasMany' || field.name === 'manyToMany') : field.directives.filter(field => field.name === 'connection');
           return {
             name: field.name,
             directives: fieldDirectives,

--- a/packages/graphql-types-generator/src/utilities/graphql.ts
+++ b/packages/graphql-types-generator/src/utilities/graphql.ts
@@ -46,8 +46,21 @@ export function isMetaFieldName(name: string) {
 export function removeConnectionDirectives(ast: ASTNode) {
   return visit(ast, {
     Directive(node: DirectiveNode): DirectiveNode | null {
-      if (node.name.value === 'connection') return null;
-      return node;
+      switch(node.name.value) {
+        // TODO: remove reference to 'connection' on transformer vNext release
+        case 'connection':
+          return null;
+        case 'hasOne':
+          return null;
+        case 'belongsTo':
+          return null;
+        case 'hasMany':
+          return null;
+        case 'manyToMany':
+          return null;
+        default:
+          return node;
+      }
     },
   });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adding new functionality to support the V2 transformer directives `@hasOne`, `@hasMany`, `@belongsTo`
This also fixes some of the code with `@primaryKey` and `@index` being supported next to `@connection` since that will never happen in a real world scenario
Removes use of the FeatureFlags class in amplify-cli-core and uses feature flags the way that codegen does
Fixes some of the tests that were using FeatureFlags


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Ran unit tests, writing some new unit tests, manual testing


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.