### PR TITLE
Release(appsync-modelgen-plugin): Add new primaryKey, index, hasOne, hasMany, and belongsTo directive support

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -72,6 +72,7 @@ async function generateModels(context) {
 
   const generateIndexRules = readFeatureFlag('codegen.generateIndexRules');
   const emitAuthProvider = readFeatureFlag('codegen.emitAuthProvider');
+  const usePipelinedTransformer = readFeatureFlag('graphQLTransformer.useExperimentalPipelinedTransformer')
 
   let enableDartNullSafety = readFeatureFlag('codegen.enableDartNullSafety');
 
@@ -101,7 +102,8 @@ async function generateModels(context) {
       emitAuthProvider,
       generateIndexRules,
       enableDartNullSafety,
-      handleListNullabilityTransparently
+      handleListNullabilityTransparently,
+      usePipelinedTransformer
     },
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -8,6 +8,7 @@ import {
   getConnectedField,
 } from '../../utils/process-connections';
 import { CodeGenModelMap, CodeGenModel } from '../../visitors/appsync-visitor';
+import { processConnectionsV2 } from '../../utils/process-connections-v2';
 
 describe('process connection', () => {
   describe('Bi-Directional connection (named connection)', () => {
@@ -461,6 +462,315 @@ describe('process connection', () => {
       const employeeModel = modelMap.Employee;
       expect(getConnectedField(supervisorField, employeeModel, employeeModel)).toEqual(subordinateField);
       expect(getConnectedField(subordinateField, employeeModel, employeeModel)).toEqual(supervisorField);
+    });
+  });
+
+  describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
+    let hasOneWithFieldsModelMap: CodeGenModelMap;
+    let hasOneNoFieldsModelMap: CodeGenModelMap;
+    let v2ModelMap: CodeGenModelMap;
+    let v2IndexModelMap: CodeGenModelMap;
+
+    beforeEach(() => {
+      const hasOneWithFieldsSchema = /* GraphQL */ `
+        type BatteryCharger @model {
+          chargerID: ID!
+          powerSource: PowerSource @hasOne(fields: ["chargerID"])
+        }
+
+        type PowerSource @model {
+          sourceID: ID! @primaryKey
+          amps: Float!
+          volts: Float!
+        }
+      `;
+
+      const hasOneNoFieldsSchema = /* GraphQL */ `
+        type BatteryCharger @model {
+          powerSource: PowerSource @hasOne
+        }
+
+        type PowerSource @model {
+          id: ID!
+          amps: Float!
+          volts: Float!
+        }
+      `;
+
+      const v2Schema = /* GraphQL */ `
+        type Post @model {
+          comments: [Comment] @hasMany(fields: ["id"])
+        }
+        
+        type Comment @model {
+          postID: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          post: Post @belongsTo(fields:["postID"])
+        }
+      `;
+
+      const v2IndexSchema = /* graphQL */ `
+        type Post @model {
+          id: ID!
+          title: String!
+          comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
+        }
+        
+        type Comment @model {
+          id: ID!
+          postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
+          content: String!
+        }
+      `;
+
+      hasOneWithFieldsModelMap = {
+        BatteryCharger: {
+          name: 'BatteryCharger',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'chargerID',
+              directives: []
+            },
+            {
+              type: 'PowerSource',
+              isNullable: true,
+              isList: false,
+              name: 'powerSource',
+              directives: [{ name: 'hasOne', arguments: { fields: ['chargerID'] } }],
+            },
+          ],
+        },
+        PowerSource: {
+          name: 'PowerSource',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'sourceID',
+              directives: [{ name: 'primaryKey', arguments: {} }],
+            },
+            {
+              type: 'Float',
+              isNullable: false,
+              isList: false,
+              name: 'amps',
+              directives: [],
+            },
+            {
+              type: 'Float',
+              isNullable: false,
+              isList: false,
+              name: 'volts',
+              directives: [],
+            },
+          ],
+        },
+      };
+
+      hasOneNoFieldsModelMap = {
+        BatteryCharger: {
+          name: 'BatteryCharger',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'PowerSource',
+              isNullable: true,
+              isList: false,
+              name: 'powerSource',
+              directives: [{ name: 'hasOne', arguments: {} }],
+            },
+          ],
+        },
+        PowerSource: {
+          name: 'PowerSource',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'id',
+              directives: []
+            },
+            {
+              type: 'Float',
+              isNullable: false,
+              isList: false,
+              name: 'amps',
+              directives: [],
+            },
+            {
+              type: 'Float',
+              isNullable: false,
+              isList: false,
+              name: 'volts',
+              directives: [],
+            },
+          ],
+        },
+      };
+
+      v2ModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'hasMany', arguments: { fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'id',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'primaryKey', arguments: { sortKeyFields: ['content'] } }],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+            {
+              type: 'Post',
+              isNullable: false,
+              isList: false,
+              name: 'post',
+              directives: [{ name: 'belongsTo', arguments: { fields: ['postID'] } }],
+            },
+          ],
+        },
+      };
+
+      v2IndexModelMap = {
+        Post: {
+          name: 'Post',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'id',
+              directives: [],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'title',
+              directives: [],
+            },
+            {
+              type: 'Comment',
+              isNullable: true,
+              isList: true,
+              name: 'comments',
+              directives: [{ name: 'hasMany', arguments: { indexName: 'byPost', fields: ['id'] } }],
+            },
+          ],
+        },
+        Comment: {
+          name: 'Comment',
+          type: 'model',
+          directives: [],
+          fields: [
+            {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'id',
+              directives: [],
+            },
+            {
+              type: 'ID',
+              isNullable: false,
+              isList: false,
+              name: 'postID',
+              directives: [{name: 'index', arguments: { name: 'byPost', sortKeyFields: ['content'] }}],
+            },
+            {
+              type: 'String',
+              isNullable: false,
+              isList: false,
+              name: 'content',
+              directives: [],
+            },
+          ],
+        },
+      };
+    });
+
+    describe('Has many comparison', () => {
+      it('should support connection with @primaryKey on BELONGS_TO side', () => {
+        const postField = v2ModelMap.Comment.fields[2];
+        const connectionInfo = (processConnectionsV2(postField, v2ModelMap.Post, v2ModelMap) as any) as CodeGenFieldConnectionBelongsTo;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
+        expect(connectionInfo.targetName).toEqual(v2ModelMap.Comment.fields[0].name);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
+
+      it('should support connection with @primaryKey on HAS_MANY side', () => {
+        const commentsField = v2ModelMap.Post.fields[0];
+        const connectionInfo = (processConnectionsV2(commentsField, v2ModelMap.Comment, v2ModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2ModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
+
+      it('Should support connection with @index on BELONGS_TO side', () => {
+        const commentsField = v2IndexModelMap.Post.fields[2];
+        const connectionInfo = (processConnectionsV2(commentsField, v2IndexModelMap.Comment, v2IndexModelMap) as any) as CodeGenFieldConnectionHasMany;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
+        expect(connectionInfo.connectedModel).toEqual(v2IndexModelMap.Comment);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
+    });
+
+    describe('Has one testing', () => {
+      it('Should support @hasOne with no explicit primary key', () => {
+        const powerSourceField = hasOneNoFieldsModelMap.BatteryCharger.fields[0];
+        const connectionInfo = (processConnectionsV2(powerSourceField, hasOneNoFieldsModelMap.PowerSource, hasOneNoFieldsModelMap)) as CodeGenFieldConnectionHasOne;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+        expect(connectionInfo.connectedModel).toEqual(hasOneNoFieldsModelMap.PowerSource);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
+      });
+      it('Should support @hasOne with an explicit primary key', () => {
+        const powerSourceField = hasOneWithFieldsModelMap.BatteryCharger.fields[1];
+        const connectionInfo = (processConnectionsV2(powerSourceField, hasOneWithFieldsModelMap.PowerSource, hasOneWithFieldsModelMap)) as CodeGenFieldConnectionHasOne;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+        expect(connectionInfo.connectedModel).toEqual(hasOneWithFieldsModelMap.PowerSource);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+      });
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -9,16 +9,20 @@ const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
 };
 
-const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code) => {
+const getVisitor = (schema: string, selectedType?: string, generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code, usePipelinedTransformer: boolean = false) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
   const visitor = new AppSyncModelJavaVisitor(
     builtSchema,
-    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP, isTimestampFieldsAdded: true, handleListNullabilityTransparently: true },
+    { directives, target: 'android', generate, scalars: JAVA_SCALAR_MAP, isTimestampFieldsAdded: true, handleListNullabilityTransparently: true, usePipelinedTransformer: usePipelinedTransformer },
     { selectedType },
   );
   visit(ast, { leave: visitor });
   return visitor;
+};
+
+const getVisitorPipelinedTransformer = (schema: string, selectedType?: string, generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code) => {
+  return getVisitor(schema, selectedType, generate, true);
 };
 
 describe('AppSyncModelVisitor', () => {
@@ -187,6 +191,62 @@ describe('AppSyncModelVisitor', () => {
     const generatedCode = visitor.generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
+  });
+
+  describe('vNext transformer feature parity tests', () => {
+    it('should produce the same result for @primaryKey as the primary key variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["author_id"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+      const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID!
+        author_id: ID! @primaryKey
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitorPipelinedTransformer(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
+
+      expect(version1Code).toMatch(version2Code);
+    });
+
+    it('should produce the same result for @index as the secondary index variant of @key', async () => {
+      const schemaV1 = /* GraphQL */ `
+      type authorBook @model @key(fields: ["id"]) @key(name: "authorSecondary", fields: ["author_id", "author"]) {
+        id: ID!
+        author_id: ID!
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+      const schemaV2 = /* GraphQL */ `
+      type authorBook @model {
+        id: ID! @primaryKey
+        author_id: ID! @index(name: "authorSecondary", sortKeyFields: ["author"])
+        book_id: ID!
+        author: String
+        book: String
+      }
+    `;
+      const visitorV1 = getVisitor(schemaV1, 'authorBook');
+      const visitorV2 = getVisitorPipelinedTransformer(schemaV2, 'authorBook');
+      const version1Code = visitorV1.generate();
+      const version2Code = visitorV2.generate();
+
+      expect(version1Code).toMatch(version2Code);
+    });
   });
 
   it('Should handle nullability of lists appropriately', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -27,6 +27,7 @@ const getVisitor = (schema: string, target: 'typescript' | 'javascript' | 'typeD
 };
 
 describe('Metadata visitor', () => {
+
   const schema = /* GraphQL */ `
     type SimpleModel @model {
       id: ID!

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -133,6 +133,16 @@ export const directives = /* GraphQL */ `
   }
 
   directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+  
+  # GraphQL vNext Directives
+  # primaryKey directive
+  directive @primaryKey(sortKeyFields: [String!], queryField: String) on FIELD_DEFINITION
+  directive @index(name: String!, sortKeyFields: [String], queryField: String) on FIELD_DEFINITION
+
+  directive @hasOne(fields: [String!]) on FIELD_DEFINITION
+  directive @hasMany(indexName: String, fields: [String], limit: Int = 100) on FIELD_DEFINITION
+  directive @belongsTo(fields: [String]) on FIELD_DEFINITION
+  directive @manyToMany(relationName: String!) on FIELD_DEFINITION
 `;
 
 export const scalars = [

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -1,0 +1,60 @@
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import {
+  CodeGenConnectionType,
+  CodeGenFieldConnection,
+  makeConnectionAttributeName,
+} from './process-connections';
+import { getConnectedFieldV2 } from './process-connections-v2';
+
+
+export function processBelongsToConnection(
+  field: CodeGenField,
+  model: CodeGenModel,
+  modelMap: CodeGenModelMap,
+  connectionDirective: CodeGenDirective,
+): CodeGenFieldConnection | undefined {
+  const otherSide = modelMap[field.type];
+  const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
+  const connectionFields = connectionDirective.arguments.fields || [];
+
+  if (connectionFields.length > 1) {
+    // Todo: Move to a common function and update the error message
+    throw new Error('DataStore only support one key in field');
+  }
+
+  if (field.isList) {
+    throw new Error(
+      `A list field does not support the 'belongsTo' relation`
+    );
+  }
+  else if (field.isNullable && otherSideField.isNullable) {
+    throw new Error(
+      `DataStore does not support 1 to 1 connection with both sides of connection as optional field: ${model.name}.${field.name}`,
+    );
+  }
+
+  let validOtherSideField = false;
+  otherSideField.directives.forEach(dir => {
+    if (dir.name === 'hasOne' || dir.name === 'hasMany') {
+      validOtherSideField = true;
+    }
+  });
+
+  if (!validOtherSideField) {
+    throw new Error(
+      `A 'belongsTo' field should match to a corresponding 'hasMany' or 'hasOne' field`
+    );
+  }
+  // if a type is connected using name, then amplify-graphql-relational-transformer adds a field to
+  //  track the connection and that field is not part of the selection set
+  // but if the field are connected using fields argument in connection directive
+  // we are reusing the field and it should be preserved in selection set
+  const isConnectingFieldAutoCreated = connectionFields.length === 0;
+
+  return {
+    kind: CodeGenConnectionType.BELONGS_TO,
+    connectedModel: otherSide,
+    isConnectingFieldAutoCreated,
+    targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+  };
+}

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -1,0 +1,93 @@
+import { CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import {
+  CodeGenFieldConnection, DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives,
+  getDirective,
+  makeConnectionAttributeName,
+} from './process-connections';
+import { processHasOneConnection } from './process-has-one';
+import { processBelongsToConnection } from './process-belongs-to';
+import { processHasManyConnection } from './process-has-many';
+
+// TODO: This file holds several references to utility functions in the v1 process connections file, those functions need to go here before that file is removed
+
+export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel, directiveName: string): CodeGenField {
+  const connectionInfo = getDirective(field)(directiveName);
+  if (!connectionInfo) {
+    throw new Error(`The ${field.name} on model ${model.name} is not connected`);
+  }
+
+  const indexName = connectionInfo.arguments.indexName;
+  const connectionFields = connectionInfo.arguments.fields;
+  if (connectionFields) {
+    let indexDirective;
+    if (indexName) {
+      indexDirective = flattenFieldDirectives(connectedModel).find(dir => {
+        return dir.name === 'index' && dir.arguments.name === indexName;
+      });
+      if (!indexDirective) {
+        throw new Error(
+          `Error processing @${connectionInfo.name} directive on ${model.name}.${field.name}, @index directive with name ${indexName} was not found in connected model ${connectedModel.name}`,
+        );
+      }
+    } else {
+      indexDirective = flattenFieldDirectives(connectedModel).find(dir => {
+        return dir.name === 'primaryKey';
+      });
+    }
+
+    // when there is a fields argument in the connection
+    const connectedFieldName = indexDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(indexDirective as CodeGenFieldDirective) : DEFAULT_HASH_KEY_FIELD;
+
+    // Find a field on the other side which connected by a @connection and has the same fields[0] as indexName field
+    const otherSideConnectedField = connectedModel.fields.find(f => {
+      return f.directives.find(d => {
+        return (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.fields && d.arguments.fields[0] === connectedFieldName;
+      });
+    });
+    if (otherSideConnectedField) {
+      return otherSideConnectedField;
+    }
+    // If there are no field with @connection with indexName then try to find a field that has same name as connection name
+    const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+
+    if (!connectedField) {
+      throw new Error(`Can not find key field ${connectedFieldName} in ${connectedModel}`);
+    }
+    return connectedField;
+  }
+  // un-named connection. Use an existing field or generate a new field
+  const connectedFieldName = makeConnectionAttributeName(model.name, field.name);
+  const connectedField = connectedModel.fields.find(f => f.name === connectedFieldName);
+  return connectedField
+    ? connectedField
+    : {
+      name: connectedFieldName,
+      directives: [],
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+    };
+}
+
+
+export function processConnectionsV2(
+  field: CodeGenField,
+  model: CodeGenModel,
+  modelMap: CodeGenModelMap,
+): CodeGenFieldConnection | undefined {
+  const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
+
+  if(connectionDirective) {
+
+    switch(connectionDirective.name) {
+      case 'hasOne':
+        return processHasOneConnection(field, model, modelMap, connectionDirective);
+      case 'belongsTo':
+        return processBelongsToConnection(field, model, modelMap, connectionDirective);
+      case 'hasMany':
+        return processHasManyConnection(field, model, modelMap, connectionDirective);
+      default:
+        break;
+    }
+  }
+}

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -1,0 +1,59 @@
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import {
+  CodeGenConnectionType,
+  CodeGenFieldConnection,
+  makeConnectionAttributeName,
+} from './process-connections';
+import { getConnectedFieldV2 } from './process-connections-v2';
+
+
+export function processHasManyConnection(
+  field: CodeGenField,
+  model: CodeGenModel,
+  modelMap: CodeGenModelMap,
+  connectionDirective: CodeGenDirective,
+): CodeGenFieldConnection | undefined {
+  const otherSide = modelMap[field.type];
+  const connectionFields = connectionDirective.arguments.fields || [];
+  const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
+
+  const isNewField = !otherSide.fields.includes(otherSideField);
+
+  // if a type is connected using name, then graphql-connection-transformer adds a field to
+  //  track the connection and that field is not part of the selection set
+  // but if the field are connected using fields argument in connection directive
+  // we are reusing the field and it should be preserved in selection set
+  const isConnectingFieldAutoCreated = connectionFields.length === 0;
+
+  if (!isNewField) {
+    if (field.isList && !otherSideField.isList) {
+      return {
+        kind: CodeGenConnectionType.HAS_MANY,
+        associatedWith: otherSideField,
+        isConnectingFieldAutoCreated,
+        connectedModel: otherSide,
+      };
+    }
+  }
+  else {
+    if (field.isList) {
+      const connectionFieldName = makeConnectionAttributeName(model.name, field.name);
+      const existingConnectionField = otherSide.fields.find(f => f.name === connectionFieldName);
+      return {
+        kind: CodeGenConnectionType.HAS_MANY,
+        connectedModel: otherSide,
+        isConnectingFieldAutoCreated,
+        associatedWith: existingConnectionField || {
+          name: connectionFieldName,
+          type: 'ID',
+          isList: false,
+          isNullable: true,
+          directives: [],
+        },
+      };
+    }
+    else {
+      throw new Error("A field with hasMany must be a list type");
+    }
+  }
+}

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -1,0 +1,43 @@
+import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
+import {
+  CodeGenConnectionType,
+  CodeGenFieldConnection,
+  makeConnectionAttributeName,
+} from './process-connections';
+import { getConnectedFieldV2 } from './process-connections-v2';
+
+export function processHasOneConnection(
+  field: CodeGenField,
+  model: CodeGenModel,
+  modelMap: CodeGenModelMap,
+  connectionDirective: CodeGenDirective,
+): CodeGenFieldConnection | undefined {
+  const otherSide = modelMap[field.type];
+  const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
+  const connectionFields = connectionDirective.arguments.fields || [];
+
+  // TODO: Update comment, graphql-connection-transformer is the v1 package and this file is created for vNext
+  // if a type is connected using name, then graphql-connection-transformer adds a field to
+  //  track the connection and that field is not part of the selection set
+  // but if the field are connected using fields argument in connection directive
+  // we are reusing the field and it should be preserved in selection set
+  const isConnectingFieldAutoCreated = connectionFields.length === 0;
+
+  if (!field.isList && !otherSideField.isList) {
+    if (field.isNullable && (!otherSideField.isNullable || connectionFields.length === 0)) {
+      return {
+        kind: CodeGenConnectionType.HAS_ONE,
+        associatedWith: otherSideField,
+        connectedModel: otherSide,
+        isConnectingFieldAutoCreated,
+        targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+      };
+    }
+    else {
+      throw new Error("A hasOne relationship should be optional on the owning side and not optional on the owned side");
+    }
+  }
+  else {
+    throw new Error("A hasOne relationship should be 1:1, no lists");
+  }
+}

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -441,13 +441,47 @@ export class AppSyncSwiftVisitor<
   }
 
   protected generateKeyRules(model: CodeGenModel): string[] {
-    const keyDirectives = model.directives
-      .filter(directive => directive.name === 'key')
-      .map(directive => {
-        const name = directive.arguments.name ? `"${directive.arguments.name}"` : 'nil';
-        const fields: string = directive.arguments.fields.map((field: string) => `"${field}"`).join(', ');
-        return `.index(fields: [${fields}], name: ${name})`;
+    let keyDirectives: string[];
+
+    if (this.config.usePipelinedTransformer) {
+      let fieldDirectiveList: any[] = new Array<any>();
+      model.fields.forEach(field => {
+        field.directives.forEach(directive => {
+          fieldDirectiveList.push({
+            fieldName: field.name,
+            directive: directive
+          });
+        });
       });
+
+      keyDirectives = fieldDirectiveList
+        .filter(directiveObj => directiveObj.directive.name === 'primaryKey' || directiveObj.directive.name === 'index')
+        .map(directiveObj => {
+          switch(directiveObj.directive.name) {
+            case 'index':
+            case 'primaryKey':
+              const name = directiveObj.directive.arguments.name ? `"${directiveObj.directive.arguments.name}"` : 'nil';
+              if (!directiveObj.directive.arguments.sortKeyFields) {
+                directiveObj.directive.arguments.sortKeyFields = new Array<string>();
+              }
+              directiveObj.directive.arguments.sortKeyFields = [directiveObj.fieldName, ...directiveObj.directive.arguments.sortKeyFields]
+              const fields: string = directiveObj.directive.arguments.sortKeyFields.map((field: string) => `"${field}"`).join(', ');
+              return `.index(fields: [${fields}], name: ${name})`;
+            default:
+              break;
+          }
+          return '';
+      });
+    }
+    else {
+      keyDirectives = model.directives
+        .filter(directive => directive.name === 'key')
+        .map(directive => {
+          const name = directive.arguments.name ? `"${directive.arguments.name}"` : 'nil';
+          const fields: string = directive.arguments.fields.map((field: string) => `"${field}"`).join(', ');
+          return `.index(fields: [${fields}], name: ${name})`;
+        });
+    }
 
     return keyDirectives;
   }

--- a/packages/graphql-types-generator/src/utilities/graphql.ts
+++ b/packages/graphql-types-generator/src/utilities/graphql.ts
@@ -46,8 +46,21 @@ export function isMetaFieldName(name: string) {
 export function removeConnectionDirectives(ast: ASTNode) {
   return visit(ast, {
     Directive(node: DirectiveNode): DirectiveNode | null {
-      if (node.name.value === 'connection') return null;
-      return node;
+      switch(node.name.value) {
+        // TODO: remove reference to 'connection' on transformer vNext release
+        case 'connection':
+          return null;
+        case 'hasOne':
+          return null;
+        case 'belongsTo':
+          return null;
+        case 'hasMany':
+          return null;
+        case 'manyToMany':
+          return null;
+        default:
+          return node;
+      }
     },
   });
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Codegen support for Amplify CLI v2 key and connection directives
Tested in https://github.com/aws-amplify/amplify-codegen/pull/237

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Tested in https://github.com/aws-amplify/amplify-codegen/pull/237


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.