### PR TITLE
change default maximum statement depth to 3

### DIFF
--- a/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
@@ -2,7 +2,7 @@ const inquirer = require('inquirer');
 
 const constants = require('../../constants');
 
-async function askMaxDepth(defaultDepth = 2) {
+async function askMaxDepth(defaultDepth = 3) {
   const answer = await inquirer.prompt([
     {
       name: 'maxDepth',


### PR DESCRIPTION
#### Description of changes
Change the default maximum statement depth to 3. This is required for the aggregate result union type to generate properly.

#### Description of how you validated changes
Manual test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.