### PR TITLE
fix(graphql-types-generator): correct typename for nested fragments

### DIFF
--- a/packages/graphql-types-generator/src/typescript/codeGeneration.ts
+++ b/packages/graphql-types-generator/src/typescript/codeGeneration.ts
@@ -307,7 +307,7 @@ export function interfaceDeclarationForFragment(generator: CodeGenerator, fragme
               type: { name: `"${fragment.typeCondition}"` } as GraphQLType,
             };
           } else {
-            return field;
+            return updateTypeNameField(field);
           }
         });
 

--- a/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
+++ b/packages/graphql-types-generator/test/angular/__snapshots__/index.js.snap
@@ -1884,7 +1884,7 @@ export type humanDetailsFragment = {
   name: string;
   // A list of starships this person has piloted, or an empty list if none
   starships?: Array<{
-    __typename: string;
+    __typename: \\"Starship\\";
     // The ID of the starship
     id: string;
     // The name of the starship

--- a/packages/graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/packages/graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -1467,7 +1467,7 @@ export type humanDetailsFragment = {
   name: string,
   // A list of starships this person has piloted, or an empty list if none
   starships?:  Array< {
-    __typename: string,
+    __typename: \\"Starship\\",
     // The ID of the starship
     id: string,
     // The name of the starship


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The nested fragment fields now have correct typename generated

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #236 


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.