### PR TITLE
Revert "change default maximum statement depth to 3"

### DIFF
--- a/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
+++ b/packages/amplify-codegen/src/walkthrough/questions/maxDepth.js
@@ -2,7 +2,7 @@ const inquirer = require('inquirer');
 
 const constants = require('../../constants');
 
-async function askMaxDepth(defaultDepth = 3) {
+async function askMaxDepth(defaultDepth = 2) {
   const answer = await inquirer.prompt([
     {
       name: 'maxDepth',


### PR DESCRIPTION
Reverts aws-amplify/amplify-codegen#261

Reverting the default statement depth to 2. A different approach will be followed for resolving searchable aggregate codegen.