### PR TITLE
feat(appsync-dart-visitor): insert auth provider info

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -2334,6 +2334,348 @@ class _SimpleModelModelType extends ModelType<SimpleModel> {
 "
 `;
 
+exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule with provider information when enabled inserting auth provider to auth when nullsafety is disabled 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the TodoWithAuth type in your schema. */
+@immutable
+class TodoWithAuth extends Model {
+  static const classType = const _TodoWithAuthModelType();
+  final String id;
+  final String name;
+  final TemporalDateTime createdAt;
+  final TemporalDateTime updatedAt;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  const TodoWithAuth._internal(
+      {@required this.id, @required this.name, this.createdAt, this.updatedAt});
+
+  factory TodoWithAuth({String id, @required String name}) {
+    return TodoWithAuth._internal(
+        id: id == null ? UUID.getUUID() : id, name: name);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TodoWithAuth && id == other.id && name == other.name;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write(\\"TodoWithAuth {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"name=\\" + \\"$name\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" +
+        (createdAt != null ? createdAt.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"updatedAt=\\" + (updatedAt != null ? updatedAt.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+
+    return buffer.toString();
+  }
+
+  TodoWithAuth copyWith({String id, String name}) {
+    return TodoWithAuth._internal(id: id ?? this.id, name: name ?? this.name);
+  }
+
+  TodoWithAuth.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'],
+        createdAt = json['createdAt'] != null
+            ? TemporalDateTime.fromString(json['createdAt'])
+            : null,
+        updatedAt = json['updatedAt'] != null
+            ? TemporalDateTime.fromString(json['updatedAt'])
+            : null;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'createdAt': createdAt?.format(),
+        'updatedAt': updatedAt?.format()
+      };
+
+  static final QueryField ID = QueryField(fieldName: \\"todoWithAuth.id\\");
+  static final QueryField NAME = QueryField(fieldName: \\"name\\");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"TodoWithAuth\\";
+    modelSchemaDefinition.pluralName = \\"TodoWithAuths\\";
+
+    modelSchemaDefinition.authRules = [
+      AuthRule(
+          authStrategy: AuthStrategy.GROUPS,
+          groupClaim: \\"cognito:groups\\",
+          groups: [\\"admin\\"],
+          provider: AuthRuleProvider.USERPOOLS,
+          operations: [
+            ModelOperation.CREATE,
+            ModelOperation.UPDATE,
+            ModelOperation.DELETE,
+            ModelOperation.READ
+          ]),
+      AuthRule(
+          authStrategy: AuthStrategy.OWNER,
+          ownerField: \\"owner\\",
+          identityClaim: \\"cognito:username\\",
+          provider: AuthRuleProvider.USERPOOLS,
+          operations: [ModelOperation.CREATE, ModelOperation.UPDATE]),
+      AuthRule(
+          authStrategy: AuthStrategy.PUBLIC,
+          provider: AuthRuleProvider.APIKEY,
+          operations: [ModelOperation.READ])
+    ];
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: TodoWithAuth.NAME,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
+        fieldName: 'createdAt',
+        isRequired: false,
+        isReadOnly: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
+        fieldName: 'updatedAt',
+        isRequired: false,
+        isReadOnly: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+  });
+}
+
+class _TodoWithAuthModelType extends ModelType<TodoWithAuth> {
+  const _TodoWithAuthModelType();
+
+  @override
+  TodoWithAuth fromJson(Map<String, dynamic> jsonData) {
+    return TodoWithAuth.fromJson(jsonData);
+  }
+}
+"
+`;
+
+exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule with provider information when enabled inserting auth provider to auth when nullsafety is enabled 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+
+/** This is an auto generated class representing the TodoWithAuth type in your schema. */
+@immutable
+class TodoWithAuth extends Model {
+  static const classType = const _TodoWithAuthModelType();
+  final String id;
+  final String? _name;
+  final TemporalDateTime? _createdAt;
+  final TemporalDateTime? _updatedAt;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  String get name {
+    try {
+      return _name!;
+    } catch(e) {
+      throw new DataStoreException(
+      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      recoverySuggestion:
+        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+      underlyingException: e.toString()
+    );
+    }
+  }
+  
+  TemporalDateTime? get createdAt {
+    return _createdAt;
+  }
+  
+  TemporalDateTime? get updatedAt {
+    return _updatedAt;
+  }
+  
+  const TodoWithAuth._internal({required this.id, required name, createdAt, updatedAt}): _name = name, _createdAt = createdAt, _updatedAt = updatedAt;
+  
+  factory TodoWithAuth({String? id, required String name}) {
+    return TodoWithAuth._internal(
+      id: id == null ? UUID.getUUID() : id,
+      name: name);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TodoWithAuth &&
+      id == other.id &&
+      _name == other._name;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"TodoWithAuth {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"name=\\" + \\"$_name\\" + \\", \\");
+    buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  TodoWithAuth copyWith({String? id, String? name}) {
+    return TodoWithAuth._internal(
+      id: id ?? this.id,
+      name: name ?? this.name);
+  }
+  
+  TodoWithAuth.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _name = json['name'],
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"todoWithAuth.id\\");
+  static final QueryField NAME = QueryField(fieldName: \\"name\\");
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"TodoWithAuth\\";
+    modelSchemaDefinition.pluralName = \\"TodoWithAuths\\";
+    
+    modelSchemaDefinition.authRules = [
+      AuthRule(
+        authStrategy: AuthStrategy.GROUPS,
+        groupClaim: \\"cognito:groups\\",
+        groups: [ \\"admin\\" ],
+        provider: AuthRuleProvider.USERPOOLS,
+        operations: [
+          ModelOperation.CREATE,
+          ModelOperation.UPDATE,
+          ModelOperation.DELETE,
+          ModelOperation.READ
+        ]),
+      AuthRule(
+        authStrategy: AuthStrategy.OWNER,
+        ownerField: \\"owner\\",
+        identityClaim: \\"cognito:username\\",
+        provider: AuthRuleProvider.USERPOOLS,
+        operations: [
+          ModelOperation.CREATE,
+          ModelOperation.UPDATE
+        ]),
+      AuthRule(
+        authStrategy: AuthStrategy.PUBLIC,
+        provider: AuthRuleProvider.APIKEY,
+        operations: [
+          ModelOperation.READ
+        ])
+    ];
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: TodoWithAuth.NAME,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
+      fieldName: 'createdAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
+      fieldName: 'updatedAt',
+      isRequired: false,
+      isReadOnly: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)
+    ));
+  });
+}
+
+class _TodoWithAuthModelType extends ModelType<TodoWithAuth> {
+  const _TodoWithAuthModelType();
+  
+  @override
+  TodoWithAuth fromJson(Map<String, dynamic> jsonData) {
+    return TodoWithAuth.fromJson(jsonData);
+  }
+}"
+`;
+
 exports[`AppSync Dart Visitor Model with Auth Directive should generate class with custom claims 1`] = `
 "/*
 * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -9,7 +9,7 @@ import {
 import { DartDeclarationBlock } from '../languages/dart-declaration-block';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { indent, indentMultiline, NormalizedScalarsMap } from '@graphql-codegen/visitor-plugin-common';
-import { AuthDirective, AuthProvider, AuthStrategy } from '../utils/process-auth';
+import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import {
   LOADER_CLASS_NAME,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -9,7 +9,7 @@ import {
 import { DartDeclarationBlock } from '../languages/dart-declaration-block';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { indent, indentMultiline, NormalizedScalarsMap } from '@graphql-codegen/visitor-plugin-common';
-import { AuthDirective, AuthStrategy } from '../utils/process-auth';
+import { AuthDirective, AuthProvider, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
 import {
   LOADER_CLASS_NAME,
@@ -36,6 +36,13 @@ export interface RawAppSyncModelDartConfig extends RawAppSyncModelConfig {
   /**
    * @name directives
    * @type boolean
+   * @descriptions optional boolean, if true emits the provider value of @auth directives
+   */
+  emitAuthProvider?: boolean;
+
+  /**
+   * @name directives
+   * @type boolean
    * @description optional, defines if dart model files are generated with null safety feature.
    */
   enableDartNullSafety?: boolean;
@@ -48,6 +55,7 @@ export interface RawAppSyncModelDartConfig extends RawAppSyncModelConfig {
 }
 
 export interface ParsedAppSyncModelDartConfig extends ParsedAppSyncModelConfig {
+  emitAuthProvider?: boolean;
   enableDartNullSafety: boolean;
   enableDartNonModelGeneration: boolean;
 }
@@ -62,6 +70,7 @@ export class AppSyncModelDartVisitor<
     defaultScalars: NormalizedScalarsMap = DART_SCALAR_MAP,
   ) {
     super(schema, rawConfig, additionalConfig, defaultScalars);
+    this._parsedConfig.emitAuthProvider = rawConfig.emitAuthProvider || false;
     this._parsedConfig.enableDartNullSafety = rawConfig.enableDartNullSafety || false;
     this._parsedConfig.enableDartNonModelGeneration = rawConfig.enableDartNonModelGeneration || false;
   }
@@ -759,6 +768,9 @@ export class AppSyncModelDartVisitor<
             default:
               printWarning(`Model has auth with authStrategy ${rule.allow} of which is not yet supported`);
               return '';
+          }
+          if (this.config.emitAuthProvider && rule.provider) {
+            authRule.push(`provider: AuthRuleProvider.${rule.provider.toUpperCase()}`);
           }
           authRule.push(
             ['operations: [', indentMultiline(rule.operations.map(op => `ModelOperation.${op.toUpperCase()}`).join(',\n')), ']'].join('\n'),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->

# Please do not merge for now

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

This change inserts `provider` information to `AuthRule` initializer in generated Dart model classes. This changes is required to align with the multi-auth implementation in amplify-ios (https://github.com/aws-amplify/amplify-codegen/pull/184).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.