### PR TITLE
fix(amplify-codegen): updates hasone link location

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -317,6 +317,31 @@ describe('AppSyncModelVisitor', () => {
       expect(commentsField).not.toContain('post');
       expect(commentsField).toContain('postCommentsId'); // because of connection from Post.comments
     });
+
+    it('should generate projectTeamId connection field for hasOne directive in the parent object', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          id: ID!
+          name: String
+          team: Team @hasOne
+        }
+        type Team @model {
+          id: ID!
+          name: String!
+        }
+      `;
+      const ast = parse(schema);
+      const builtSchema = buildSchemaWithDirectives(schema);
+      const visitor = new AppSyncModelVisitor(
+        builtSchema,
+        { directives, target: 'typescript', generate: CodeGenGenerateEnum.code, usePipelinedTransformer: true },
+        {},
+      );
+      visit(ast, { leave: visitor });
+      visitor.generate();
+      const projectFields = visitor.models.Project.fields.map(field => field.name);
+      expect(projectFields).toContain('projectTeamId');
+    });
   });
 
   describe('auth directive', () => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -1,6 +1,8 @@
 import { CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
 import {
-  CodeGenFieldConnection, DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives,
+  CodeGenFieldConnection,
+  DEFAULT_HASH_KEY_FIELD,
+  flattenFieldDirectives,
   getDirective,
   makeConnectionAttributeName,
 } from './process-connections';
@@ -10,13 +12,18 @@ import { processHasManyConnection } from './process-has-many';
 
 // TODO: This file holds several references to utility functions in the v1 process connections file, those functions need to go here before that file is removed
 
-export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel, directiveName: string): CodeGenField {
+export function getConnectedFieldV2(
+  field: CodeGenField,
+  model: CodeGenModel,
+  connectedModel: CodeGenModel,
+  directiveName: string,
+): CodeGenField {
   const connectionInfo = getDirective(field)(directiveName);
   if (!connectionInfo) {
     throw new Error(`The ${field.name} on model ${model.name} is not connected`);
   }
 
-  if(connectionInfo.name === 'belongsTo') {
+  if (connectionInfo.name === 'belongsTo') {
     let connectedFieldBelongsTo = getBelongsToConnectedField(field, model, connectedModel);
     if (connectedFieldBelongsTo) {
       return connectedFieldBelongsTo;
@@ -25,7 +32,7 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
 
   const indexName = connectionInfo.arguments.indexName;
   const connectionFields = connectionInfo.arguments.fields;
-  if (connectionFields) {
+  if (connectionFields || directiveName === 'hasOne') {
     let indexDirective;
     if (indexName) {
       indexDirective = flattenFieldDirectives(connectedModel).find(dir => {
@@ -43,12 +50,20 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
     }
 
     // when there is a fields argument in the connection
-    const connectedFieldName = indexDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(indexDirective as CodeGenFieldDirective) : DEFAULT_HASH_KEY_FIELD;
+    const connectedFieldName = indexDirective
+      ? ((fieldDir: CodeGenFieldDirective) => {
+          return fieldDir.fieldName;
+        })(indexDirective as CodeGenFieldDirective)
+      : DEFAULT_HASH_KEY_FIELD;
 
     // Find a field on the other side which connected by a @connection and has the same fields[0] as indexName field
     const otherSideConnectedField = connectedModel.fields.find(f => {
       return f.directives.find(d => {
-        return (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.fields && d.arguments.fields[0] === connectedFieldName;
+        return (
+          (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') &&
+          d.arguments.fields &&
+          d.arguments.fields[0] === connectedFieldName
+        );
       });
     });
     if (otherSideConnectedField) {
@@ -68,14 +83,13 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
   return connectedField
     ? connectedField
     : {
-      name: connectedFieldName,
-      directives: [],
-      type: 'ID',
-      isList: false,
-      isNullable: true,
-    };
+        name: connectedFieldName,
+        directives: [],
+        type: 'ID',
+        isList: false,
+        isNullable: true,
+      };
 }
-
 
 export function processConnectionsV2(
   field: CodeGenField,
@@ -84,9 +98,8 @@ export function processConnectionsV2(
 ): CodeGenFieldConnection | undefined {
   const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
 
-  if(connectionDirective) {
-
-    switch(connectionDirective.name) {
+  if (connectionDirective) {
+    switch (connectionDirective.name) {
       case 'hasOne':
         return processHasOneConnection(field, model, modelMap, connectionDirective);
       case 'belongsTo':

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -679,9 +679,17 @@ export class AppSyncModelVisitor<
       model.fields.forEach(field => {
         const connectionInfo = processConnectionsV2(field, model, this.modelMap);
         if (connectionInfo) {
-          if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+          if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
             // Need to update the other side of the connection even if there is no connection directive
             addFieldToModel(connectionInfo.connectedModel, connectionInfo.associatedWith);
+          } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+            addFieldToModel(model, {
+              name: connectionInfo.targetName,
+              directives: [],
+              type: 'ID',
+              isList: false,
+              isNullable: connectionInfo.associatedWith.isNullable,
+            });
           } else if (connectionInfo.targetName !== 'id') {
             // Need to remove the field that is targetName
             removeFieldFromModel(model, connectionInfo.targetName);


### PR DESCRIPTION
#### Description of changes
- ensure hasOne without fields generates the connected field in the parent object similar to hasOne with fields to create the same developer experience
- there is a cli PR for the same changes [here](https://github.com/aws-amplify/amplify-cli/pull/8679)

#### Description of how you validated changes
- `yarn test` passes
- test updated

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.