### PR TITLE
fix: retain v2 indexes in codegen

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -167,4 +167,56 @@ describe('processIndex', () => {
       },
     ]);
   });
+
+  it('does not add duplicate indexes', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+        {
+          name: 'key',
+          arguments: {
+            name: 'byItem',
+            fields: ['connectionField'],
+          },
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItem',
+              },
+            },
+          ],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherConnection',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byAnother',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives.length).toBe(3);
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -2,12 +2,12 @@ import { processIndex } from '../../utils/process-index';
 import { CodeGenModel } from '../../visitors/appsync-visitor';
 
 describe('processIndex', () => {
-  it('should add multiple compound @index directives as model key attributes', () => {
+  it('adds multiple compound @index directives as model key attributes', () => {
     const model: CodeGenModel = {
       directives: [
         {
           name: 'model',
-          arguments: [],
+          arguments: {},
         },
       ],
       name: 'testModel',
@@ -49,7 +49,7 @@ describe('processIndex', () => {
     expect(model.directives).toEqual([
       {
         name: 'model',
-        arguments: [],
+        arguments: {},
       },
       {
         name: 'key',
@@ -68,12 +68,12 @@ describe('processIndex', () => {
     ]);
   });
 
-  it('should add simple @index directives as model key attributes', () => {
+  it('adds simple @index directives as model key attributes', () => {
     const model: CodeGenModel = {
       directives: [
         {
           name: 'model',
-          arguments: [],
+          arguments: {},
         },
       ],
       name: 'testModel',
@@ -113,7 +113,7 @@ describe('processIndex', () => {
     expect(model.directives).toEqual([
       {
         name: 'model',
-        arguments: [],
+        arguments: {},
       },
       {
         name: 'key',
@@ -128,6 +128,42 @@ describe('processIndex', () => {
           name: 'byAnother',
           fields: ['anotherConnection'],
         },
+      },
+    ]);
+  });
+
+  it('does nothing if no @index directives in model', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'aNormalField',
+          directives: [],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherNormalField',
+          directives: [],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
       },
     ]);
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -1,0 +1,134 @@
+import { processIndex } from '../../utils/process-index';
+import { CodeGenModel } from '../../visitors/appsync-visitor';
+
+describe('processIndex', () => {
+  it('should add multiple compound @index directives as model key attributes', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: [],
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItem',
+                sortKeyFields: ['sortField'],
+              },
+            },
+          ],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherConnection',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byAnother',
+                sortKeyFields: ['anotherSortField'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: [],
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItem',
+          fields: ['connectionField', 'sortField'],
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byAnother',
+          fields: ['anotherConnection', 'anotherSortField'],
+        },
+      },
+    ]);
+  });
+
+  it('should add simple @index directives as model key attributes', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: [],
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItem',
+              },
+            },
+          ],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherConnection',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byAnother',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: [],
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItem',
+          fields: ['connectionField'],
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byAnother',
+          fields: ['anotherConnection'],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
@@ -112,4 +112,39 @@ describe('processPrimaryKey', () => {
       },
     ]);
   });
+
+  it('does not add duplicate primaryKey', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+        {
+          name: 'key',
+          arguments: {
+            fields: ['primaryField'],
+          },
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'primaryField',
+          directives: [
+            {
+              name: 'primaryKey',
+              arguments: {},
+            },
+          ],
+        },
+      ],
+    };
+    processPrimaryKey(model);
+    expect(model.directives.length).toBe(2);
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
@@ -2,12 +2,12 @@ import { processPrimaryKey } from '../../utils/process-primary-key';
 import { CodeGenModel } from '../../visitors/appsync-visitor';
 
 describe('processPrimaryKey', () => {
-  it('should add compound @primaryKey directive as model key attributes', () => {
+  it('adds compound @primaryKey directive as model key attributes', () => {
     const model: CodeGenModel = {
       directives: [
         {
           name: 'model',
-          arguments: [],
+          arguments: {},
         },
       ],
       name: 'testModel',
@@ -33,7 +33,7 @@ describe('processPrimaryKey', () => {
     expect(model.directives).toEqual([
       {
         name: 'model',
-        arguments: [],
+        arguments: {},
       },
       {
         name: 'key',
@@ -44,12 +44,12 @@ describe('processPrimaryKey', () => {
     ]);
   });
 
-  it('should add simple @primaryKey directive as model key attributes', () => {
+  it('adds simple @primaryKey directive as model key attributes', () => {
     const model: CodeGenModel = {
       directives: [
         {
           name: 'model',
-          arguments: [],
+          arguments: {},
         },
       ],
       name: 'testModel',
@@ -73,13 +73,42 @@ describe('processPrimaryKey', () => {
     expect(model.directives).toEqual([
       {
         name: 'model',
-        arguments: [],
+        arguments: {},
       },
       {
         name: 'key',
         arguments: {
           fields: ['primaryField'],
         },
+      },
+    ]);
+  });
+
+  it('does nothing if no @primaryKey directive in model', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'normalField',
+          directives: [],
+        },
+      ],
+    };
+    processPrimaryKey(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
       },
     ]);
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-primary-key.test.ts
@@ -1,0 +1,86 @@
+import { processPrimaryKey } from '../../utils/process-primary-key';
+import { CodeGenModel } from '../../visitors/appsync-visitor';
+
+describe('processPrimaryKey', () => {
+  it('should add compound @primaryKey directive as model key attributes', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: [],
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'primaryField',
+          directives: [
+            {
+              name: 'primaryKey',
+              arguments: {
+                sortKeyFields: ['sortField'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processPrimaryKey(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: [],
+      },
+      {
+        name: 'key',
+        arguments: {
+          fields: ['primaryField', 'sortField'],
+        },
+      },
+    ]);
+  });
+
+  it('should add simple @primaryKey directive as model key attributes', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: [],
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'primaryField',
+          directives: [
+            {
+              name: 'primaryKey',
+              arguments: {},
+            },
+          ],
+        },
+      ],
+    };
+    processPrimaryKey(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: [],
+      },
+      {
+        name: 'key',
+        arguments: {
+          fields: ['primaryField'],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -345,6 +345,72 @@ describe('AppSyncModelVisitor', () => {
     });
   });
 
+  describe('index directives', () => {
+    it('processes index directive', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          id: ID!
+          name: String @index(name: "nameIndex", sortKeyFields: ["team"])
+          team: Team
+        }
+
+        type Team @model {
+          id: ID!
+          name: String! @index(name: "teamNameIndex")
+        }
+      `;
+      const visitor = createAndGenerateVisitor(schema, true);
+      visitor.generate();
+      const projectKeyDirective = visitor.models.Project.directives.find(directive => directive.name === 'key');
+      expect(projectKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          name: 'nameIndex',
+          fields: ['name', 'team'],
+        },
+      });
+      const teamKeyDirective = visitor.models.Team.directives.find(directive => directive.name === 'key');
+      expect(teamKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          name: 'teamNameIndex',
+          fields: ['name'],
+        },
+      });
+    });
+
+    it('processes primaryKey directive', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          id: ID!
+          name: String @primaryKey(sortKeyFields: ["team"])
+          team: Team
+        }
+
+        type Team @model {
+          id: ID!
+          name: String! @primaryKey
+        }
+      `;
+      const visitor = createAndGenerateVisitor(schema, true);
+      visitor.generate();
+      const projectKeyDirective = visitor.models.Project.directives.find(directive => directive.name === 'key');
+      expect(projectKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          fields: ['name', 'team'],
+        },
+      });
+      const teamKeyDirective = visitor.models.Team.directives.find(directive => directive.name === 'key');
+      expect(teamKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          fields: ['name'],
+        },
+      });
+    });
+  });
+
   describe('auth directive', () => {
     it('should process auth with owner authorization', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
@@ -1,4 +1,4 @@
-import { CodeGenField, CodeGenModel } from '../visitors/appsync-visitor';
+import { CodeGenDirective, CodeGenField, CodeGenModel } from '../visitors/appsync-visitor';
 
 export function addFieldToModel(model: CodeGenModel, field: CodeGenField): void {
   const existingField = model.fields.find(f => f.name === field.name);
@@ -8,5 +8,8 @@ export function addFieldToModel(model: CodeGenModel, field: CodeGenField): void 
 }
 
 export function removeFieldFromModel(model: CodeGenModel, fieldName: string): void {
-  model.fields= model.fields.filter(field => field.name !== fieldName);
+  model.fields = model.fields.filter(field => field.name !== fieldName);
 }
+
+export const getDirective = (fieldOrModel: CodeGenField | CodeGenModel) => (directiveName: string): CodeGenDirective | undefined =>
+  fieldOrModel.directives.find(d => d.name === directiveName);

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -1,22 +1,24 @@
 import { CodeGenField, CodeGenFieldDirective, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
-import {
-  CodeGenFieldConnection, DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives,
-  getDirective,
-  makeConnectionAttributeName,
-} from './process-connections';
+import { CodeGenFieldConnection, DEFAULT_HASH_KEY_FIELD, flattenFieldDirectives, makeConnectionAttributeName } from './process-connections';
 import { processHasOneConnection } from './process-has-one';
 import { processBelongsToConnection, getBelongsToConnectedField } from './process-belongs-to';
 import { processHasManyConnection } from './process-has-many';
+import { getDirective } from './fieldUtils';
 
 // TODO: This file holds several references to utility functions in the v1 process connections file, those functions need to go here before that file is removed
 
-export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel, directiveName: string): CodeGenField {
+export function getConnectedFieldV2(
+  field: CodeGenField,
+  model: CodeGenModel,
+  connectedModel: CodeGenModel,
+  directiveName: string,
+): CodeGenField {
   const connectionInfo = getDirective(field)(directiveName);
   if (!connectionInfo) {
     throw new Error(`The ${field.name} on model ${model.name} is not connected`);
   }
 
-  if(connectionInfo.name === 'belongsTo') {
+  if (connectionInfo.name === 'belongsTo') {
     let connectedFieldBelongsTo = getBelongsToConnectedField(field, model, connectedModel);
     if (connectedFieldBelongsTo) {
       return connectedFieldBelongsTo;
@@ -43,12 +45,20 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
     }
 
     // when there is a fields argument in the connection
-    const connectedFieldName = indexDirective ? ((fieldDir: CodeGenFieldDirective) => { return fieldDir.fieldName ;})(indexDirective as CodeGenFieldDirective) : DEFAULT_HASH_KEY_FIELD;
+    const connectedFieldName = indexDirective
+      ? ((fieldDir: CodeGenFieldDirective) => {
+          return fieldDir.fieldName;
+        })(indexDirective as CodeGenFieldDirective)
+      : DEFAULT_HASH_KEY_FIELD;
 
     // Find a field on the other side which connected by a @connection and has the same fields[0] as indexName field
     const otherSideConnectedField = connectedModel.fields.find(f => {
       return f.directives.find(d => {
-        return (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') && d.arguments.fields && d.arguments.fields[0] === connectedFieldName;
+        return (
+          (d.name === 'belongsTo' || d.name === 'hasOne' || d.name === 'hasMany') &&
+          d.arguments.fields &&
+          d.arguments.fields[0] === connectedFieldName
+        );
       });
     });
     if (otherSideConnectedField) {
@@ -68,14 +78,13 @@ export function getConnectedFieldV2(field: CodeGenField, model: CodeGenModel, co
   return connectedField
     ? connectedField
     : {
-      name: connectedFieldName,
-      directives: [],
-      type: 'ID',
-      isList: false,
-      isNullable: true,
-    };
+        name: connectedFieldName,
+        directives: [],
+        type: 'ID',
+        isList: false,
+        isNullable: true,
+      };
 }
-
 
 export function processConnectionsV2(
   field: CodeGenField,
@@ -84,9 +93,8 @@ export function processConnectionsV2(
 ): CodeGenFieldConnection | undefined {
   const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
 
-  if(connectionDirective) {
-
-    switch(connectionDirective.name) {
+  if (connectionDirective) {
+    switch (connectionDirective.name) {
       case 'hasOne':
         return processHasOneConnection(field, model, modelMap, connectionDirective);
       case 'belongsTo':

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -1,5 +1,6 @@
 import { CodeGenModel, CodeGenModelMap, CodeGenField, CodeGenDirective, CodeGenFieldDirective } from '../visitors/appsync-visitor';
 import { camelCase } from 'change-case';
+import { getDirective } from './fieldUtils';
 
 export enum CodeGenConnectionType {
   HAS_ONE = 'HAS_ONE',
@@ -30,11 +31,6 @@ export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
 
 export type CodeGenFieldConnection = CodeGenFieldConnectionBelongsTo | CodeGenFieldConnectionHasOne | CodeGenFieldConnectionHasMany;
 
-export function getDirective(fieldOrModel: CodeGenField | CodeGenModel) {
-  return (directiveName: string): CodeGenDirective | undefined => {
-    return fieldOrModel.directives.find(d => d.name === directiveName);
-  };
-}
 export function makeConnectionAttributeName(type: string, field?: string) {
   // The same logic is used graphql-connection-transformer package to generate association field
   // Make sure the logic gets update in that package
@@ -48,7 +44,7 @@ export function flattenFieldDirectives(model: CodeGenModel) {
       let fieldDir = dir as CodeGenFieldDirective;
       fieldDir.fieldName = field.name;
       totalDirectives.push(fieldDir);
-    })
+    });
   });
   return totalDirectives;
 }

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -14,12 +14,16 @@ export const processIndex = (model: CodeGenModel) => {
     return { ...acc, [field.name]: indexDirective };
   }, {} as Record<string, CodeGenDirective>);
 
-  const keyList = Object.entries(indexMap).map(([fieldName, directive]) => ({
+  const keyList: CodeGenDirective[] = Object.entries(indexMap).map(([fieldName, directive]) => ({
     name: 'key',
     arguments: {
       name: directive.arguments.name,
       fields: [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? []),
     },
-  })) as CodeGenDirective[];
-  model.directives.push(...keyList);
+  }));
+  const existingIndexNames = model.directives
+    .filter(directive => directive.name === 'key' && !!directive.arguments.name)
+    .map(directive => directive.arguments.name);
+  const deDupedKeyList = keyList.filter(key => !existingIndexNames.includes(key.arguments.name));
+  model.directives.push(...deDupedKeyList);
 };

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -1,0 +1,25 @@
+import { CodeGenDirective, CodeGenModel } from '../visitors/appsync-visitor';
+import { getDirective } from './fieldUtils';
+
+/**
+ * Maps @index directives back to how they would be represented with the old @key directive
+ * @param model The model to process
+ */
+export const processIndex = (model: CodeGenModel) => {
+  const indexMap = model.fields.reduce((acc, field) => {
+    const indexDirective = getDirective(field)('index');
+    if (!indexDirective) {
+      return acc;
+    }
+    return { ...acc, [field.name]: indexDirective };
+  }, {} as Record<string, CodeGenDirective>);
+
+  const keyList = Object.entries(indexMap).map(([fieldName, directive]) => ({
+    name: 'key',
+    arguments: {
+      name: directive.arguments.name,
+      fields: [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? []),
+    },
+  })) as CodeGenDirective[];
+  model.directives.push(...keyList);
+};

--- a/packages/appsync-modelgen-plugin/src/utils/process-primary-key.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-primary-key.ts
@@ -1,0 +1,17 @@
+import { CodeGenModel } from '../visitors/appsync-visitor';
+import { getDirective } from './fieldUtils';
+
+export const processPrimaryKey = (model: CodeGenModel) => {
+  const primaryKeyField = model.fields.find(field => getDirective(field)('primaryKey'));
+  if (!primaryKeyField) {
+    return;
+  }
+  const primaryKeyDirective = getDirective(primaryKeyField)('primaryKey')!;
+  model.directives.push({
+    name: 'key',
+    arguments: {
+      name: primaryKeyDirective.arguments.name,
+      fields: [primaryKeyField.name].concat((primaryKeyDirective.arguments.sortKeyFields as string[]) ?? []),
+    },
+  });
+};

--- a/packages/appsync-modelgen-plugin/src/utils/process-primary-key.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-primary-key.ts
@@ -1,7 +1,17 @@
 import { CodeGenModel } from '../visitors/appsync-visitor';
 import { getDirective } from './fieldUtils';
 
+/**
+ * Maps @primaryKey directives back to how they would be represented with the old @key directive
+ * @param model The model to translate
+ */
 export const processPrimaryKey = (model: CodeGenModel) => {
+  const alreadyHasPrimaryKeySanityCheck = model.directives.some(
+    directive => directive.name === 'key' && directive.arguments.name === undefined,
+  );
+  if (alreadyHasPrimaryKeySanityCheck) {
+    return;
+  }
   const primaryKeyField = model.fields.find(field => getDirective(field)('primaryKey'));
   if (!primaryKeyField) {
     return;
@@ -10,7 +20,6 @@ export const processPrimaryKey = (model: CodeGenModel) => {
   model.directives.push({
     name: 'key',
     arguments: {
-      name: primaryKeyDirective.arguments.name,
       fields: [primaryKeyField.name].concat((primaryKeyDirective.arguments.sortKeyFields as string[]) ?? []),
     },
   });

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -772,40 +772,6 @@ export class AppSyncModelJavaVisitor<
       return '';
     });
 
-    var modelLevelFieldAnnotations: string[] = new Array<string>();
-    model.fields.forEach(field => {
-      field.directives.forEach(directive => {
-        switch (directive.name) {
-          case 'primaryKey':
-            if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
-              const keyArgs: string[] = [];
-              keyArgs.push(`name = "undefined"`);
-              if (!directive.arguments.sortKeyFields) {
-                directive.arguments.sortKeyFields = new Array<string>();
-              }
-              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
-              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
-              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
-            }
-            break;
-          case 'index':
-            if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
-              const keyArgs: string[] = [];
-              keyArgs.push(`name = "${directive.arguments.name}"`);
-              if (!directive.arguments.sortKeyFields) {
-                directive.arguments.sortKeyFields = new Array<string>();
-              }
-              directive.arguments.sortKeyFields = [field.name, ...directive.arguments.sortKeyFields];
-              keyArgs.push(`fields = {${(directive.arguments.sortKeyFields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
-              modelLevelFieldAnnotations.push(`Index(${keyArgs.join(', ')})`);
-            }
-            break;
-          default:
-            break;
-        }
-      });
-    });
-    annotations.push(...modelLevelFieldAnnotations);
     return ['SuppressWarnings("all")', ...annotations].filter(annotation => annotation);
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -762,13 +762,10 @@ export class AppSyncModelJavaVisitor<
           }
           return `ModelConfig(${modelArgs.join(', ')})`;
         case 'key':
-          if (!(this.config.usePipelinedTransformer || this.config.transformerVersion === 2)) {
-            const keyArgs: string[] = [];
-            keyArgs.push(`name = "${directive.arguments.name}"`);
-            keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
-            return `Index(${keyArgs.join(', ')})`;
-          }
-          break;
+          const keyArgs: string[] = [];
+          keyArgs.push(`name = "${directive.arguments.name}"`);
+          keyArgs.push(`fields = {${(directive.arguments.fields as string[]).map((f: string) => `"${f}"`).join(',')}}`);
+          return `Index(${keyArgs.join(', ')})`;
         default:
           break;
       }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -41,7 +41,7 @@ export interface ParsedAppSyncModelSwiftConfig extends ParsedAppSyncModelConfig 
 export class AppSyncSwiftVisitor<
   TRawConfig extends RawAppSyncModelSwiftConfig = RawAppSyncModelSwiftConfig,
   TPluginConfig extends ParsedAppSyncModelSwiftConfig = ParsedAppSyncModelSwiftConfig
-  > extends AppSyncModelVisitor<TRawConfig, TPluginConfig> {
+> extends AppSyncModelVisitor<TRawConfig, TPluginConfig> {
   protected modelExtensionImports: string[] = ['import Amplify', 'import Foundation'];
   protected imports: string[] = ['import Amplify', 'import Foundation'];
 
@@ -441,49 +441,13 @@ export class AppSyncSwiftVisitor<
   }
 
   protected generateKeyRules(model: CodeGenModel): string[] {
-    let keyDirectives: string[];
-
-    if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
-      let fieldDirectiveList: any[] = new Array<any>();
-      model.fields.forEach(field => {
-        field.directives.forEach(directive => {
-          fieldDirectiveList.push({
-            fieldName: field.name,
-            directive: directive
-          });
-        });
+    return model.directives
+      .filter(directive => directive.name === 'key')
+      .map(directive => {
+        const name = directive.arguments.name ? `"${directive.arguments.name}"` : 'nil';
+        const fields: string = directive.arguments.fields.map((field: string) => `"${field}"`).join(', ');
+        return `.index(fields: [${fields}], name: ${name})`;
       });
-
-      keyDirectives = fieldDirectiveList
-        .filter(directiveObj => directiveObj.directive.name === 'primaryKey' || directiveObj.directive.name === 'index')
-        .map(directiveObj => {
-          switch(directiveObj.directive.name) {
-            case 'index':
-            case 'primaryKey':
-              const name = directiveObj.directive.arguments.name ? `"${directiveObj.directive.arguments.name}"` : 'nil';
-              if (!directiveObj.directive.arguments.sortKeyFields) {
-                directiveObj.directive.arguments.sortKeyFields = new Array<string>();
-              }
-              directiveObj.directive.arguments.sortKeyFields = [directiveObj.fieldName, ...directiveObj.directive.arguments.sortKeyFields]
-              const fields: string = directiveObj.directive.arguments.sortKeyFields.map((field: string) => `"${field}"`).join(', ');
-              return `.index(fields: [${fields}], name: ${name})`;
-            default:
-              break;
-          }
-          return '';
-      });
-    }
-    else {
-      keyDirectives = model.directives
-        .filter(directive => directive.name === 'key')
-        .map(directive => {
-          const name = directive.arguments.name ? `"${directive.arguments.name}"` : 'nil';
-          const fields: string = directive.arguments.fields.map((field: string) => `"${field}"`).join(', ');
-          return `.index(fields: [${fields}], name: ${name})`;
-        });
-    }
-
-    return keyDirectives;
   }
 
   protected isHasManyConnectionField(field: CodeGenField): boolean {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -295,8 +295,8 @@ export class AppSyncModelVisitor<
     };
   }
   processDirectives() {
-    this.processV2KeyDirectives();
     if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
+      this.processV2KeyDirectives();
       this.processConnectionDirectivesV2();
     } else {
       this.processConnectionDirective();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Maps new @index and @primaryKey directives back to their equivalent key representations to ensure the key attributes are not lost during the field pruning that happens when parsing connections.

The important chunks of logic are in `process-index.ts` and `process-primary-key.ts`. In these files, we look through all the fields on the model and if we find an `@index` or `@primaryKey`, respectively, we translate that into a "key" directive and attach it to the model. This allows other downstream codegen components to generate keys as they always have.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Description of how you validated changes
Added unit tests and verified the v2 codegen output of Android, iOS, JS, and Flutter are identical to the output of an equivalent v1 schema.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.