### PR TITLE
fix(graphql): allow aws_lambda directive

### DIFF
--- a/packages/amplify-codegen/awsAppSyncDirectives.graphql
+++ b/packages/amplify-codegen/awsAppSyncDirectives.graphql
@@ -18,5 +18,6 @@ directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITI
 directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
 directive @aws_api_key on FIELD_DEFINITION | OBJECT
 directive @aws_iam on FIELD_DEFINITION | OBJECT
+directive @aws_lambda on FIELD_DEFINITION | OBJECT
 directive @aws_oidc on FIELD_DEFINITION | OBJECT
 directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT

--- a/packages/graphql-docs-generator/awsAppSyncDirectives.graphql
+++ b/packages/graphql-docs-generator/awsAppSyncDirectives.graphql
@@ -19,4 +19,5 @@ directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
 directive @aws_api_key on FIELD_DEFINITION | OBJECT
 directive @aws_iam on FIELD_DEFINITION | OBJECT
 directive @aws_oidc on FIELD_DEFINITION | OBJECT
+directive @aws_lambda on FIELD_DEFINITION | OBJECT
 directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT

--- a/packages/graphql-docs-generator/awsAppSyncDirectives.graphql
+++ b/packages/graphql-docs-generator/awsAppSyncDirectives.graphql
@@ -18,6 +18,6 @@ directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITI
 directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
 directive @aws_api_key on FIELD_DEFINITION | OBJECT
 directive @aws_iam on FIELD_DEFINITION | OBJECT
-directive @aws_oidc on FIELD_DEFINITION | OBJECT
 directive @aws_lambda on FIELD_DEFINITION | OBJECT
+directive @aws_oidc on FIELD_DEFINITION | OBJECT
 directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT

--- a/packages/graphql-types-generator/awsAppSyncDirectives.graphql
+++ b/packages/graphql-types-generator/awsAppSyncDirectives.graphql
@@ -18,5 +18,6 @@ directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITI
 directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
 directive @aws_api_key on FIELD_DEFINITION | OBJECT
 directive @aws_iam on FIELD_DEFINITION | OBJECT
+directive @aws_lambda on FIELD_DEFINITION | OBJECT
 directive @aws_oidc on FIELD_DEFINITION | OBJECT
 directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT


### PR DESCRIPTION
#### Description of changes
AppSync introduced new directive to support Lambda authorizer mode. Add @aws_lambda directive to allowed directives list.

#### Description of how you validated changes
- Test with CLI
- yarn test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.