### PR TITLE
Hasone nonnull field fix

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -339,8 +339,9 @@ describe('AppSyncModelVisitor', () => {
       );
       visit(ast, { leave: visitor });
       visitor.generate();
-      const projectFields = visitor.models.Project.fields.map(field => field.name);
-      expect(projectFields).toContain('projectTeamId');
+      const projectTeamIdField = visitor.models.Project.fields.find(field => { return field.name === 'projectTeamId'; });
+      expect(projectTeamIdField).toBeDefined();
+      expect(projectTeamIdField.isNullable).toBeTruthy();
     });
   });
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -691,7 +691,7 @@ export class AppSyncModelVisitor<
               directives: [],
               type: 'ID',
               isList: false,
-              isNullable: connectionInfo.associatedWith.isNullable,
+              isNullable: field.isNullable,
             });
           } else if (connectionInfo.targetName !== 'id') {
             // Need to remove the field that is targetName


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
For a hasOne connection on an optional field, codegen was creating a required connection field which didn't match the optional connection field in the compiled schema. This fixes that


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit testing and a sample flutter app which the bug was reported for


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.