### PR TITLE
feat(amplify-codegen): datastore and api support for @default directive

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1385,6 +1385,398 @@ class _PostTagsModelType extends ModelType<PostTags> {
 "
 `;
 
+exports[`AppSync Dart Visitor Model Directive Should generate a default values for a Model with @default directives 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
+
+import 'ModelProvider.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+/** This is an auto generated class representing the SimpleModel type in your schema. */
+@immutable
+class SimpleModel extends Model {
+  static const classType = const _SimpleModelModelType();
+  final String id;
+  final String stringValue;
+  final int intVal;
+  final double floatValue;
+  final bool booleanValue;
+  final String awsJsonValue;
+  final TemporalDate awsDateValue;
+  final TemporalTimestamp awsTimestampValue;
+  final String awsEmailValue;
+  final String awsURLValue;
+  final String awsPhoneValue;
+  final String awsIPAddressValue1;
+  final String awsIPAddressValue2;
+  final Tag enumValue;
+  final TemporalTime awsTimeValue;
+  final TemporalDateTime awsDateTime;
+
+  @override
+  getInstanceType() => classType;
+
+  @override
+  String getId() {
+    return id;
+  }
+
+  const SimpleModel._internal(
+      {@required this.id,
+      this.stringValue,
+      this.intVal,
+      this.floatValue,
+      this.booleanValue,
+      this.awsJsonValue,
+      this.awsDateValue,
+      this.awsTimestampValue,
+      this.awsEmailValue,
+      this.awsURLValue,
+      this.awsPhoneValue,
+      this.awsIPAddressValue1,
+      this.awsIPAddressValue2,
+      this.enumValue,
+      this.awsTimeValue,
+      this.awsDateTime});
+
+  factory SimpleModel(
+      {String id,
+      String stringValue,
+      int intVal,
+      double floatValue,
+      bool booleanValue,
+      String awsJsonValue,
+      TemporalDate awsDateValue,
+      TemporalTimestamp awsTimestampValue,
+      String awsEmailValue,
+      String awsURLValue,
+      String awsPhoneValue,
+      String awsIPAddressValue1,
+      String awsIPAddressValue2,
+      Tag enumValue,
+      TemporalTime awsTimeValue,
+      TemporalDateTime awsDateTime}) {
+    return SimpleModel._internal(
+        id: id == null ? UUID.getUUID() : id,
+        stringValue: stringValue == null ? \\"hello world\\" : stringValue,
+        intVal: intVal == null ? 10002000 : intVal,
+        floatValue: floatValue == null ? 123456.34565 : floatValue,
+        booleanValue: booleanValue == null ? true : booleanValue,
+        awsJsonValue: awsJsonValue == null
+            ? \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\"
+            : awsJsonValue,
+        awsDateValue: awsDateValue == null
+            ? TemporalDate.fromString(\\"2016-01-29\\")
+            : awsDateValue,
+        awsTimestampValue: awsTimestampValue == null
+            ? TemporalTimestamp.fromSeconds(545345345)
+            : awsTimestampValue,
+        awsEmailValue:
+            awsEmailValue == null ? \\"local-part@domain-part\\" : awsEmailValue,
+        awsURLValue: awsURLValue == null
+            ? \\"https://www.amazon.com/dp/B000NZW3KC/\\"
+            : awsURLValue,
+        awsPhoneValue:
+            awsPhoneValue == null ? \\"+41 44 668 18 00\\" : awsPhoneValue,
+        awsIPAddressValue1:
+            awsIPAddressValue1 == null ? \\"123.12.34.56\\" : awsIPAddressValue1,
+        awsIPAddressValue2: awsIPAddressValue2 == null
+            ? \\"1a2b:3c4b::1234:4567\\"
+            : awsIPAddressValue2,
+        enumValue: enumValue == null ? Tag.RANDOM : enumValue,
+        awsTimeValue: awsTimeValue == null
+            ? TemporalTime.fromString(\\"12:00:34Z\\")
+            : awsTimeValue,
+        awsDateTime: awsDateTime == null
+            ? TemporalDateTime.fromString(\\"2007-04-05T14:30:34Z\\")
+            : awsDateTime);
+  }
+
+  bool equals(Object other) {
+    return this == other;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SimpleModel &&
+        id == other.id &&
+        stringValue == other.stringValue &&
+        intVal == other.intVal &&
+        floatValue == other.floatValue &&
+        booleanValue == other.booleanValue &&
+        awsJsonValue == other.awsJsonValue &&
+        awsDateValue == other.awsDateValue &&
+        awsTimestampValue == other.awsTimestampValue &&
+        awsEmailValue == other.awsEmailValue &&
+        awsURLValue == other.awsURLValue &&
+        awsPhoneValue == other.awsPhoneValue &&
+        awsIPAddressValue1 == other.awsIPAddressValue1 &&
+        awsIPAddressValue2 == other.awsIPAddressValue2 &&
+        enumValue == other.enumValue &&
+        awsTimeValue == other.awsTimeValue &&
+        awsDateTime == other.awsDateTime;
+  }
+
+  @override
+  int get hashCode => toString().hashCode;
+
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+
+    buffer.write(\\"SimpleModel {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"stringValue=\\" + \\"$stringValue\\" + \\", \\");
+    buffer.write(
+        \\"intVal=\\" + (intVal != null ? intVal.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"floatValue=\\" +
+        (floatValue != null ? floatValue.toString() : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"booleanValue=\\" +
+        (booleanValue != null ? booleanValue.toString() : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"awsJsonValue=\\" + \\"$awsJsonValue\\" + \\", \\");
+    buffer.write(\\"awsDateValue=\\" +
+        (awsDateValue != null ? awsDateValue.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"awsTimestampValue=\\" +
+        (awsTimestampValue != null ? awsTimestampValue.toString() : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"awsEmailValue=\\" + \\"$awsEmailValue\\" + \\", \\");
+    buffer.write(\\"awsURLValue=\\" + \\"$awsURLValue\\" + \\", \\");
+    buffer.write(\\"awsPhoneValue=\\" + \\"$awsPhoneValue\\" + \\", \\");
+    buffer.write(\\"awsIPAddressValue1=\\" + \\"$awsIPAddressValue1\\" + \\", \\");
+    buffer.write(\\"awsIPAddressValue2=\\" + \\"$awsIPAddressValue2\\" + \\", \\");
+    buffer.write(\\"enumValue=\\" +
+        (enumValue != null ? enumToString(enumValue) : \\"null\\") +
+        \\", \\");
+    buffer.write(\\"awsTimeValue=\\" +
+        (awsTimeValue != null ? awsTimeValue.format() : \\"null\\") +
+        \\", \\");
+    buffer.write(
+        \\"awsDateTime=\\" + (awsDateTime != null ? awsDateTime.format() : \\"null\\"));
+    buffer.write(\\"}\\");
+
+    return buffer.toString();
+  }
+
+  SimpleModel copyWith(
+      {String id,
+      String stringValue,
+      int intVal,
+      double floatValue,
+      bool booleanValue,
+      String awsJsonValue,
+      TemporalDate awsDateValue,
+      TemporalTimestamp awsTimestampValue,
+      String awsEmailValue,
+      String awsURLValue,
+      String awsPhoneValue,
+      String awsIPAddressValue1,
+      String awsIPAddressValue2,
+      Tag enumValue,
+      TemporalTime awsTimeValue,
+      TemporalDateTime awsDateTime}) {
+    return SimpleModel(
+        id: id ?? this.id,
+        stringValue: stringValue ?? this.stringValue,
+        intVal: intVal ?? this.intVal,
+        floatValue: floatValue ?? this.floatValue,
+        booleanValue: booleanValue ?? this.booleanValue,
+        awsJsonValue: awsJsonValue ?? this.awsJsonValue,
+        awsDateValue: awsDateValue ?? this.awsDateValue,
+        awsTimestampValue: awsTimestampValue ?? this.awsTimestampValue,
+        awsEmailValue: awsEmailValue ?? this.awsEmailValue,
+        awsURLValue: awsURLValue ?? this.awsURLValue,
+        awsPhoneValue: awsPhoneValue ?? this.awsPhoneValue,
+        awsIPAddressValue1: awsIPAddressValue1 ?? this.awsIPAddressValue1,
+        awsIPAddressValue2: awsIPAddressValue2 ?? this.awsIPAddressValue2,
+        enumValue: enumValue ?? this.enumValue,
+        awsTimeValue: awsTimeValue ?? this.awsTimeValue,
+        awsDateTime: awsDateTime ?? this.awsDateTime);
+  }
+
+  SimpleModel.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        stringValue = json['stringValue'],
+        intVal = (json['intVal'] as num)?.toInt(),
+        floatValue = (json['floatValue'] as num)?.toDouble(),
+        booleanValue = json['booleanValue'],
+        awsJsonValue = json['awsJsonValue'],
+        awsDateValue = json['awsDateValue'] != null
+            ? TemporalDate.fromString(json['awsDateValue'])
+            : null,
+        awsTimestampValue = json['awsTimestampValue'] != null
+            ? TemporalTimestamp.fromSeconds(json['awsTimestampValue'])
+            : null,
+        awsEmailValue = json['awsEmailValue'],
+        awsURLValue = json['awsURLValue'],
+        awsPhoneValue = json['awsPhoneValue'],
+        awsIPAddressValue1 = json['awsIPAddressValue1'],
+        awsIPAddressValue2 = json['awsIPAddressValue2'],
+        enumValue = enumFromString<Tag>(json['enumValue'], Tag.values),
+        awsTimeValue = json['awsTimeValue'] != null
+            ? TemporalTime.fromString(json['awsTimeValue'])
+            : null,
+        awsDateTime = json['awsDateTime'] != null
+            ? TemporalDateTime.fromString(json['awsDateTime'])
+            : null;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'stringValue': stringValue,
+        'intVal': intVal,
+        'floatValue': floatValue,
+        'booleanValue': booleanValue,
+        'awsJsonValue': awsJsonValue,
+        'awsDateValue': awsDateValue?.format(),
+        'awsTimestampValue': awsTimestampValue?.toSeconds(),
+        'awsEmailValue': awsEmailValue,
+        'awsURLValue': awsURLValue,
+        'awsPhoneValue': awsPhoneValue,
+        'awsIPAddressValue1': awsIPAddressValue1,
+        'awsIPAddressValue2': awsIPAddressValue2,
+        'enumValue': enumToString(enumValue),
+        'awsTimeValue': awsTimeValue?.format(),
+        'awsDateTime': awsDateTime?.format()
+      };
+
+  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField STRINGVALUE = QueryField(fieldName: \\"stringValue\\");
+  static final QueryField INTVAL = QueryField(fieldName: \\"intVal\\");
+  static final QueryField FLOATVALUE = QueryField(fieldName: \\"floatValue\\");
+  static final QueryField BOOLEANVALUE = QueryField(fieldName: \\"booleanValue\\");
+  static final QueryField AWSJSONVALUE = QueryField(fieldName: \\"awsJsonValue\\");
+  static final QueryField AWSDATEVALUE = QueryField(fieldName: \\"awsDateValue\\");
+  static final QueryField AWSTIMESTAMPVALUE =
+      QueryField(fieldName: \\"awsTimestampValue\\");
+  static final QueryField AWSEMAILVALUE =
+      QueryField(fieldName: \\"awsEmailValue\\");
+  static final QueryField AWSURLVALUE = QueryField(fieldName: \\"awsURLValue\\");
+  static final QueryField AWSPHONEVALUE =
+      QueryField(fieldName: \\"awsPhoneValue\\");
+  static final QueryField AWSIPADDRESSVALUE1 =
+      QueryField(fieldName: \\"awsIPAddressValue1\\");
+  static final QueryField AWSIPADDRESSVALUE2 =
+      QueryField(fieldName: \\"awsIPAddressValue2\\");
+  static final QueryField ENUMVALUE = QueryField(fieldName: \\"enumValue\\");
+  static final QueryField AWSTIMEVALUE = QueryField(fieldName: \\"awsTimeValue\\");
+  static final QueryField AWSDATETIME = QueryField(fieldName: \\"awsDateTime\\");
+  static var schema =
+      Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"SimpleModel\\";
+    modelSchemaDefinition.pluralName = \\"SimpleModels\\";
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.STRINGVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.INTVAL,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.int)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.FLOATVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.double)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.BOOLEANVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.bool)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSJSONVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSDATEVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.date)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSTIMESTAMPVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.timestamp)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSEMAILVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSURLVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSPHONEVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSIPADDRESSVALUE1,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSIPADDRESSVALUE2,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.ENUMVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.enumeration)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSTIMEVALUE,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.time)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: SimpleModel.AWSDATETIME,
+        isRequired: false,
+        ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)));
+  });
+}
+
+class _SimpleModelModelType extends ModelType<SimpleModel> {
+  const _SimpleModelModelType();
+
+  @override
+  SimpleModel fromJson(Map<String, dynamic> jsonData) {
+    return SimpleModel.fromJson(jsonData);
+  }
+}
+"
+`;
+
 exports[`AppSync Dart Visitor Model Directive should generate a class for a Simple Model 1`] = `
 "/*
 * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -3485,6 +3485,562 @@ public final class SimpleModel implements Model {
 "
 `;
 
+exports[`AppSyncModelVisitor Should generate a default values for a Model with @default directives 1`] = `
+"package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the SimpleModel type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"SimpleModels\\")
+public final class SimpleModel implements Model {
+  public static final QueryField ID = field(\\"SimpleModel\\", \\"id\\");
+  public static final QueryField STRING_VALUE = field(\\"SimpleModel\\", \\"stringValue\\");
+  public static final QueryField INT_VAL = field(\\"SimpleModel\\", \\"intVal\\");
+  public static final QueryField FLOAT_VALUE = field(\\"SimpleModel\\", \\"floatValue\\");
+  public static final QueryField BOOLEAN_VALUE = field(\\"SimpleModel\\", \\"booleanValue\\");
+  public static final QueryField AWS_JSON_VALUE = field(\\"SimpleModel\\", \\"awsJsonValue\\");
+  public static final QueryField AWS_DATE_VALUE = field(\\"SimpleModel\\", \\"awsDateValue\\");
+  public static final QueryField AWS_TIMESTAMP_VALUE = field(\\"SimpleModel\\", \\"awsTimestampValue\\");
+  public static final QueryField AWS_EMAIL_VALUE = field(\\"SimpleModel\\", \\"awsEmailValue\\");
+  public static final QueryField AWS_URL_VALUE = field(\\"SimpleModel\\", \\"awsURLValue\\");
+  public static final QueryField AWS_PHONE_VALUE = field(\\"SimpleModel\\", \\"awsPhoneValue\\");
+  public static final QueryField AWS_IP_ADDRESS_VALUE1 = field(\\"SimpleModel\\", \\"awsIPAddressValue1\\");
+  public static final QueryField AWS_IP_ADDRESS_VALUE2 = field(\\"SimpleModel\\", \\"awsIPAddressValue2\\");
+  public static final QueryField ENUM_VALUE = field(\\"SimpleModel\\", \\"enumValue\\");
+  public static final QueryField AWS_TIME_VALUE = field(\\"SimpleModel\\", \\"awsTimeValue\\");
+  public static final QueryField AWS_DATE_TIME = field(\\"SimpleModel\\", \\"awsDateTime\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"String\\") String stringValue;
+  private final @ModelField(targetType=\\"Int\\") Integer intVal;
+  private final @ModelField(targetType=\\"Float\\") Double floatValue;
+  private final @ModelField(targetType=\\"Boolean\\") Boolean booleanValue;
+  private final @ModelField(targetType=\\"AWSJSON\\") String awsJsonValue;
+  private final @ModelField(targetType=\\"AWSDate\\") Temporal.Date awsDateValue;
+  private final @ModelField(targetType=\\"AWSTimestamp\\") Temporal.Timestamp awsTimestampValue;
+  private final @ModelField(targetType=\\"AWSEmail\\") String awsEmailValue;
+  private final @ModelField(targetType=\\"AWSURL\\") String awsURLValue;
+  private final @ModelField(targetType=\\"AWSPhone\\") String awsPhoneValue;
+  private final @ModelField(targetType=\\"AWSIPAddress\\") String awsIPAddressValue1;
+  private final @ModelField(targetType=\\"AWSIPAddress\\") String awsIPAddressValue2;
+  private final @ModelField(targetType=\\"Tag\\") Tag enumValue;
+  private final @ModelField(targetType=\\"AWSTime\\") Temporal.Time awsTimeValue;
+  private final @ModelField(targetType=\\"AWSDateTime\\") Temporal.DateTime awsDateTime;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  public String getId() {
+      return id;
+  }
+  
+  public String getStringValue() {
+      return stringValue;
+  }
+  
+  public Integer getIntVal() {
+      return intVal;
+  }
+  
+  public Double getFloatValue() {
+      return floatValue;
+  }
+  
+  public Boolean getBooleanValue() {
+      return booleanValue;
+  }
+  
+  public String getAwsJsonValue() {
+      return awsJsonValue;
+  }
+  
+  public Temporal.Date getAwsDateValue() {
+      return awsDateValue;
+  }
+  
+  public Temporal.Timestamp getAwsTimestampValue() {
+      return awsTimestampValue;
+  }
+  
+  public String getAwsEmailValue() {
+      return awsEmailValue;
+  }
+  
+  public String getAwsUrlValue() {
+      return awsURLValue;
+  }
+  
+  public String getAwsPhoneValue() {
+      return awsPhoneValue;
+  }
+  
+  public String getAwsIpAddressValue1() {
+      return awsIPAddressValue1;
+  }
+  
+  public String getAwsIpAddressValue2() {
+      return awsIPAddressValue2;
+  }
+  
+  public Tag getEnumValue() {
+      return enumValue;
+  }
+  
+  public Temporal.Time getAwsTimeValue() {
+      return awsTimeValue;
+  }
+  
+  public Temporal.DateTime getAwsDateTime() {
+      return awsDateTime;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private SimpleModel(String id, String stringValue, Integer intVal, Double floatValue, Boolean booleanValue, String awsJsonValue, Temporal.Date awsDateValue, Temporal.Timestamp awsTimestampValue, String awsEmailValue, String awsURLValue, String awsPhoneValue, String awsIPAddressValue1, String awsIPAddressValue2, Tag enumValue, Temporal.Time awsTimeValue, Temporal.DateTime awsDateTime) {
+    this.id = id;
+    this.stringValue = stringValue;
+    this.intVal = intVal;
+    this.floatValue = floatValue;
+    this.booleanValue = booleanValue;
+    this.awsJsonValue = awsJsonValue;
+    this.awsDateValue = awsDateValue;
+    this.awsTimestampValue = awsTimestampValue;
+    this.awsEmailValue = awsEmailValue;
+    this.awsURLValue = awsURLValue;
+    this.awsPhoneValue = awsPhoneValue;
+    this.awsIPAddressValue1 = awsIPAddressValue1;
+    this.awsIPAddressValue2 = awsIPAddressValue2;
+    this.enumValue = enumValue;
+    this.awsTimeValue = awsTimeValue;
+    this.awsDateTime = awsDateTime;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      SimpleModel simpleModel = (SimpleModel) obj;
+      return ObjectsCompat.equals(getId(), simpleModel.getId()) &&
+              ObjectsCompat.equals(getStringValue(), simpleModel.getStringValue()) &&
+              ObjectsCompat.equals(getIntVal(), simpleModel.getIntVal()) &&
+              ObjectsCompat.equals(getFloatValue(), simpleModel.getFloatValue()) &&
+              ObjectsCompat.equals(getBooleanValue(), simpleModel.getBooleanValue()) &&
+              ObjectsCompat.equals(getAwsJsonValue(), simpleModel.getAwsJsonValue()) &&
+              ObjectsCompat.equals(getAwsDateValue(), simpleModel.getAwsDateValue()) &&
+              ObjectsCompat.equals(getAwsTimestampValue(), simpleModel.getAwsTimestampValue()) &&
+              ObjectsCompat.equals(getAwsEmailValue(), simpleModel.getAwsEmailValue()) &&
+              ObjectsCompat.equals(getAwsUrlValue(), simpleModel.getAwsUrlValue()) &&
+              ObjectsCompat.equals(getAwsPhoneValue(), simpleModel.getAwsPhoneValue()) &&
+              ObjectsCompat.equals(getAwsIpAddressValue1(), simpleModel.getAwsIpAddressValue1()) &&
+              ObjectsCompat.equals(getAwsIpAddressValue2(), simpleModel.getAwsIpAddressValue2()) &&
+              ObjectsCompat.equals(getEnumValue(), simpleModel.getEnumValue()) &&
+              ObjectsCompat.equals(getAwsTimeValue(), simpleModel.getAwsTimeValue()) &&
+              ObjectsCompat.equals(getAwsDateTime(), simpleModel.getAwsDateTime()) &&
+              ObjectsCompat.equals(getCreatedAt(), simpleModel.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), simpleModel.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getStringValue())
+      .append(getIntVal())
+      .append(getFloatValue())
+      .append(getBooleanValue())
+      .append(getAwsJsonValue())
+      .append(getAwsDateValue())
+      .append(getAwsTimestampValue())
+      .append(getAwsEmailValue())
+      .append(getAwsUrlValue())
+      .append(getAwsPhoneValue())
+      .append(getAwsIpAddressValue1())
+      .append(getAwsIpAddressValue2())
+      .append(getEnumValue())
+      .append(getAwsTimeValue())
+      .append(getAwsDateTime())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"SimpleModel {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"stringValue=\\" + String.valueOf(getStringValue()) + \\", \\")
+      .append(\\"intVal=\\" + String.valueOf(getIntVal()) + \\", \\")
+      .append(\\"floatValue=\\" + String.valueOf(getFloatValue()) + \\", \\")
+      .append(\\"booleanValue=\\" + String.valueOf(getBooleanValue()) + \\", \\")
+      .append(\\"awsJsonValue=\\" + String.valueOf(getAwsJsonValue()) + \\", \\")
+      .append(\\"awsDateValue=\\" + String.valueOf(getAwsDateValue()) + \\", \\")
+      .append(\\"awsTimestampValue=\\" + String.valueOf(getAwsTimestampValue()) + \\", \\")
+      .append(\\"awsEmailValue=\\" + String.valueOf(getAwsEmailValue()) + \\", \\")
+      .append(\\"awsURLValue=\\" + String.valueOf(getAwsUrlValue()) + \\", \\")
+      .append(\\"awsPhoneValue=\\" + String.valueOf(getAwsPhoneValue()) + \\", \\")
+      .append(\\"awsIPAddressValue1=\\" + String.valueOf(getAwsIpAddressValue1()) + \\", \\")
+      .append(\\"awsIPAddressValue2=\\" + String.valueOf(getAwsIpAddressValue2()) + \\", \\")
+      .append(\\"enumValue=\\" + String.valueOf(getEnumValue()) + \\", \\")
+      .append(\\"awsTimeValue=\\" + String.valueOf(getAwsTimeValue()) + \\", \\")
+      .append(\\"awsDateTime=\\" + String.valueOf(getAwsDateTime()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static BuildStep builder() {
+      return new Builder();
+  }
+  
+  /** 
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static SimpleModel justId(String id) {
+    return new SimpleModel(
+      id,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      stringValue,
+      intVal,
+      floatValue,
+      booleanValue,
+      awsJsonValue,
+      awsDateValue,
+      awsTimestampValue,
+      awsEmailValue,
+      awsURLValue,
+      awsPhoneValue,
+      awsIPAddressValue1,
+      awsIPAddressValue2,
+      enumValue,
+      awsTimeValue,
+      awsDateTime);
+  }
+  public interface BuildStep {
+    SimpleModel build();
+    BuildStep id(String id);
+    BuildStep stringValue(String stringValue);
+    BuildStep intVal(Integer intVal);
+    BuildStep floatValue(Double floatValue);
+    BuildStep booleanValue(Boolean booleanValue);
+    BuildStep awsJsonValue(String awsJsonValue);
+    BuildStep awsDateValue(Temporal.Date awsDateValue);
+    BuildStep awsTimestampValue(Temporal.Timestamp awsTimestampValue);
+    BuildStep awsEmailValue(String awsEmailValue);
+    BuildStep awsUrlValue(String awsUrlValue);
+    BuildStep awsPhoneValue(String awsPhoneValue);
+    BuildStep awsIpAddressValue1(String awsIpAddressValue1);
+    BuildStep awsIpAddressValue2(String awsIpAddressValue2);
+    BuildStep enumValue(Tag enumValue);
+    BuildStep awsTimeValue(Temporal.Time awsTimeValue);
+    BuildStep awsDateTime(Temporal.DateTime awsDateTime);
+  }
+  
+
+  public static class Builder implements BuildStep {
+    private String id;
+    private String stringValue;
+    private Integer intVal;
+    private Double floatValue;
+    private Boolean booleanValue;
+    private String awsJsonValue;
+    private Temporal.Date awsDateValue;
+    private Temporal.Timestamp awsTimestampValue;
+    private String awsEmailValue;
+    private String awsURLValue;
+    private String awsPhoneValue;
+    private String awsIPAddressValue1;
+    private String awsIPAddressValue2;
+    private Tag enumValue;
+    private Temporal.Time awsTimeValue;
+    private Temporal.DateTime awsDateTime;
+    @Override
+     public SimpleModel build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        String stringValue = this.stringValue != null ? this.stringValue : \\"hello world\\";
+        Integer intVal = this.intVal != null ? this.intVal : 10002000;
+        Double floatValue = this.floatValue != null ? this.floatValue : 123456.34565;
+        Boolean booleanValue = this.booleanValue != null ? this.booleanValue : true;
+        String awsJsonValue = this.awsJsonValue != null ? this.awsJsonValue : \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\";
+        Temporal.Date awsDateValue = this.awsDateValue != null ? this.awsDateValue : new Temporal.Date(\\"2016-01-29\\");
+        Temporal.Timestamp awsTimestampValue = this.awsTimestampValue != null ? this.awsTimestampValue : new Temporal.Timestamp(new java.util.Date(545345345));
+        String awsEmailValue = this.awsEmailValue != null ? this.awsEmailValue : \\"local-part@domain-part\\";
+        String awsURLValue = this.awsURLValue != null ? this.awsURLValue : \\"https://www.amazon.com/dp/B000NZW3KC/\\";
+        String awsPhoneValue = this.awsPhoneValue != null ? this.awsPhoneValue : \\"+41 44 668 18 00\\";
+        String awsIPAddressValue1 = this.awsIPAddressValue1 != null ? this.awsIPAddressValue1 : \\"123.12.34.56\\";
+        String awsIPAddressValue2 = this.awsIPAddressValue2 != null ? this.awsIPAddressValue2 : \\"1a2b:3c4b::1234:4567\\";
+        Tag enumValue = this.enumValue != null ? this.enumValue : Tag.RANDOM;
+        Temporal.Time awsTimeValue = this.awsTimeValue != null ? this.awsTimeValue : new Temporal.Time(\\"12:00:34Z\\");
+        Temporal.DateTime awsDateTime = this.awsDateTime != null ? this.awsDateTime : new Temporal.DateTime(\\"2007-04-05T14:30:34Z\\");
+        
+        return new SimpleModel(
+          id,
+          stringValue,
+          intVal,
+          floatValue,
+          booleanValue,
+          awsJsonValue,
+          awsDateValue,
+          awsTimestampValue,
+          awsEmailValue,
+          awsURLValue,
+          awsPhoneValue,
+          awsIPAddressValue1,
+          awsIPAddressValue2,
+          enumValue,
+          awsTimeValue,
+          awsDateTime);
+    }
+    
+    @Override
+     public BuildStep stringValue(String stringValue) {
+        this.stringValue = stringValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep intVal(Integer intVal) {
+        this.intVal = intVal;
+        return this;
+    }
+    
+    @Override
+     public BuildStep floatValue(Double floatValue) {
+        this.floatValue = floatValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep booleanValue(Boolean booleanValue) {
+        this.booleanValue = booleanValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsJsonValue(String awsJsonValue) {
+        this.awsJsonValue = awsJsonValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsDateValue(Temporal.Date awsDateValue) {
+        this.awsDateValue = awsDateValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsTimestampValue(Temporal.Timestamp awsTimestampValue) {
+        this.awsTimestampValue = awsTimestampValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsEmailValue(String awsEmailValue) {
+        this.awsEmailValue = awsEmailValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsUrlValue(String awsUrlValue) {
+        this.awsURLValue = awsUrlValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsPhoneValue(String awsPhoneValue) {
+        this.awsPhoneValue = awsPhoneValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsIpAddressValue1(String awsIpAddressValue1) {
+        this.awsIPAddressValue1 = awsIpAddressValue1;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsIpAddressValue2(String awsIpAddressValue2) {
+        this.awsIPAddressValue2 = awsIpAddressValue2;
+        return this;
+    }
+    
+    @Override
+     public BuildStep enumValue(Tag enumValue) {
+        this.enumValue = enumValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsTimeValue(Temporal.Time awsTimeValue) {
+        this.awsTimeValue = awsTimeValue;
+        return this;
+    }
+    
+    @Override
+     public BuildStep awsDateTime(Temporal.DateTime awsDateTime) {
+        this.awsDateTime = awsDateTime;
+        return this;
+    }
+    
+    /** 
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, String stringValue, Integer intVal, Double floatValue, Boolean booleanValue, String awsJsonValue, Temporal.Date awsDateValue, Temporal.Timestamp awsTimestampValue, String awsEmailValue, String awsUrlValue, String awsPhoneValue, String awsIpAddressValue1, String awsIpAddressValue2, Tag enumValue, Temporal.Time awsTimeValue, Temporal.DateTime awsDateTime) {
+      super.id(id);
+      super.stringValue(stringValue)
+        .intVal(intVal)
+        .floatValue(floatValue)
+        .booleanValue(booleanValue)
+        .awsJsonValue(awsJsonValue)
+        .awsDateValue(awsDateValue)
+        .awsTimestampValue(awsTimestampValue)
+        .awsEmailValue(awsEmailValue)
+        .awsUrlValue(awsUrlValue)
+        .awsPhoneValue(awsPhoneValue)
+        .awsIpAddressValue1(awsIpAddressValue1)
+        .awsIpAddressValue2(awsIpAddressValue2)
+        .enumValue(enumValue)
+        .awsTimeValue(awsTimeValue)
+        .awsDateTime(awsDateTime);
+    }
+    
+    @Override
+     public CopyOfBuilder stringValue(String stringValue) {
+      return (CopyOfBuilder) super.stringValue(stringValue);
+    }
+    
+    @Override
+     public CopyOfBuilder intVal(Integer intVal) {
+      return (CopyOfBuilder) super.intVal(intVal);
+    }
+    
+    @Override
+     public CopyOfBuilder floatValue(Double floatValue) {
+      return (CopyOfBuilder) super.floatValue(floatValue);
+    }
+    
+    @Override
+     public CopyOfBuilder booleanValue(Boolean booleanValue) {
+      return (CopyOfBuilder) super.booleanValue(booleanValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsJsonValue(String awsJsonValue) {
+      return (CopyOfBuilder) super.awsJsonValue(awsJsonValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsDateValue(Temporal.Date awsDateValue) {
+      return (CopyOfBuilder) super.awsDateValue(awsDateValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsTimestampValue(Temporal.Timestamp awsTimestampValue) {
+      return (CopyOfBuilder) super.awsTimestampValue(awsTimestampValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsEmailValue(String awsEmailValue) {
+      return (CopyOfBuilder) super.awsEmailValue(awsEmailValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsUrlValue(String awsUrlValue) {
+      return (CopyOfBuilder) super.awsUrlValue(awsUrlValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsPhoneValue(String awsPhoneValue) {
+      return (CopyOfBuilder) super.awsPhoneValue(awsPhoneValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsIpAddressValue1(String awsIpAddressValue1) {
+      return (CopyOfBuilder) super.awsIpAddressValue1(awsIpAddressValue1);
+    }
+    
+    @Override
+     public CopyOfBuilder awsIpAddressValue2(String awsIpAddressValue2) {
+      return (CopyOfBuilder) super.awsIpAddressValue2(awsIpAddressValue2);
+    }
+    
+    @Override
+     public CopyOfBuilder enumValue(Tag enumValue) {
+      return (CopyOfBuilder) super.enumValue(enumValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsTimeValue(Temporal.Time awsTimeValue) {
+      return (CopyOfBuilder) super.awsTimeValue(awsTimeValue);
+    }
+    
+    @Override
+     public CopyOfBuilder awsDateTime(Temporal.DateTime awsDateTime) {
+      return (CopyOfBuilder) super.awsDateTime(awsDateTime);
+    }
+  }
+  
+}
+"
+`;
+
 exports[`AppSyncModelVisitor Should handle nullability of lists appropriately 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -7,6 +7,206 @@ import Foundation
 "
 `;
 
+exports[`AppSyncSwiftVisitor Should generate a default vales for a Model with @default directives 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct SimpleModel: Model {
+  public let id: String
+  public var stringValue: String?
+  public var intVal: Int?
+  public var floatValue: Double?
+  public var booleanValue: Bool?
+  public var awsJsonValue: String?
+  public var awsDateValue: Temporal.Date?
+  public var awsTimestampValue: Int?
+  public var awsEmailValue: String?
+  public var awsURLValue: String?
+  public var awsPhoneValue: String?
+  public var awsIPAddressValue1: String?
+  public var awsIPAddressValue2: String?
+  public var enumValue: Tag?
+  public var awsTimeValue: Temporal.Time?
+  public var awsDateTime: Temporal.DateTime?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      stringValue: String? = \\"hello world\\",
+      intVal: Int? = 10002000,
+      floatValue: Double? = 123456.34565,
+      booleanValue: Bool? = true,
+      awsJsonValue: String? = \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\",
+      awsDateValue: Temporal.Date? = try? Temporal.Date(iso8601String: \\"2016-01-29\\"),
+      awsTimestampValue: Int? = 545345345,
+      awsEmailValue: String? = \\"local-part@domain-part\\",
+      awsURLValue: String? = \\"https://www.amazon.com/dp/B000NZW3KC/\\",
+      awsPhoneValue: String? = \\"+41 44 668 18 00\\",
+      awsIPAddressValue1: String? = \\"123.12.34.56\\",
+      awsIPAddressValue2: String? = \\"1a2b:3c4b::1234:4567\\",
+      enumValue: Tag? = Tag.random,
+      awsTimeValue: Temporal.Time? = try? Temporal.Time(iso8601String: \\"12:00:34Z\\"),
+      awsDateTime: Temporal.DateTime? = try? Temporal.DateTime(iso8601String: \\"2007-04-05T14:30:34Z\\")) {
+    self.init(id: id,
+      stringValue: stringValue,
+      intVal: intVal,
+      floatValue: floatValue,
+      booleanValue: booleanValue,
+      awsJsonValue: awsJsonValue,
+      awsDateValue: awsDateValue,
+      awsTimestampValue: awsTimestampValue,
+      awsEmailValue: awsEmailValue,
+      awsURLValue: awsURLValue,
+      awsPhoneValue: awsPhoneValue,
+      awsIPAddressValue1: awsIPAddressValue1,
+      awsIPAddressValue2: awsIPAddressValue2,
+      enumValue: enumValue,
+      awsTimeValue: awsTimeValue,
+      awsDateTime: awsDateTime,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      stringValue: String? = \\"hello world\\",
+      intVal: Int? = 10002000,
+      floatValue: Double? = 123456.34565,
+      booleanValue: Bool? = true,
+      awsJsonValue: String? = \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\",
+      awsDateValue: Temporal.Date? = try? Temporal.Date(iso8601String: \\"2016-01-29\\"),
+      awsTimestampValue: Int? = 545345345,
+      awsEmailValue: String? = \\"local-part@domain-part\\",
+      awsURLValue: String? = \\"https://www.amazon.com/dp/B000NZW3KC/\\",
+      awsPhoneValue: String? = \\"+41 44 668 18 00\\",
+      awsIPAddressValue1: String? = \\"123.12.34.56\\",
+      awsIPAddressValue2: String? = \\"1a2b:3c4b::1234:4567\\",
+      enumValue: Tag? = Tag.random,
+      awsTimeValue: Temporal.Time? = try? Temporal.Time(iso8601String: \\"12:00:34Z\\"),
+      awsDateTime: Temporal.DateTime? = try? Temporal.DateTime(iso8601String: \\"2007-04-05T14:30:34Z\\"),
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.stringValue = stringValue
+      self.intVal = intVal
+      self.floatValue = floatValue
+      self.booleanValue = booleanValue
+      self.awsJsonValue = awsJsonValue
+      self.awsDateValue = awsDateValue
+      self.awsTimestampValue = awsTimestampValue
+      self.awsEmailValue = awsEmailValue
+      self.awsURLValue = awsURLValue
+      self.awsPhoneValue = awsPhoneValue
+      self.awsIPAddressValue1 = awsIPAddressValue1
+      self.awsIPAddressValue2 = awsIPAddressValue2
+      self.enumValue = enumValue
+      self.awsTimeValue = awsTimeValue
+      self.awsDateTime = awsDateTime
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should generate a default values for a Model with @default directives 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct SimpleModel: Model {
+  public let id: String
+  public var stringValue: String?
+  public var intVal: Int?
+  public var floatValue: Double?
+  public var booleanValue: Bool?
+  public var awsJsonValue: String?
+  public var awsDateValue: Temporal.Date?
+  public var awsTimestampValue: Int?
+  public var awsEmailValue: String?
+  public var awsURLValue: String?
+  public var awsPhoneValue: String?
+  public var awsIPAddressValue1: String?
+  public var awsIPAddressValue2: String?
+  public var enumValue: Tag?
+  public var awsTimeValue: Temporal.Time?
+  public var awsDateTime: Temporal.DateTime?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      stringValue: String? = \\"hello world\\",
+      intVal: Int? = 10002000,
+      floatValue: Double? = 123456.34565,
+      booleanValue: Bool? = true,
+      awsJsonValue: String? = \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\",
+      awsDateValue: Temporal.Date? = try? Temporal.Date(iso8601String: \\"2016-01-29\\"),
+      awsTimestampValue: Int? = 545345345,
+      awsEmailValue: String? = \\"local-part@domain-part\\",
+      awsURLValue: String? = \\"https://www.amazon.com/dp/B000NZW3KC/\\",
+      awsPhoneValue: String? = \\"+41 44 668 18 00\\",
+      awsIPAddressValue1: String? = \\"123.12.34.56\\",
+      awsIPAddressValue2: String? = \\"1a2b:3c4b::1234:4567\\",
+      enumValue: Tag? = Tag.random,
+      awsTimeValue: Temporal.Time? = try? Temporal.Time(iso8601String: \\"12:00:34Z\\"),
+      awsDateTime: Temporal.DateTime? = try? Temporal.DateTime(iso8601String: \\"2007-04-05T14:30:34Z\\")) {
+    self.init(id: id,
+      stringValue: stringValue,
+      intVal: intVal,
+      floatValue: floatValue,
+      booleanValue: booleanValue,
+      awsJsonValue: awsJsonValue,
+      awsDateValue: awsDateValue,
+      awsTimestampValue: awsTimestampValue,
+      awsEmailValue: awsEmailValue,
+      awsURLValue: awsURLValue,
+      awsPhoneValue: awsPhoneValue,
+      awsIPAddressValue1: awsIPAddressValue1,
+      awsIPAddressValue2: awsIPAddressValue2,
+      enumValue: enumValue,
+      awsTimeValue: awsTimeValue,
+      awsDateTime: awsDateTime,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      stringValue: String? = \\"hello world\\",
+      intVal: Int? = 10002000,
+      floatValue: Double? = 123456.34565,
+      booleanValue: Bool? = true,
+      awsJsonValue: String? = \\"{\\\\\\"a\\\\\\":1, \\\\\\"b\\\\\\":3, \\\\\\"string\\\\\\": 234}\\",
+      awsDateValue: Temporal.Date? = try? Temporal.Date(iso8601String: \\"2016-01-29\\"),
+      awsTimestampValue: Int? = 545345345,
+      awsEmailValue: String? = \\"local-part@domain-part\\",
+      awsURLValue: String? = \\"https://www.amazon.com/dp/B000NZW3KC/\\",
+      awsPhoneValue: String? = \\"+41 44 668 18 00\\",
+      awsIPAddressValue1: String? = \\"123.12.34.56\\",
+      awsIPAddressValue2: String? = \\"1a2b:3c4b::1234:4567\\",
+      enumValue: Tag? = Tag.random,
+      awsTimeValue: Temporal.Time? = try? Temporal.Time(iso8601String: \\"12:00:34Z\\"),
+      awsDateTime: Temporal.DateTime? = try? Temporal.DateTime(iso8601String: \\"2007-04-05T14:30:34Z\\"),
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.stringValue = stringValue
+      self.intVal = intVal
+      self.floatValue = floatValue
+      self.booleanValue = booleanValue
+      self.awsJsonValue = awsJsonValue
+      self.awsDateValue = awsDateValue
+      self.awsTimestampValue = awsTimestampValue
+      self.awsEmailValue = awsEmailValue
+      self.awsURLValue = awsURLValue
+      self.awsPhoneValue = awsPhoneValue
+      self.awsIPAddressValue1 = awsIPAddressValue1
+      self.awsIPAddressValue2 = awsIPAddressValue2
+      self.enumValue = enumValue
+      self.awsTimeValue = awsTimeValue
+      self.awsDateTime = awsDateTime
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
 exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `
 "// swiftlint:disable all
 import Amplify

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -3,6 +3,7 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelDartVisitor } from '../../visitors/appsync-dart-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { DART_SCALAR_MAP } from '../../scalars';
+import { schemaWithDefaultDirective } from './schema-definitions';
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -13,7 +14,7 @@ const getVisitor = (
   selectedType?: string,
   generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code,
   enableDartNullSafety: boolean = false,
-  transformerVersion: number = 1
+  transformerVersion: number = 1,
 ) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
@@ -51,6 +52,11 @@ describe('AppSync Dart Visitor', () => {
       `;
       const visitor = getVisitor(schema);
       const generatedCode = visitor.generate();
+      expect(generatedCode).toMatchSnapshot();
+    });
+
+    it('Should generate a default values for a Model with @default directives', () => {
+      const generatedCode = getVisitor(schemaWithDefaultDirective, null, CodeGenGenerateEnum.code, false, 2).generate();
       expect(generatedCode).toMatchSnapshot();
     });
   });
@@ -475,7 +481,7 @@ describe('AppSync Dart Visitor', () => {
           content: String
           tags: [Tag] @manyToMany(relationName: "PostTags")
         }
-        
+
         type Tag @model {
           id: ID!
           label: String!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-java-visitor.test.ts
@@ -4,11 +4,11 @@ import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelJavaVisitor } from '../../visitors/appsync-java-visitor';
 import { CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
 import { JAVA_SCALAR_MAP } from '../../scalars';
+import { schemaWithDefaultDirective } from './schema-definitions';
 
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
 };
-
 
 const getVisitor = (
   schema: string,
@@ -207,6 +207,12 @@ describe('AppSyncModelVisitor', () => {
     `;
     const visitor = getVisitor(schema, 'authorBook');
     const generatedCode = visitor.generate();
+    expect(() => validateJava(generatedCode)).not.toThrow();
+    expect(generatedCode).toMatchSnapshot();
+  });
+
+  it('Should generate a default values for a Model with @default directives', () => {
+    const generatedCode = getVisitorPipelinedTransformer(schemaWithDefaultDirective, 'SimpleModel').generate();
     expect(() => validateJava(generatedCode)).not.toThrow();
     expect(generatedCode).toMatchSnapshot();
   });
@@ -592,7 +598,7 @@ describe('AppSyncModelVisitor', () => {
           content: String
           tags: [Tag] @manyToMany(relationName: "PostTags")
         }
-        
+
         type Tag @model {
           id: ID!
           label: String!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/schema-definitions.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/schema-definitions.ts
@@ -1,0 +1,25 @@
+export const schemaWithDefaultDirective = /* GraphQL */ `
+  type SimpleModel @model {
+    id: ID!
+    stringValue: String @default(value: "hello world")
+    intVal: Int @default(value: "10002000")
+    floatValue: Float @default(value: "123456.34565")
+    booleanValue: Boolean @default(value: "true")
+    awsJsonValue: AWSJSON @default(value: "{\\"a\\":1, \\"b\\":3, \\"string\\": 234}")
+    awsDateValue: AWSDate @default(value: "2016-01-29")
+    awsTimestampValue: AWSTimestamp @default(value: "545345345")
+    awsEmailValue: AWSEmail @default(value: "local-part@domain-part")
+    awsURLValue: AWSURL @default(value: "https://www.amazon.com/dp/B000NZW3KC/")
+    awsPhoneValue: AWSPhone @default(value: "+41 44 668 18 00")
+    awsIPAddressValue1: AWSIPAddress @default(value: "123.12.34.56")
+    awsIPAddressValue2: AWSIPAddress @default(value: "1a2b:3c4b::1234:4567")
+    enumValue: Tag @default(value: "RANDOM")
+    awsTimeValue: AWSTime @default(value: "12:00:34Z")
+    awsDateTime: AWSDateTime @default(value: "2007-04-05T14:30:34Z")
+  }
+
+  enum Tag {
+    NEWS
+    RANDOM
+  }
+`;

--- a/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/supported-directives.ts
@@ -133,7 +133,7 @@ export const directives = /* GraphQL */ `
   }
 
   directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
-  
+
   # GraphQL vNext Directives
   # primaryKey directive
   directive @primaryKey(sortKeyFields: [String!], queryField: String) on FIELD_DEFINITION
@@ -143,6 +143,7 @@ export const directives = /* GraphQL */ `
   directive @hasMany(indexName: String, fields: [String], limit: Int = 100) on FIELD_DEFINITION
   directive @belongsTo(fields: [String]) on FIELD_DEFINITION
   directive @manyToMany(relationName: String!) on FIELD_DEFINITION
+  directive @default(value: String!) on FIELD_DEFINITION
 `;
 
 export const scalars = [


### PR DESCRIPTION
#### Description of changes
- added support for api and datastore @default directive
- changes the platform constructors to initialize values that have @default directive

#### Description of how you validated changes
- `yarn test` passes
- new added unit tests
- manually tested javascript app with @default and API and Datastore
- manually tested ios app with @default and API and Datastore  
- manually tested android app with @default and API and Datastore
- manually tested flutter app with @default  and Datastore (API not available)

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.