### PR TITLE
Fix E2e tests by including the API category walkthrough changes

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/categories/api.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/api.ts
@@ -32,14 +32,15 @@ const defaultOptions: AddApiOptions = {
   testingWithLatestCodebase: false
 };
 
-export function addApiWithoutSchema(cwd: string, opts: Partial<AddApiOptions> = {}) {
+export function addApiWithoutSchema(cwd: string, opts: Partial<AddApiOptions & { apiKeyExpirationDays: number }> = {}) {
   const options = _.assign(defaultOptions, opts);
   return new Promise<void>((resolve, reject) => {
-    spawn(getCLIPath(), ['add', 'api'], { cwd, stripColors: true })
+    spawn(getCLIPath(options.testingWithLatestCodebase), ['add', 'api'], { cwd, stripColors: true })
       .wait('Please select from one of the below mentioned services:')
       .sendCarriageReturn()
       .wait(/.*Here is the GraphQL API that we will create. Select a setting to edit or continue.*/)
       .sendKeyUp(3)
+      .sendCarriageReturn()
       .wait('Provide API name:')
       .sendLine(options.apiName)
       .wait(/.*Here is the GraphQL API that we will create. Select a setting to edit or continue.*/)
@@ -48,10 +49,9 @@ export function addApiWithoutSchema(cwd: string, opts: Partial<AddApiOptions> = 
       .sendCarriageReturn()
       .wait('Do you want to edit the schema now?')
       .sendConfirmNo()
-      .wait('Successfully added resource collectionapi locally')
-      // .wait(
-      //   '"amplify publish" will build all your local backend and frontend resources (if you have hosting category added) and provision it in the cloud',
-      // )
+      .wait(
+        '"amplify publish" will build all your local backend and frontend resources (if you have hosting category added) and provision it in the cloud',
+      )
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-codegen-e2e-core/src/categories/api.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/api.ts
@@ -126,45 +126,6 @@ export function addApiWithBlankSchemaAndConflictDetection(cwd: string) {
   });
 }
 
-export function addApiWithSchemaAndConflictDetection(cwd: string, schemaFile: string) {
-  const schemaPath = getSchemaPath(schemaFile);
-  return new Promise<void>((resolve, reject) => {
-    spawn(getCLIPath(), ['add', 'api'], { cwd, stripColors: true })
-      .wait('Please select from one of the below mentioned services:')
-      .sendCarriageReturn()
-      .wait('Provide API name:')
-      .sendCarriageReturn()
-      .wait(/.*Choose the default authorization type for the API.*/)
-      .sendCarriageReturn()
-      .wait(/.*Enter a description for the API key.*/)
-      .sendCarriageReturn()
-      .wait(/.*After how many days from now the API key should expire.*/)
-      .sendCarriageReturn()
-      .wait(/.*Do you want to configure advanced settings for the GraphQL API.*/)
-      .sendLine(KEY_DOWN_ARROW) // Down
-      .wait(/.*Configure additional auth types.*/)
-      .sendLine('n')
-      .wait(/.*Enable conflict detection.*/)
-      .sendLine('y')
-      .wait(/.*Select the default resolution strategy.*/)
-      .sendCarriageReturn()
-      .wait(/.*Do you have an annotated GraphQL schema.*/)
-      .sendLine('y')
-      .wait('Provide your schema file path:')
-      .sendLine(schemaPath)
-      .wait(
-        '"amplify publish" will build all your local backend and frontend resources (if you have hosting category added) and provision it in the cloud',
-      )
-      .run((err: Error) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(err);
-        }
-      });
-  });
-}
-
 export function updateApiSchema(cwd: string, projectName: string, schemaName: string, forceUpdate: boolean = false) {
   const testSchemaPath = getSchemaPath(schemaName);
   let schemaText = fs.readFileSync(testSchemaPath).toString();
@@ -253,26 +214,6 @@ export function apiDisableDataStore(cwd: string, settings: any) {
       .wait(/.*Select a setting to edit.*/)
       .sendKeyDown(2) // Disable conflict detection
       .sendCarriageReturn()
-      .wait(/.*Successfully updated resource.*/)
-      .sendEof()
-      .run((err: Error) => {
-        if (!err) {
-          resolve();
-        } else {
-          reject(err);
-        }
-      });
-  });
-}
-
-export function apiUpdateToggleDataStore(cwd: string, settings: any = {}) {
-  return new Promise<void>((resolve, reject) => {
-    spawn(getCLIPath(settings.testingWithLatestCodebase), ['update', 'api'], { cwd, stripColors: true })
-      .wait('Please select from one of the below mentioned services:')
-      .sendCarriageReturn()
-      .wait('Select from the options below')
-      .send(KEY_DOWN_ARROW)
-      .sendLine(KEY_DOWN_ARROW) // select enable datastore for the api
       .wait(/.*Successfully updated resource.*/)
       .sendEof()
       .run((err: Error) => {

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
@@ -1,9 +1,11 @@
 import { 
     createNewProjectDir,
     initProjectWithProfile,
-    addApiWithSchema,
     addCodegen,
-    DEFAULT_JS_CONFIG
+    DEFAULT_JS_CONFIG,
+    createRandomName,
+    addApiWithoutSchema,
+    updateApiSchema
 } from "amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
@@ -46,7 +48,9 @@ describe('codegen add tests - JS', () => {
     it(`Adding codegen twice gives appropriate message`, async () => {
         // init project and add API category
         await initProjectWithProfile(projectRoot, { ...config });
-        await addApiWithSchema(projectRoot, schema);
+        const projectName = createRandomName();
+        await addApiWithoutSchema(projectRoot, { apiName: projectName });
+        await updateApiSchema(projectRoot, projectName, schema);
 
         const userSourceCodePath = testSetupBeforeAddCodegen(projectRoot, config);
 

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/env-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/env-codegen.test.ts
@@ -2,10 +2,10 @@ import {
   createNewProjectDir, 
   deleteProjectDir,
   deleteProject,
-  addApiWithSchema,
   initJSProjectWithProfile,
   amplifyPush,
   generateModels,
+  addApiWithoutSchema,
   updateApiSchema
 } from "amplify-codegen-e2e-core";
 import { addEnvironment, checkoutEnvironment } from "../environment/env";
@@ -27,7 +27,9 @@ describe('env codegen tests', () => {
   it('should generate models in different environments', async () => {
     //create amplify project with enva
     await initJSProjectWithProfile(projectRoot, { envName: 'enva' });
-    await addApiWithSchema(projectRoot, schema, { apiName });
+    await addApiWithoutSchema(projectRoot, { apiName: apiName });
+    await updateApiSchema(projectRoot, apiName, schema);
+
     await amplifyPush(projectRoot);
     //create new envb
     await addEnvironment(projectRoot, { envName: 'envb' });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
@@ -3,7 +3,9 @@ import {
   deleteProjectDir,
   deleteProject,
   initJSProjectWithProfile,
-  addApiWithSchemaAndConflictDetection,
+  addApiWithBlankSchemaAndConflictDetection,
+  updateApiSchema,
+  createRandomName,
   amplifyPush,
   amplifyPull,
   getAppId,
@@ -37,9 +39,11 @@ describe('Amplify pull in amplify app with codegen tests', () => {
   let projectRoot: string;
   let appId: string;
   beforeAll(async () => {
+    const name = createRandomName();
     projectRoot = await createNewProjectDir('pullCodegen');
-    await initJSProjectWithProfile(projectRoot, { envName, disableAmplifyAppCreation: false });
-    await addApiWithSchemaAndConflictDetection(projectRoot, schema);
+    await initJSProjectWithProfile(projectRoot, { name, envName, disableAmplifyAppCreation: false });
+    await addApiWithBlankSchemaAndConflictDetection(projectRoot);
+    await updateApiSchema(projectRoot, name, schema);
     await amplifyPush(projectRoot);
     appId = getAppId(projectRoot);
     expect(appId).toBeDefined();

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-js.test.ts
@@ -3,7 +3,9 @@ import {
     DEFAULT_JS_CONFIG, 
     removeCodegen,
     initProjectWithProfile,
-    addApiWithSchema
+    addApiWithoutSchema,
+    updateApiSchema,
+    createRandomName
 } from "amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testRemoveCodegen } from '../codegen-tests-base';
 
@@ -23,7 +25,9 @@ describe('codegen remove tests - JS', () => {
     it(`Give appropriate message during remove when codegen is not added in JS project`, async () => {
         // init project and add API category
         await initProjectWithProfile(projectRoot, DEFAULT_JS_CONFIG);
-        await addApiWithSchema(projectRoot, schema);
+        const projectName = createRandomName();
+        await addApiWithoutSchema(projectRoot, { apiName: projectName });
+        await updateApiSchema(projectRoot, projectName, schema);
         
         // remove command should give expected message
         await expect(removeCodegen(projectRoot, false)).resolves.not.toThrow();

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -1,23 +1,24 @@
 import {
     initProjectWithProfile,
     addApiWithBlankSchemaAndConflictDetection,
-    generateModels,
-    AmplifyFrontendConfig,
+    updateApiSchema,
     createRandomName,
-    updateApiSchema
+    generateModels,
+    AmplifyFrontendConfig
 } from "amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';
 
 export async function testCodegenModels(config: AmplifyFrontendConfig, projectRoot: string, schema: string) {
+    const name = createRandomName();
+
     // init project and add API category
-    await initProjectWithProfile(projectRoot, { ...config });
+    await initProjectWithProfile(projectRoot, { name, ...config });
 
     //enable datastore
-    const projectName = createRandomName();
     await addApiWithBlankSchemaAndConflictDetection(projectRoot);
-    await updateApiSchema(projectRoot, projectName, schema);
+    await updateApiSchema(projectRoot, name, schema);
 
     //generate pre existing user file
     const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
@@ -5,8 +5,8 @@ import {
     createRandomName,
     amplifyPushWithCodegenAdd,
     AmplifyFrontendConfig,
-    apiUpdateToggleDataStore,
-    amplifyPushWithCodegenUpdate
+    amplifyPushWithCodegenUpdate,
+    updateAPIWithResolutionStrategyWithModels
 } from "amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
@@ -32,7 +32,7 @@ export async function testPushCodegen(config: AmplifyFrontendConfig, projectRoot
     expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
 
     //enable datastore
-    await apiUpdateToggleDataStore(projectRoot);
+    await updateAPIWithResolutionStrategyWithModels(projectRoot, {});
     //push with codegen update
     await amplifyPushWithCodegenUpdate(projectRoot);
     expect(existsSync(userSourceCodePath)).toBe(true);

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { addApiWithSchemaAndConflictDetection, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApiWithBlankSchemaAndConflictDetection, updateApiSchema, amplifyPush } from 'amplify-codegen-e2e-core';
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 import { testQueries, testMutations } from '../common';
 
@@ -269,8 +269,9 @@ export const expected_result_query5 = {
   },
 };
 
-export async function runTest(projectDir: string, testModule: any) {
-  await addApiWithSchemaAndConflictDetection(projectDir, testModule.schemaName);
+export async function runTest(projectDir: string, testModule: any, appName: string) {
+  await addApiWithBlankSchemaAndConflictDetection(projectDir);
+  await updateApiSchema(projectDir, appName, testModule.schemaName);
   await amplifyPush(projectDir);
 
   const awsconfig = configureAmplify(projectDir);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Amplify CLI release `v6.4.0` introduced some breaking changes to the API category walkthrough.
This PR incorporates those changes into the codegen e2e test setup.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
tests are run successfully on CI/CD post changes.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.