### PR TITLE
fix(amplify-codegen): fix name for many to many join table fields

### DIFF
--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -6,7 +6,7 @@ import {
   ParsedConfig,
   RawConfig,
 } from '@graphql-codegen/visitor-plugin-common';
-import { constantCase, pascalCase } from 'change-case';
+import { camelCase, constantCase, pascalCase } from 'change-case';
 import { plural } from 'pluralize';
 import crypto from 'crypto';
 import {
@@ -553,8 +553,8 @@ export class AppSyncModelVisitor<
     secondField: CodeGenField,
     relationName: string,
   ) {
-    const firstModelKeyFieldName = `${firstModel.name.toLowerCase()}ID`;
-    const secondModelKeyFieldName = `${secondModel.name.toLowerCase()}ID`;
+    const firstModelKeyFieldName = `${camelCase(firstModel.name)}ID`;
+    const secondModelKeyFieldName = `${camelCase(secondModel.name)}ID`;
     let intermediateModel: CodeGenModel = {
       name: relationName,
       type: 'model',
@@ -585,14 +585,14 @@ export class AppSyncModelVisitor<
           type: firstModel.name,
           isNullable: false,
           isList: false,
-          name: firstModel.name.toLowerCase(),
+          name: camelCase(firstModel.name),
           directives: [{ name: 'belongsTo', arguments: { fields: [firstModelKeyFieldName] } }],
         },
         {
           type: secondModel.name,
           isNullable: false,
           isList: false,
-          name: secondModel.name.toLowerCase(),
+          name: camelCase(secondModel.name),
           directives: [{ name: 'belongsTo', arguments: { fields: [secondModelKeyFieldName] } }],
         },
       ],
@@ -708,7 +708,9 @@ export class AppSyncModelVisitor<
         const connectionInfo = field.connectionInfo;
         if (modelTypes.includes(fieldType) && connectionInfo === undefined) {
           printWarning(
-            `Model ${model.name} has field ${field.name} of type ${field.type} but its not connected. Add the appropriate ${field.isList ? '@hasMany' : '@hasOne'}/@belongsTo directive if you want to connect them.`,
+            `Model ${model.name} has field ${field.name} of type ${field.type} but its not connected. Add the appropriate ${
+              field.isList ? '@hasMany' : '@hasOne'
+            }/@belongsTo directive if you want to connect them.`,
           );
           return false;
         }


### PR DESCRIPTION
#### Description of changes
- fix naming for many-to-many join table fields

#### Description of how you validated changes
- manual testing for iOS datastore app
- `yarn test` passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.