### PR TITLE
fix: repo dev dependencies of cli components

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,9 @@
     "ts-jest": "^25.5.0",
     "ts-node": "^8.10.1",
     "typescript": "^3.8.3",
-    "amplify-cli-core": "^1.17.2",
-    "graphql-transformer-core": "^6.26.2",
-    "amplify-headless-interface": "^1.6.0"
+    "amplify-cli-core": "^2.3.0",
+    "graphql-transformer-core": "^7.2.1",
+    "amplify-headless-interface": "^1.13.1"
   },
   "config": {
     "commitizen": {

--- a/packages/amplify-codegen-e2e-core/package.json
+++ b/packages/amplify-codegen-e2e-core/package.json
@@ -35,8 +35,8 @@
     "uuid": "7.0.1"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^1.18.1",
-    "amplify-headless-interface": "^1.5.3",
-    "graphql-transformer-core": "^6.27.0"
+    "amplify-cli-core": "^2.3.0",
+    "amplify-headless-interface": "^1.13.1",
+    "graphql-transformer-core": "^7.2.1"
   }
 }

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -42,8 +42,8 @@
     "ts-node": "^8.9.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^1.18.1",
-    "graphql-transformer-core": "^6.27.0"
+    "amplify-cli-core": "^2.3.0",
+    "graphql-transformer-core": "^7.2.1"
   },
   "jest": {
     "verbose": false,

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -40,8 +40,8 @@
     "slash": "^3.0.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^1.17.2",
-    "graphql-transformer-core": "^6.26.2"
+    "amplify-cli-core": "^2.3.0",
+    "graphql-transformer-core": "^7.2.1"
   },
   "jest": {
     "collectCoverage": true,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The recent release of CLI has major version bump for its component packages, which codegen repo has a dev dependency. Bump the dependency to next major version so that the `amplify-dev` will not break

Related packages:

- `amplify-cli-core`: `1.x` to `2.x`
- `graphql-transformer-core`: `6.x` to `7.x`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.