### PR TITLE
Fix: stop unnecessarily removing fields from belongsTo models

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
@@ -403,7 +403,7 @@ describe('GraphQL V2 process connections tests', () => {
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(belongsToModelMap.Project2);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
     });
 
@@ -546,7 +546,7 @@ describe('GraphQL V2 process connections tests', () => {
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Blog);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
 
       it('Should detect second belongsTo', () => {
@@ -555,7 +555,7 @@ describe('GraphQL V2 process connections tests', () => {
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Post);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
     });
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1279,6 +1279,8 @@ class _TagModelType extends ModelType<Tag> {
 class PostTags extends Model {
   static const classType = const _PostTagsModelType();
   final String id;
+  final String postID;
+  final String tagID;
   final Post post;
   final Tag tag;
 
@@ -1291,11 +1293,24 @@ class PostTags extends Model {
   }
 
   const PostTags._internal(
-      {@required this.id, @required this.post, @required this.tag});
+      {@required this.id,
+      @required this.postID,
+      @required this.tagID,
+      @required this.post,
+      @required this.tag});
 
-  factory PostTags({String id, @required Post post, @required Tag tag}) {
+  factory PostTags(
+      {String id,
+      @required String postID,
+      @required String tagID,
+      @required Post post,
+      @required Tag tag}) {
     return PostTags._internal(
-        id: id == null ? UUID.getUUID() : id, post: post, tag: tag);
+        id: id == null ? UUID.getUUID() : id,
+        postID: postID,
+        tagID: tagID,
+        post: post,
+        tag: tag);
   }
 
   bool equals(Object other) {
@@ -1307,6 +1322,8 @@ class PostTags extends Model {
     if (identical(other, this)) return true;
     return other is PostTags &&
         id == other.id &&
+        postID == other.postID &&
+        tagID == other.tagID &&
         post == other.post &&
         tag == other.tag;
   }
@@ -1320,6 +1337,8 @@ class PostTags extends Model {
 
     buffer.write(\\"PostTags {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"postID=\\" + \\"$postID\\" + \\", \\");
+    buffer.write(\\"tagID=\\" + \\"$tagID\\" + \\", \\");
     buffer.write(\\"post=\\" + (post != null ? post.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"tag=\\" + (tag != null ? tag.toString() : \\"null\\"));
     buffer.write(\\"}\\");
@@ -1327,13 +1346,20 @@ class PostTags extends Model {
     return buffer.toString();
   }
 
-  PostTags copyWith({String id, Post post, Tag tag}) {
+  PostTags copyWith(
+      {String id, String postID, String tagID, Post post, Tag tag}) {
     return PostTags(
-        id: id ?? this.id, post: post ?? this.post, tag: tag ?? this.tag);
+        id: id ?? this.id,
+        postID: postID ?? this.postID,
+        tagID: tagID ?? this.tagID,
+        post: post ?? this.post,
+        tag: tag ?? this.tag);
   }
 
   PostTags.fromJson(Map<String, dynamic> json)
       : id = json['id'],
+        postID = json['postID'],
+        tagID = json['tagID'],
         post = json['post'] != null
             ? Post.fromJson(new Map<String, dynamic>.from(json['post']))
             : null,
@@ -1341,10 +1367,17 @@ class PostTags extends Model {
             ? Tag.fromJson(new Map<String, dynamic>.from(json['tag']))
             : null;
 
-  Map<String, dynamic> toJson() =>
-      {'id': id, 'post': post?.toJson(), 'tag': tag?.toJson()};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'postID': postID,
+        'tagID': tagID,
+        'post': post?.toJson(),
+        'tag': tag?.toJson()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"postTags.id\\");
+  static final QueryField POSTID = QueryField(fieldName: \\"postID\\");
+  static final QueryField TAGID = QueryField(fieldName: \\"tagID\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -1359,6 +1392,16 @@ class PostTags extends Model {
     modelSchemaDefinition.pluralName = \\"PostTags\\";
 
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: PostTags.POSTID,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: PostTags.TAGID,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
 
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
         key: PostTags.POST,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -833,10 +833,10 @@ describe('AppSyncModelVisitor', () => {
       expect(visitor.models.Human.fields[2].directives[0].arguments.fields[0]).toEqual('governmentID');
       expect(visitor.models.Human.fields[2].directives[0].arguments.indexName).toEqual('byHuman');
       expect(visitor.models.PetFriend).toBeDefined();
-      expect(visitor.models.PetFriend.fields.length).toEqual(5);
-      expect(visitor.models.PetFriend.fields[2].directives[0].name).toEqual('belongsTo');
-      expect(visitor.models.PetFriend.fields[2].directives[0].arguments.fields.length).toEqual(1);
-      expect(visitor.models.PetFriend.fields[2].directives[0].arguments.fields[0]).toEqual('animalID');
+      expect(visitor.models.PetFriend.fields.length).toEqual(7);
+      expect(visitor.models.PetFriend.fields[4].directives[0].name).toEqual('belongsTo');
+      expect(visitor.models.PetFriend.fields[4].directives[0].arguments.fields.length).toEqual(1);
+      expect(visitor.models.PetFriend.fields[4].directives[0].arguments.fields[0]).toEqual('animalID');
       expect(visitor.models.Animal.fields.length).toEqual(5);
       expect(visitor.models.Animal.fields[2].type).toEqual('PetFriend');
       expect(visitor.models.Animal.fields[2].directives.length).toEqual(1);
@@ -856,7 +856,7 @@ describe('AppSyncModelVisitor', () => {
       expect(visitor.models.ModelA.fields[1].directives[0].arguments.indexName).toEqual('byModelA');
 
       expect(visitor.models.Models).toBeDefined();
-      expect(visitor.models.Models.fields.length).toEqual(5);
+      expect(visitor.models.Models.fields.length).toEqual(7);
 
       const modelA = visitor.models.Models.fields.find(f => f.name === 'modelA');
       expect(modelA).toBeDefined();

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -45,13 +45,15 @@ export function processBelongsToConnection(
   //  track the connection and that field is not part of the selection set
   // but if the field are connected using fields argument in connection directive
   // we are reusing the field and it should be preserved in selection set
-  const isConnectingFieldAutoCreated = connectionFields.length === 0;
+  const otherSideHasMany = otherSideField.isList;
+  const isConnectingFieldAutoCreated = false;
 
   return {
     kind: CodeGenConnectionType.BELONGS_TO,
     connectedModel: otherSide,
     isConnectingFieldAutoCreated,
-    targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
+    targetName: connectionFields[0] || (otherSideHasMany ? makeConnectionAttributeName(otherSide.name, otherSideField.name) :
+      makeConnectionAttributeName(model.name, field.name)),
   };
 }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -693,9 +693,6 @@ export class AppSyncModelVisitor<
               isList: false,
               isNullable: field.isNullable,
             });
-          } else if (connectionInfo.targetName !== 'id') {
-            // Need to remove the field that is targetName
-            removeFieldFromModel(model, connectionInfo.targetName);
           }
           field.connectionInfo = connectionInfo;
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
A remnant of the V1 transformer is removing any auto generated fields from a belongsTo type connection. This was done to patch a bug in V1 that was solved by the explicit V2 directives, so we're removing the part where any belongsTo creates a field, as well as the part where added fields from belongsTo are removed.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Running unit tests and running codegen locally


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.