### PR TITLE
fix: include queryField when mapping index to key

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -219,4 +219,49 @@ describe('processIndex', () => {
     processIndex(model);
     expect(model.directives.length).toBe(3);
   });
+
+  it('adds index with queryFields', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'testField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                queryField: 'myQuery',
+                name: 'byItem',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItem',
+          queryField: 'myQuery',
+          fields: ['testField'],
+        },
+      },
+    ]);
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -411,6 +411,26 @@ describe('AppSyncModelVisitor', () => {
         },
       });
     });
+
+    it('processes index with queryField', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          id: ID!
+          name: String @index(name: "nameIndex", queryField: "myQuery")
+        }
+      `;
+      const visitor = createAndGenerateVisitor(schema, true);
+      visitor.generate();
+      const projectKeyDirective = visitor.models.Project.directives.find(directive => directive.name === 'key');
+      expect(projectKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          name: 'nameIndex',
+          queryField: 'myQuery',
+          fields: ['name'],
+        },
+      });
+    });
   });
 
   describe('auth directive', () => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -18,6 +18,7 @@ export const processIndex = (model: CodeGenModel) => {
     name: 'key',
     arguments: {
       name: directive.arguments.name,
+      queryField: directive.arguments.queryField,
       fields: [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? []),
     },
   }));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Fixes an omission from https://github.com/aws-amplify/amplify-codegen/pull/286 where indexes with a queryField did not have the queryField included when mapping to a key directive on the model

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Manually verified and added unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.