### PR TITLE
fix: update codegen models to use v2 schema shapes

### DIFF
--- a/packages/amplify-codegen-e2e-tests/schemas/modelgen/model_gen_schema_with_aws_scalars.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/modelgen/model_gen_schema_with_aws_scalars.graphql
@@ -31,12 +31,12 @@ type User @model {
 type Post @model {
   title: String!
   content: String
-  comments: [Comment] @connection(name: "PostComment")
+  comments: [Comment] @hasMany
 }
 
 type Comment @model {
   comment: String!
-  post: Post @connection(name: "PostComment")
+  post: Post @belongsTo
 }
 
 # 1:1 Connection
@@ -44,11 +44,11 @@ type Comment @model {
 type Person @model {
   id: ID!
   name: String!
-  license: License @connection
+  license: License @hasOne
 }
 
 type License @model {
   id: ID!
   number: String!
-  belongsTo: Person @connection
+  belongsTo: Person @belongsTo
 }


### PR DESCRIPTION
#### Description of changes
Updating e2e tests to use new v2 graphql hasMany/hasOne/belongsTo instead of connection directives, since currently tests are failing.

#### Issue #, if available
N/A, this is blocking release of https://github.com/aws-amplify/amplify-codegen/pull/313

#### Description of how you validated changes
TBD - I haven't been able to run the changes locally so far, still working through that.

#### Checklist

- [X] PR description included
- [X] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.