### PR TITLE
release support for index queryField

### DIFF
--- a/packages/amplify-codegen-e2e-tests/schemas/modelgen/model_gen_schema_with_aws_scalars.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/modelgen/model_gen_schema_with_aws_scalars.graphql
@@ -31,12 +31,12 @@ type User @model {
 type Post @model {
   title: String!
   content: String
-  comments: [Comment] @connection(name: "PostComment")
+  comments: [Comment] @hasMany
 }
 
 type Comment @model {
   comment: String!
-  post: Post @connection(name: "PostComment")
+  post: Post @belongsTo
 }
 
 # 1:1 Connection
@@ -44,11 +44,11 @@ type Comment @model {
 type Person @model {
   id: ID!
   name: String!
-  license: License @connection
+  license: License @hasOne
 }
 
 type License @model {
   id: ID!
   number: String!
-  belongsTo: Person @connection
+  belongsTo: Person @belongsTo
 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -219,4 +219,49 @@ describe('processIndex', () => {
     processIndex(model);
     expect(model.directives.length).toBe(3);
   });
+
+  it('adds index with queryFields', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'testField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                queryField: 'myQuery',
+                name: 'byItem',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItem',
+          queryField: 'myQuery',
+          fields: ['testField'],
+        },
+      },
+    ]);
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -411,6 +411,26 @@ describe('AppSyncModelVisitor', () => {
         },
       });
     });
+
+    it('processes index with queryField', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          id: ID!
+          name: String @index(name: "nameIndex", queryField: "myQuery")
+        }
+      `;
+      const visitor = createAndGenerateVisitor(schema, true);
+      visitor.generate();
+      const projectKeyDirective = visitor.models.Project.directives.find(directive => directive.name === 'key');
+      expect(projectKeyDirective).toEqual({
+        name: 'key',
+        arguments: {
+          name: 'nameIndex',
+          queryField: 'myQuery',
+          fields: ['name'],
+        },
+      });
+    });
   });
 
   describe('auth directive', () => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -18,6 +18,7 @@ export const processIndex = (model: CodeGenModel) => {
     name: 'key',
     arguments: {
       name: directive.arguments.name,
+      queryField: directive.arguments.queryField,
       fields: [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? []),
     },
   }));


### PR DESCRIPTION
#### Description of changes
Fixes an omission from #286 where indexes with a queryField did not have the queryField included when mapping to a key directive on the model, and updated E2E tests to support newly enabled v2 graphql transformer.


#### Issue #, if available
https://github.com/aws-amplify/amplify-cli/issues/9083

#### Description of how you validated changes
Verified manually and via e2e tests in original PR.

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.