### PR TITLE
fix: address hasOne issue if referenced in a hasMany relationship

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/hasOne-bug-fix/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/hasOne-bug-fix/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppSyncSwiftVisitor - hasOne Bug Regression Tests v2 should support a schema as part of hasOne/hasMany relationships 1`] = `
+"// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+
+
+const { ModelTwo, ModelOne } = initSchema(schema);
+
+export {
+  ModelTwo,
+  ModelOne
+};"
+`;
+
+exports[`AppSyncSwiftVisitor - hasOne Bug Regression Tests v2 should support a schema as part of hasOne/hasMany relationships 2`] = `
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+export declare class ModelTwo {
+  readonly id: string;
+  readonly ModelOnes?: (ModelOne | null)[];
+  constructor(init: ModelInit<ModelTwo>);
+  static copyOf(source: ModelTwo, mutator: (draft: MutableModel<ModelTwo>) => MutableModel<ModelTwo> | void): ModelTwo;
+}
+
+export declare class ModelOne {
+  readonly id: string;
+  readonly ModelTwo?: ModelTwo;
+  readonly modeltwoID?: string;
+  readonly modelOneModelTwoId?: string;
+  constructor(init: ModelInit<ModelOne>);
+  static copyOf(source: ModelOne, mutator: (draft: MutableModel<ModelOne>) => MutableModel<ModelOne> | void): ModelOne;
+}"
+`;
+
+exports[`AppSyncSwiftVisitor - hasOne Bug Regression Tests v2 should support a schema as part of hasOne/hasMany relationships 3`] = `
+"// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+
+
+const { ModelTwo, ModelOne } = initSchema(schema);
+
+export {
+  ModelTwo,
+  ModelOne
+};"
+`;
+
+exports[`AppSyncSwiftVisitor - hasOne Bug Regression Tests v2 should support a schema as part of hasOne/hasMany relationships 4`] = `
+"import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+export declare class ModelTwo {
+  readonly id: string;
+  readonly ModelOnes?: (ModelOne | null)[];
+  constructor(init: ModelInit<ModelTwo>);
+  static copyOf(source: ModelTwo, mutator: (draft: MutableModel<ModelTwo>) => MutableModel<ModelTwo> | void): ModelTwo;
+}
+
+export declare class ModelOne {
+  readonly id: string;
+  readonly ModelTwo?: ModelTwo;
+  readonly modeltwoID?: string;
+  readonly modelOneModelTwoId?: string;
+  constructor(init: ModelInit<ModelOne>);
+  static copyOf(source: ModelOne, mutator: (draft: MutableModel<ModelOne>) => MutableModel<ModelOne> | void): ModelOne;
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/hasOne-bug-fix/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/hasOne-bug-fix/appsync-javascript-visitor.test.ts
@@ -1,0 +1,49 @@
+import { buildSchema, GraphQLSchema, parse, visit } from 'graphql';
+import { directives, scalars } from '../../../scalars/supported-directives';
+import { TYPESCRIPT_SCALAR_MAP } from '../../../scalars';
+import { AppSyncModelJavascriptVisitor } from '../../../visitors/appsync-javascript-visitor';
+import { CodeGenGenerateEnum } from '../../../visitors/appsync-visitor';
+
+const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
+  return buildSchema([schema, directives, scalars].join('\n'));
+};
+
+const getGQLv2Visitor = (
+  schema: string,
+  selectedType?: string,
+  isDeclaration: boolean = false,
+  generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code,
+  isTimestampFieldsAdded: boolean = false,
+): AppSyncModelJavascriptVisitor => {
+  const ast = parse(schema);
+  const builtSchema = buildSchemaWithDirectives(schema);
+  const visitor = new AppSyncModelJavascriptVisitor(
+    builtSchema,
+    { directives, target: 'javascript', scalars: TYPESCRIPT_SCALAR_MAP, isDeclaration, isTimestampFieldsAdded, transformerVersion: 2 },
+    { selectedType, generate },
+  );
+  visit(ast, { leave: visitor });
+  return visitor;
+};
+
+describe('AppSyncSwiftVisitor - hasOne Bug Regression Tests', () => {
+  it('v2 should support a schema as part of hasOne/hasMany relationships', () => {
+    const schema = /* GraphQL */ `
+        type ModelTwo @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        ModelOnes: [ModelOne] @hasMany(indexName: "byModelTwo", fields: ["id"])
+        }
+        #
+
+        type ModelOne @model @auth(rules: [{ allow: public }]) {
+        id: ID!
+        ModelTwo: ModelTwo @hasOne
+        modeltwoID: ID @index(name: "byModelTwo")
+        }
+  `;
+    expect(getGQLv2Visitor(schema, 'ModelOne').generate()).toMatchSnapshot();
+    expect(getGQLv2Visitor(schema, 'ModelOne', true).generate()).toMatchSnapshot();
+    expect(getGQLv2Visitor(schema, 'ModelTwo').generate()).toMatchSnapshot();
+    expect(getGQLv2Visitor(schema, 'ModelTwo', true).generate()).toMatchSnapshot();
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -23,7 +23,7 @@ export function processHasOneConnection(
   // we are reusing the field and it should be preserved in selection set
   const isConnectingFieldAutoCreated = connectionFields.length === 0;
 
-  if (!field.isList && !otherSideField.isList) {
+  if (!field.isList) {
     return {
       kind: CodeGenConnectionType.HAS_ONE,
       associatedWith: otherSideField,


### PR DESCRIPTION
#### Description of changes
PR to address issue https://github.com/aws-amplify/amplify-adminui/issues/388. We are planning to release as a tagged release in Codegen, followed by a tagged release in CLI, and then Studio BE will consume the tagged release.

There will be a full E2E suite run in CLI, as well as a test suite + manual verification run in Studio BE before they merge the change in.

#### Issue #, if available
[Failed: A hasOne relationship should be 1:1 #388 ](https://github.com/aws-amplify/amplify-adminui/issues/388)

#### Description of how you validated changes
New Unit test covering this case.

Verified that this unit test added failed before the change was applied, and passed after the change was applied, and we were able to generate sane output files.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.