### PR TITLE
fix(appsync-modelgen-plugin):remove fields in second loop

### DIFF
--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -726,7 +726,10 @@ export class AppSyncModelVisitor<
     Object.values(this.modelMap).forEach(model => {
       model.fields.forEach(field => {
         const connectionInfo = field.connectionInfo;
-        if (connectionInfo?.kind === CodeGenConnectionType.BELONGS_TO && connectionInfo.targetName !== 'id') {
+        if (connectionInfo
+          && connectionInfo.kind !== CodeGenConnectionType.HAS_MANY
+          && connectionInfo.kind !== CodeGenConnectionType.HAS_ONE
+          && connectionInfo.targetName !== 'id') {
           // Need to remove the field that is targetName
           removeFieldFromModel(model, connectionInfo.targetName);
         }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -701,10 +701,6 @@ export class AppSyncModelVisitor<
               isList: false,
               isNullable: field.isNullable,
             });
-          } else if (connectionInfo.targetName !== 'id') {
-            // TODO: Remove this branch when we can roll forward.
-            // Need to remove the field that is targetName, only apply if shouldRevertBreakingKeyChange is set
-            removeFieldFromModel(model, connectionInfo.targetName);
           }
           field.connectionInfo = connectionInfo;
         }
@@ -726,6 +722,16 @@ export class AppSyncModelVisitor<
         return true;
       });
     });
+
+    Object.values(this.modelMap).forEach(model => {
+      model.fields.forEach(field => {
+        const connectionInfo = field.connectionInfo;
+        if (connectionInfo?.kind === CodeGenConnectionType.BELONGS_TO && connectionInfo.targetName !== 'id') {
+          // Need to remove the field that is targetName
+          removeFieldFromModel(model, connectionInfo.targetName);
+        }
+      });
+    })
   }
 
   protected processV2KeyDirectives(): void {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Moving the removing fields out of first loop to avoid missing fields during processing

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
fix #320 


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.