### PR TITLE
Turn on the shouldUseModelNameFieldInHasManyAndBelongsTo flag for Android

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -791,7 +791,7 @@ public final class Blog7V2 implements Model {
   public static final QueryField NAME = field(\\"Blog7V2\\", \\"name\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String name;
-  private final @ModelField(targetType=\\"Post7V2\\") @HasMany(associatedWith = \\"blog7V2PostsId\\", type = Post7V2.class) List<Post7V2> posts = null;
+  private final @ModelField(targetType=\\"Post7V2\\") @HasMany(associatedWith = \\"blog\\", type = Post7V2.class) List<Post7V2> posts = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
@@ -968,7 +968,7 @@ public final class Post7V2 implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\", isRequired = true) String title;
   private final @ModelField(targetType=\\"Blog7V2\\") @BelongsTo(targetName = \\"blog7V2PostsId\\", type = Blog7V2.class) Blog7V2 blog;
-  private final @ModelField(targetType=\\"Comment7V2\\") @HasMany(associatedWith = \\"post7V2CommentsId\\", type = Comment7V2.class) List<Comment7V2> comments = null;
+  private final @ModelField(targetType=\\"Comment7V2\\") @HasMany(associatedWith = \\"post\\", type = Comment7V2.class) List<Comment7V2> comments = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -27,7 +27,7 @@ export class AppSyncModelJavaVisitor<
 
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
-    const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
+    const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
     this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
     if (this._parsedConfig.generate === 'loader') {
       return this.generateClassLoader();


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This Flag is needed for Android HasMany and Belongs To explicit connects for the `associatedWith` to be set correctly to the connected model field.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
unit test snapshots


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.