### PR TITLE
chore: Upgrade xcode version used in macos builds from 11.2.1 to 13.2.1

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -18,7 +18,7 @@ executors:
       shell: bash.exe
   macos_node12: &macos_node12
     macos:
-      xcode: "11.2.1"
+      xcode: 13.2.1
       resource_class: large
 
 defaults: &defaults
@@ -80,6 +80,8 @@ jobs:
               - equal: [ *windows_node12, << parameters.os >> ]
           steps:
             - checkout
+            - run: nvm install 12.22.7
+            - run: nvm alias default 12.22.7
             - run: yarn config set workspaces-experimental true
             - run: yarn cache clean --force
             - run: yarn run production-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
       shell: bash.exe
   macos_node12: &ref_1
     macos:
-      xcode: 11.2.1
+      xcode: 13.2.1
       resource_class: large
 defaults:
   working_directory: ~/repo
@@ -82,6 +82,8 @@ jobs:
                   - << parameters.os >>
           steps:
             - checkout
+            - run: nvm install 12.22.7
+            - run: nvm alias default 12.22.7
             - run: yarn config set workspaces-experimental true
             - run: yarn cache clean --force
             - run: yarn run production-build


### PR DESCRIPTION
#### Description of changes
Upgrade xcode version used in macos builds from 11.2.1 to 13.2.1, since 11.2.1 is now deprecated https://circleci.com/docs/2.0/testing-ios/\?\#supported-xcode-versions

#### Issue #, if available
N/A - Contact from Circle

#### Description of how you validated changes
Will validate via CI testing, this only impacts CircleCI configuration.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.