### PR TITLE
fix(appsync-modelgen-plugin): keep explicit belongs-to fields

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
@@ -16,42 +16,42 @@ describe('GraphQL V2 process connections tests', () => {
 
     beforeEach(() => {
       const hasOneWithFieldsSchema = /* GraphQL */ `
-          type BatteryCharger @model {
-            chargerID: ID!
-            powerSourceID: ID
-            powerSource: PowerSource @hasOne(fields: ["powerSourceID"])
-          }
-  
-          type PowerSource @model {
-            sourceID: ID! @primaryKey
-            amps: Float!
-            volts: Float!
-          }
-        `;
+        type BatteryCharger @model {
+          chargerID: ID!
+          powerSourceID: ID
+          powerSource: PowerSource @hasOne(fields: ["powerSourceID"])
+        }
+
+        type PowerSource @model {
+          sourceID: ID! @primaryKey
+          amps: Float!
+          volts: Float!
+        }
+      `;
 
       const hasOneNoFieldsSchema = /* GraphQL */ `
-          type BatteryCharger @model {
-            powerSource: PowerSource @hasOne
-          }
-  
-          type PowerSource @model {
-            id: ID!
-            amps: Float!
-            volts: Float!
-          }
-        `;
+        type BatteryCharger @model {
+          powerSource: PowerSource @hasOne
+        }
+
+        type PowerSource @model {
+          id: ID!
+          amps: Float!
+          volts: Float!
+        }
+      `;
 
       const v2Schema = /* GraphQL */ `
-          type Post @model {
-            comments: [Comment] @hasMany(fields: ["id"])
-          }
-          
-          type Comment @model {
-            postID: ID! @primaryKey(sortKeyFields: ["content"])
-            content: String!
-            post: Post @belongsTo(fields:["postID"])
-          }
-        `;
+        type Post @model {
+          comments: [Comment] @hasMany(fields: ["id"])
+        }
+
+        type Comment @model {
+          postID: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          post: Post @belongsTo(fields: ["postID"])
+        }
+      `;
 
       const v2IndexSchema = /* graphQL */ `
           type Post @model {
@@ -59,7 +59,7 @@ describe('GraphQL V2 process connections tests', () => {
             title: String!
             comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
           }
-          
+
           type Comment @model {
             id: ID!
             postID: ID! @index(name: "byPost", sortKeyFields: ["content"])
@@ -78,14 +78,14 @@ describe('GraphQL V2 process connections tests', () => {
               isNullable: false,
               isList: false,
               name: 'chargerID',
-              directives: []
+              directives: [],
             },
             {
               type: 'ID',
               isNullable: true,
               isList: false,
               name: 'powerSourceID',
-              directives: []
+              directives: [],
             },
             {
               type: 'PowerSource',
@@ -151,7 +151,7 @@ describe('GraphQL V2 process connections tests', () => {
               isNullable: false,
               isList: false,
               name: 'id',
-              directives: []
+              directives: [],
             },
             {
               type: 'Float',
@@ -196,7 +196,7 @@ describe('GraphQL V2 process connections tests', () => {
               isNullable: false,
               isList: false,
               name: 'postID',
-              directives: [{name: 'primaryKey', arguments: { sortKeyFields: ['content'] } }],
+              directives: [{ name: 'primaryKey', arguments: { sortKeyFields: ['content'] } }],
             },
             {
               type: 'String',
@@ -262,7 +262,7 @@ describe('GraphQL V2 process connections tests', () => {
               isNullable: false,
               isList: false,
               name: 'postID',
-              directives: [{name: 'index', arguments: { name: 'byPost', sortKeyFields: ['content'] }}],
+              directives: [{ name: 'index', arguments: { name: 'byPost', sortKeyFields: ['content'] } }],
             },
             {
               type: 'String',
@@ -297,7 +297,11 @@ describe('GraphQL V2 process connections tests', () => {
 
       it('Should support connection with @index on BELONGS_TO side', () => {
         const commentsField = v2IndexModelMap.Post.fields[2];
-        const connectionInfo = (processConnectionsV2(commentsField, v2IndexModelMap.Post, v2IndexModelMap) as any) as CodeGenFieldConnectionHasMany;
+        const connectionInfo = (processConnectionsV2(
+          commentsField,
+          v2IndexModelMap.Post,
+          v2IndexModelMap,
+        ) as any) as CodeGenFieldConnectionHasMany;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
         expect(connectionInfo.connectedModel).toEqual(v2IndexModelMap.Comment);
@@ -308,7 +312,11 @@ describe('GraphQL V2 process connections tests', () => {
     describe('Has one testing', () => {
       it('Should support @hasOne with no explicit primary key', () => {
         const powerSourceField = hasOneNoFieldsModelMap.BatteryCharger.fields[0];
-        const connectionInfo = (processConnectionsV2(powerSourceField, hasOneNoFieldsModelMap.BatteryCharger, hasOneNoFieldsModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(
+          powerSourceField,
+          hasOneNoFieldsModelMap.BatteryCharger,
+          hasOneNoFieldsModelMap,
+        ) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
         expect(connectionInfo.connectedModel).toEqual(hasOneNoFieldsModelMap.PowerSource);
@@ -316,7 +324,11 @@ describe('GraphQL V2 process connections tests', () => {
       });
       it('Should support @hasOne with an explicit primary key', () => {
         const powerSourceField = hasOneWithFieldsModelMap.BatteryCharger.fields[2];
-        const connectionInfo = (processConnectionsV2(powerSourceField, hasOneWithFieldsModelMap.BatteryCharger, hasOneWithFieldsModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(
+          powerSourceField,
+          hasOneWithFieldsModelMap.BatteryCharger,
+          hasOneWithFieldsModelMap,
+        ) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
         expect(connectionInfo.connectedModel).toEqual(hasOneWithFieldsModelMap.PowerSource);
@@ -329,14 +341,14 @@ describe('GraphQL V2 process connections tests', () => {
         type Project2 @model {
           id: ID!
           name: String
-          team: Team2 @hasOne 
-        } 
-        
+          team: Team2 @hasOne
+        }
+
         type Team2 @model {
           id: ID!
           name: String!
           project: Project2! @belongsTo
-        }`
+        }`;
 
       const belongsToModelMap: CodeGenModelMap = {
         Project2: {
@@ -399,11 +411,15 @@ describe('GraphQL V2 process connections tests', () => {
 
       it('Should support belongsTo and detect connected field', () => {
         const projectField = belongsToModelMap.Team2.fields[2];
-        const connectionInfo = (processConnectionsV2(projectField, belongsToModelMap.Team2, belongsToModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(
+          projectField,
+          belongsToModelMap.Team2,
+          belongsToModelMap,
+        ) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(belongsToModelMap.Project2);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
       });
     });
 
@@ -414,14 +430,14 @@ describe('GraphQL V2 process connections tests', () => {
           name: String!
           posts: [Post] @hasMany
         }
-        
+
         type Post @model {
           id: ID!
           title: String!
           blog: Blog @belongsTo
           comments: [Comment] @hasMany
         }
-        
+
         type Comment @model {
           id: ID!
           post: Post @belongsTo
@@ -524,7 +540,7 @@ describe('GraphQL V2 process connections tests', () => {
 
       it('Should detect first has many', () => {
         const postField = hasManyModelMap.Blog.fields[2];
-        const connectionInfo = (processConnectionsV2(postField, hasManyModelMap.Blog, hasManyModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(postField, hasManyModelMap.Blog, hasManyModelMap) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Post);
@@ -533,7 +549,7 @@ describe('GraphQL V2 process connections tests', () => {
 
       it('Should detect second has many', () => {
         const commentField = hasManyModelMap.Post.fields[3];
-        const connectionInfo = (processConnectionsV2(commentField, hasManyModelMap.Post, hasManyModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(commentField, hasManyModelMap.Post, hasManyModelMap) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Comment);
@@ -542,20 +558,20 @@ describe('GraphQL V2 process connections tests', () => {
 
       it('Should detect first belongsTo', () => {
         const blogField = hasManyModelMap.Post.fields[2];
-        const connectionInfo = (processConnectionsV2(blogField, hasManyModelMap.Post, hasManyModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(blogField, hasManyModelMap.Post, hasManyModelMap) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Blog);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
       });
 
       it('Should detect second belongsTo', () => {
         const postField = hasManyModelMap.Comment.fields[1];
-        const connectionInfo = (processConnectionsV2(postField, hasManyModelMap.Comment, hasManyModelMap)) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = processConnectionsV2(postField, hasManyModelMap.Comment, hasManyModelMap) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.connectedModel).toEqual(hasManyModelMap.Post);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
       });
     });
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1279,6 +1279,8 @@ class _TagModelType extends ModelType<Tag> {
 class PostTags extends Model {
   static const classType = const _PostTagsModelType();
   final String id;
+  final String postID;
+  final String tagID;
   final Post post;
   final Tag tag;
 
@@ -1291,11 +1293,24 @@ class PostTags extends Model {
   }
 
   const PostTags._internal(
-      {@required this.id, @required this.post, @required this.tag});
+      {@required this.id,
+      @required this.postID,
+      @required this.tagID,
+      @required this.post,
+      @required this.tag});
 
-  factory PostTags({String id, @required Post post, @required Tag tag}) {
+  factory PostTags(
+      {String id,
+      @required String postID,
+      @required String tagID,
+      @required Post post,
+      @required Tag tag}) {
     return PostTags._internal(
-        id: id == null ? UUID.getUUID() : id, post: post, tag: tag);
+        id: id == null ? UUID.getUUID() : id,
+        postID: postID,
+        tagID: tagID,
+        post: post,
+        tag: tag);
   }
 
   bool equals(Object other) {
@@ -1307,6 +1322,8 @@ class PostTags extends Model {
     if (identical(other, this)) return true;
     return other is PostTags &&
         id == other.id &&
+        postID == other.postID &&
+        tagID == other.tagID &&
         post == other.post &&
         tag == other.tag;
   }
@@ -1320,6 +1337,8 @@ class PostTags extends Model {
 
     buffer.write(\\"PostTags {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"postID=\\" + \\"$postID\\" + \\", \\");
+    buffer.write(\\"tagID=\\" + \\"$tagID\\" + \\", \\");
     buffer.write(\\"post=\\" + (post != null ? post.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"tag=\\" + (tag != null ? tag.toString() : \\"null\\"));
     buffer.write(\\"}\\");
@@ -1327,13 +1346,20 @@ class PostTags extends Model {
     return buffer.toString();
   }
 
-  PostTags copyWith({String id, Post post, Tag tag}) {
+  PostTags copyWith(
+      {String id, String postID, String tagID, Post post, Tag tag}) {
     return PostTags(
-        id: id ?? this.id, post: post ?? this.post, tag: tag ?? this.tag);
+        id: id ?? this.id,
+        postID: postID ?? this.postID,
+        tagID: tagID ?? this.tagID,
+        post: post ?? this.post,
+        tag: tag ?? this.tag);
   }
 
   PostTags.fromJson(Map<String, dynamic> json)
       : id = json['id'],
+        postID = json['postID'],
+        tagID = json['tagID'],
         post = json['post'] != null
             ? Post.fromJson(new Map<String, dynamic>.from(json['post']))
             : null,
@@ -1341,10 +1367,17 @@ class PostTags extends Model {
             ? Tag.fromJson(new Map<String, dynamic>.from(json['tag']))
             : null;
 
-  Map<String, dynamic> toJson() =>
-      {'id': id, 'post': post?.toJson(), 'tag': tag?.toJson()};
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'postID': postID,
+        'tagID': tagID,
+        'post': post?.toJson(),
+        'tag': tag?.toJson()
+      };
 
   static final QueryField ID = QueryField(fieldName: \\"postTags.id\\");
+  static final QueryField POSTID = QueryField(fieldName: \\"postID\\");
+  static final QueryField TAGID = QueryField(fieldName: \\"tagID\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -1359,6 +1392,16 @@ class PostTags extends Model {
     modelSchemaDefinition.pluralName = \\"PostTags\\";
 
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: PostTags.POSTID,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
+
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+        key: PostTags.TAGID,
+        isRequired: true,
+        ofType: ModelFieldType(ModelFieldTypeEnum.string)));
 
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
         key: PostTags.POST,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -345,6 +345,47 @@ describe('AppSyncModelVisitor', () => {
       expect(projectTeamIdField).toBeDefined();
       expect(projectTeamIdField.isNullable).toBeTruthy();
     });
+
+    it('should generate keep belongsTo explicit defined field but remove the auto-generated one', () => {
+      const schema = /* GraphQL */ `
+        type Blog @model {
+          id: ID!
+          posts: [Post] @hasMany(indexName: "byBlog", fields: ["id"])
+        }
+
+        type Post @model {
+          id: ID!
+          foo: ID! @index(name: "byBlog")
+          blog: Blog @belongsTo(fields: ["foo"])
+          comments: [Comment] @hasMany
+        }
+
+        type Comment @model {
+          id: ID!
+          post: Post @belongsTo
+        }
+      `;
+
+      const ast = parse(schema);
+      const builtSchema = buildSchemaWithDirectives(schema);
+      const visitor = new AppSyncModelVisitor(
+        builtSchema,
+        { directives, target: 'typescript', generate: CodeGenGenerateEnum.code, usePipelinedTransformer: true },
+        {},
+      );
+      visit(ast, { leave: visitor });
+      visitor.generate();
+
+      const fooField = visitor.models.Post.fields.find(field => {
+        return field.name === 'foo';
+      });
+      expect(fooField).toBeDefined();
+
+      const postCommentsIdField = visitor.models.Comment.fields.find(field => {
+        return field.name === 'postCommentsId';
+      });
+      expect(postCommentsIdField).not.toBeDefined();
+    });
   });
 
   describe('index directives', () => {
@@ -853,10 +894,10 @@ describe('AppSyncModelVisitor', () => {
       expect(visitor.models.Human.fields[2].directives[0].arguments.fields[0]).toEqual('governmentID');
       expect(visitor.models.Human.fields[2].directives[0].arguments.indexName).toEqual('byHuman');
       expect(visitor.models.PetFriend).toBeDefined();
-      expect(visitor.models.PetFriend.fields.length).toEqual(5);
-      expect(visitor.models.PetFriend.fields[2].directives[0].name).toEqual('belongsTo');
-      expect(visitor.models.PetFriend.fields[2].directives[0].arguments.fields.length).toEqual(1);
-      expect(visitor.models.PetFriend.fields[2].directives[0].arguments.fields[0]).toEqual('animalID');
+      expect(visitor.models.PetFriend.fields.length).toEqual(7);
+      expect(visitor.models.PetFriend.fields[4].directives[0].name).toEqual('belongsTo');
+      expect(visitor.models.PetFriend.fields[4].directives[0].arguments.fields.length).toEqual(1);
+      expect(visitor.models.PetFriend.fields[4].directives[0].arguments.fields[0]).toEqual('animalID');
       expect(visitor.models.Animal.fields.length).toEqual(5);
       expect(visitor.models.Animal.fields[2].type).toEqual('PetFriend');
       expect(visitor.models.Animal.fields[2].directives.length).toEqual(1);
@@ -876,7 +917,7 @@ describe('AppSyncModelVisitor', () => {
       expect(visitor.models.ModelA.fields[1].directives[0].arguments.indexName).toEqual('byModelA');
 
       expect(visitor.models.Models).toBeDefined();
-      expect(visitor.models.Models.fields.length).toEqual(5);
+      expect(visitor.models.Models.fields.length).toEqual(7);
 
       const modelA = visitor.models.Models.fields.find(f => f.name === 'modelA');
       expect(modelA).toBeDefined();

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -1,12 +1,6 @@
 import { CodeGenDirective, CodeGenField, CodeGenModel, CodeGenModelMap } from '../visitors/appsync-visitor';
-import {
-  CodeGenConnectionType,
-  CodeGenFieldConnection,
-  flattenFieldDirectives,
-  makeConnectionAttributeName,
-} from './process-connections';
+import { CodeGenConnectionType, CodeGenFieldConnection, flattenFieldDirectives, makeConnectionAttributeName } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';
-
 
 export function processBelongsToConnection(
   field: CodeGenField,
@@ -24,9 +18,7 @@ export function processBelongsToConnection(
   }
 
   if (field.isList) {
-    throw new Error(
-      `A list field does not support the 'belongsTo' relation`
-    );
+    throw new Error(`A list field does not support the 'belongsTo' relation`);
   }
 
   let validOtherSideField = false;
@@ -37,34 +29,45 @@ export function processBelongsToConnection(
   });
 
   if (!validOtherSideField) {
-    throw new Error(
-      `A 'belongsTo' field should match to a corresponding 'hasMany' or 'hasOne' field`
-    );
+    throw new Error(`A 'belongsTo' field should match to a corresponding 'hasMany' or 'hasOne' field`);
   }
   // if a type is connected using name, then amplify-graphql-relational-transformer adds a field to
   //  track the connection and that field is not part of the selection set
   // but if the field are connected using fields argument in connection directive
   // we are reusing the field and it should be preserved in selection set
   const otherSideHasMany = otherSideField.isList;
-  const isConnectingFieldAutoCreated = false;
+  const isConnectingFieldAutoCreated = !connectionFields.length;
 
   return {
     kind: CodeGenConnectionType.BELONGS_TO,
     connectedModel: otherSide,
     isConnectingFieldAutoCreated,
-    targetName: connectionFields[0] || (otherSideHasMany ? makeConnectionAttributeName(otherSide.name, otherSideField.name) :
-      makeConnectionAttributeName(model.name, field.name)),
+    targetName:
+      connectionFields[0] ||
+      (otherSideHasMany
+        ? makeConnectionAttributeName(otherSide.name, otherSideField.name)
+        : makeConnectionAttributeName(model.name, field.name)),
   };
 }
 
-export function getBelongsToConnectedField(field: CodeGenField, model: CodeGenModel, connectedModel: CodeGenModel): CodeGenField | undefined {
+export function getBelongsToConnectedField(
+  field: CodeGenField,
+  model: CodeGenModel,
+  connectedModel: CodeGenModel,
+): CodeGenField | undefined {
   let otherSideDirectives = flattenFieldDirectives(connectedModel).filter(dir => {
-    const connectedField = connectedModel.fields.find(connField => { return connField.name === dir.fieldName; });
+    const connectedField = connectedModel.fields.find(connField => {
+      return connField.name === dir.fieldName;
+    });
     const fieldType = connectedField?.type;
-    return ((dir.name === 'hasOne' && !connectedField?.isList) || (dir.name === 'hasMany' && connectedField?.isList)) && model.name === fieldType;
+    return (
+      ((dir.name === 'hasOne' && !connectedField?.isList) || (dir.name === 'hasMany' && connectedField?.isList)) && model.name === fieldType
+    );
   });
 
   if (otherSideDirectives?.length === 1) {
-    return connectedModel.fields.find(connField => { return connField.name === otherSideDirectives[0].fieldName; });
+    return connectedModel.fields.find(connField => {
+      return connField.name === otherSideDirectives[0].fieldName;
+    });
   }
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -546,13 +546,7 @@ export class AppSyncModelVisitor<
     });
   }
 
-  protected generateIntermediateModel(
-    firstModel: CodeGenModel,
-    secondModel: CodeGenModel,
-    firstField: CodeGenField,
-    secondField: CodeGenField,
-    relationName: string,
-  ) {
+  protected generateIntermediateModel(firstModel: CodeGenModel, secondModel: CodeGenModel, relationName: string) {
     const firstModelKeyFieldName = `${camelCase(firstModel.name)}ID`;
     const secondModelKeyFieldName = `${camelCase(secondModel.name)}ID`;
     let intermediateModel: CodeGenModel = {
@@ -659,8 +653,6 @@ export class AppSyncModelVisitor<
       let intermediateModel = this.generateIntermediateModel(
         value[0].model,
         value[1].model,
-        value[0].field,
-        value[1].field,
         graphqlName(toUpper(value[0].directive.arguments.relationName)),
       );
       const modelDirective = intermediateModel.directives.find(directive => directive.name === 'model');
@@ -693,7 +685,7 @@ export class AppSyncModelVisitor<
               isList: false,
               isNullable: field.isNullable,
             });
-          } else if (connectionInfo.targetName !== 'id') {
+          } else if (connectionInfo.targetName !== 'id' && connectionInfo.isConnectingFieldAutoCreated) {
             // Need to remove the field that is targetName
             removeFieldFromModel(model, connectionInfo.targetName);
           }


### PR DESCRIPTION
#### Description of changes
- prevent removing belongsTo explicit defined link fields
- affects the number of fields in the intermediary generated model for @manyToMany relationship

#### Issue #[9407](https://github.com/aws-amplify/amplify-cli/issues/9407)

#### Description of how you validated changes
- manual testing in a JS project
- updated existing many to many test
- added test for belongsTo with explicit defined field

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.