### PR TITLE
feat(modelgen): Custom primary key support

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -101,8 +101,7 @@ describe('Javascript visitor', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -159,8 +158,7 @@ describe('Javascript visitor', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -294,8 +292,7 @@ describe('Javascript visitor with default owner auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -368,8 +365,7 @@ describe('Javascript visitor with custom owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -444,8 +440,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -510,8 +505,7 @@ describe('Javascript visitor with auth directives in field level', () => {
       const declarations = declarationVisitor.generate();
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
-        "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+        "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 
@@ -609,8 +603,7 @@ describe('Javascript visitor with custom primary key', () => {
     const declarations = visitor.generate();
     validateTs(declarations);
     expect(declarations).toMatchInlineSnapshot(`
-      "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-      import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+      "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 
@@ -708,8 +701,7 @@ describe('Javascript visitor with custom primary key', () => {
     const declarations = visitor.generate();
     validateTs(declarations);
     expect(declarations).toMatchInlineSnapshot(`
-      "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
-      import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+      "import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -102,6 +102,7 @@ describe('Javascript visitor', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -112,6 +113,14 @@ describe('Javascript visitor', () => {
           readonly id: string;
           readonly names?: (string | null)[];
           constructor(init: ModelInit<SimpleNonModelType>);
+        }
+
+        type SimpleModelMetaData = {
+          identifier: ManagedIdentifier;
+        }
+
+        type BarMetaData = {
+          identifier: ManagedIdentifier;
         }
 
         export declare class SimpleModel {
@@ -151,6 +160,7 @@ describe('Javascript visitor', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -164,10 +174,12 @@ describe('Javascript visitor', () => {
         }
 
         type SimpleModelMetaData = {
+          identifier: ManagedIdentifier;
           readOnlyFields: 'createdAt' | 'updatedAt';
         }
 
         type BarMetaData = {
+          identifier: ManagedIdentifier;
           readOnlyFields: 'createdAt' | 'updatedAt';
         }
 
@@ -283,6 +295,7 @@ describe('Javascript visitor with default owner auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -293,6 +306,10 @@ describe('Javascript visitor with default owner auth', () => {
           readonly id: string;
           readonly names?: (string | null)[];
           constructor(init: ModelInit<SimpleNonModelType>);
+        }
+
+        type SimpleModelMetaData = {
+          identifier: ManagedIdentifier;
         }
 
         export declare class SimpleModel {
@@ -352,6 +369,7 @@ describe('Javascript visitor with custom owner field auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -362,6 +380,10 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly id: string;
           readonly names?: (string | null)[];
           constructor(init: ModelInit<SimpleNonModelType>);
+        }
+
+        type SimpleModelMetaData = {
+          identifier: ManagedIdentifier;
         }
 
         export declare class SimpleModel {
@@ -423,6 +445,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -433,6 +456,10 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly id: string;
           readonly names?: (string | null)[];
           constructor(init: ModelInit<SimpleNonModelType>);
+        }
+
+        type SimpleModelMetaData = {
+          identifier: ManagedIdentifier;
         }
 
         export declare class SimpleModel {
@@ -484,10 +511,15 @@ describe('Javascript visitor with auth directives in field level', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+        import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 
 
+
+        type EmployeeMetaData = {
+          identifier: ManagedIdentifier;
+        }
 
         export declare class Employee {
           readonly id: string;
@@ -515,7 +547,7 @@ describe('Javascript visitor with custom primary key', () => {
       workItemId: ID!
     }
 
-    type WorkItem1 @model @key(fields: ["project", "work ItemId"]) {
+    type WorkItem1 @model @key(fields: ["project", "workItemId"]) {
       project: ID!
       workItemId: ID!
     }
@@ -541,6 +573,11 @@ describe('Javascript visitor with custom primary key', () => {
     }
   `;
   const schemaV2 = /* GraphQL */ `
+    type WorkItem0 @model {
+      project: ID! @index(name: "byProject", sortKeyFields: ["workItemId"])
+      workItemId: ID!
+    }
+
     type WorkItem1 @model {
       project: ID! @primaryKey(sortKeyFields: ["workItemId"])
       workItemId: ID!
@@ -569,8 +606,11 @@ describe('Javascript visitor with custom primary key', () => {
 
   it('should generate correct declaration with custom primary key support in V1 GraphQL schema', () => {
     const visitor = getVisitor(schemaV1, true, true);
-    expect(visitor.generate()).toMatchInlineSnapshot(`
+    const declarations = visitor.generate();
+    validateTs(declarations);
+    expect(declarations).toMatchInlineSnapshot(`
       "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+      import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 
@@ -585,7 +625,7 @@ describe('Javascript visitor with custom primary key', () => {
       }
 
       type WorkItem1MetaData = {
-        identifier: CustomIdentifier<'project' | 'work ItemId'>;
+        identifier: CustomIdentifier<'project' | 'workItemId'>;
         readOnlyFields: 'createdAt' | 'updatedAt';
       }
 
@@ -663,16 +703,24 @@ describe('Javascript visitor with custom primary key', () => {
     `);
   });
 
-  it.only('should generate correct declaration with custom primary key support in V2 GraphQL schema', () => {
+  it('should generate correct declaration with custom primary key support in V2 GraphQL schema', () => {
     const visitor = getVisitor(schemaV2, true, true, 2);
-    expect(visitor.generate()).toMatchInlineSnapshot(`
+    const declarations = visitor.generate();
+    validateTs(declarations);
+    expect(declarations).toMatchInlineSnapshot(`
       "import { ModelInit, MutableModel, PersistentModelConstructor } from \\"@aws-amplify/datastore\\";
+      import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
 
 
 
       export declare class WorkItem6 {
         readonly id: string;
         constructor(init: ModelInit<WorkItem6>);
+      }
+
+      type WorkItem0MetaData = {
+        identifier: ManagedIdentifier;
+        readOnlyFields: 'createdAt' | 'updatedAt';
       }
 
       type WorkItem1MetaData = {
@@ -698,6 +746,16 @@ describe('Javascript visitor with custom primary key', () => {
       type WorkItem5MetaData = {
         identifier: ManagedIdentifier;
         readOnlyFields: 'createdAt' | 'updatedAt';
+      }
+
+      export declare class WorkItem0 {
+        readonly id: string;
+        readonly project: string;
+        readonly workItemId: string;
+        readonly createdAt?: string;
+        readonly updatedAt?: string;
+        constructor(init: ModelInit<WorkItem0, WorkItem0MetaData>);
+        static copyOf(source: WorkItem0, mutator: (draft: MutableModel<WorkItem0, WorkItem0MetaData>) => MutableModel<WorkItem0, WorkItem0MetaData> | void): WorkItem0;
       }
 
       export declare class WorkItem1 {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -1,7 +1,7 @@
 import { buildSchema, parse, visit } from 'graphql';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { CodeGenConnectionType, CodeGenFieldConnectionBelongsTo, CodeGenFieldConnectionHasMany } from '../../utils/process-connections';
-import { AppSyncModelVisitor, CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+import { AppSyncModelVisitor, CodeGenGenerateEnum, CodeGenPrimaryKeyType } from '../../visitors/appsync-visitor';
 
 const buildSchemaWithDirectives = (schema: String) => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -895,6 +895,182 @@ describe('AppSyncModelVisitor', () => {
       expect(visitor.models.ModelB.fields[1].directives[0].arguments.fields.length).toEqual(1);
       expect(visitor.models.ModelB.fields[1].directives[0].arguments.fields[0]).toEqual('id');
       expect(visitor.models.ModelB.fields[1].directives[0].arguments.indexName).toEqual('byModelB');
+    });
+  });
+
+  describe('Primary Key Type', () => {
+    describe('V1 GraphQL schema tests', () => {
+      const schemaV1 = /* GraphQL */ `
+        type WorkItem0 @model @key(name: "byProject", fields: ["project", "workItemId"]) {
+          project: ID!
+          workItemId: ID!
+        }
+
+        type WorkItem1 @model @key(fields: ["project", "workItemId"]) {
+          project: ID!
+          workItemId: ID!
+        }
+
+        type WorkItem2 @model @key(fields: ["project"]) {
+          project: ID!
+        }
+
+        type WorkItem3 @model @key(fields: ["id"]) {
+          id: ID!
+        }
+
+        type WorkItem4 @model @key(fields: ["id", "workItemId"]) {
+          id: ID!
+          workItemId: ID!
+        }
+
+        type WorkItem5 @model {
+          id: ID!
+        }
+
+        type WorkItem6 @model {
+          title: String
+        }
+
+        type WorkItem7 {
+          id: ID!
+        }
+      `;
+      const { models, nonModels } = createAndGenerateVisitor(schemaV1);
+      it('should have id field as primary key when no custom PK defined', () => {
+        const primaryKeyField = models.WorkItem0.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key and sort key defined', () => {
+        const primaryKeyField = models.WorkItem1.fields.find(field => field.name === 'project');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.CustomId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(1);
+      });
+      it('should have correct primary key info when custom primary key defined', () => {
+        const primaryKeyField = models.WorkItem2.fields.find(field => field.name === 'project');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.CustomId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key is defined as "id"', () => {
+        const primaryKeyField = models.WorkItem3.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.OptionallyManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key is defined as "id" and sort key defined', () => {
+        const primaryKeyField = models.WorkItem4.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.OptionallyManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(1);
+      });
+      it('should have correct primary key info in explicit simple model', () => {
+        const primaryKeyField = models.WorkItem5.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info in implicit simple model', () => {
+        const primaryKeyField = models.WorkItem6.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should not have primary key info in non model', () => {
+        const primaryKeyField = nonModels.WorkItem7.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo).not.toBeDefined();
+      });
+    });
+
+    describe('V2 GraphQL schema tests', () => {
+      const schemaV2 = /* GraphQL */ `
+        type WorkItem0 @model {
+          project: ID! @index(name: "byProject", sortKeyFields: ["workItemId"])
+          workItemId: ID!
+        }
+
+        type WorkItem1 @model {
+          project: ID! @primaryKey(sortKeyFields: ["workItemId"])
+          workItemId: ID!
+        }
+
+        type WorkItem2 @model {
+          project: ID! @primaryKey
+        }
+
+        type WorkItem3 @model {
+          id: ID! @primaryKey
+        }
+
+        type WorkItem4 @model {
+          id: ID! @primaryKey(sortKeyFields: ["workItemId"])
+          workItemId: ID!
+        }
+
+        type WorkItem5 @model {
+          id: ID!
+        }
+
+        type WorkItem6 @model {
+          title: String
+        }
+
+        type WorkItem7 {
+          id: ID!
+        }
+      `;
+      const { models, nonModels } = createAndGeneratePipelinedTransformerVisitor(schemaV2);
+      it('should have id field as primary key when no custom PK defined', () => {
+        const primaryKeyField = models.WorkItem0.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key and sort key defined', () => {
+        const primaryKeyField = models.WorkItem1.fields.find(field => field.name === 'project');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.CustomId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(1);
+      });
+      it('should have correct primary key info when custom primary key defined', () => {
+        const primaryKeyField = models.WorkItem2.fields.find(field => field.name === 'project');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.CustomId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key is defined as "id"', () => {
+        const primaryKeyField = models.WorkItem3.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.OptionallyManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info when custom primary key is defined as "id" and sort key defined', () => {
+        const primaryKeyField = models.WorkItem4.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.OptionallyManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(1);
+      });
+      it('should have correct primary key info in explicit simple model', () => {
+        const primaryKeyField = models.WorkItem5.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should have correct primary key info in implicit simple model', () => {
+        const primaryKeyField = models.WorkItem6.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo.primaryKeyType).toBe(CodeGenPrimaryKeyType.ManagedId);
+        expect(primaryKeyField.primaryKeyInfo.sortKeyFields.length).toBe(0);
+      });
+      it('should not have primary key info in non model', () => {
+        const primaryKeyField = nonModels.WorkItem7.fields.find(field => field.name === 'id');
+        expect(primaryKeyField).toBeDefined();
+        expect(primaryKeyField.primaryKeyInfo).not.toBeDefined();
+      });
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -385,7 +385,7 @@ describe('AppSyncModelVisitor', () => {
       const schema = /* GraphQL */ `
         type Project @model {
           id: ID!
-          name: String @primaryKey(sortKeyFields: ["team"])
+          name: String! @primaryKey(sortKeyFields: ["team"])
           team: Team
         }
 
@@ -847,11 +847,11 @@ describe('AppSyncModelVisitor', () => {
     it('Should correctly convert the model map of a simple manyToMany', () => {
       const visitor = createAndGeneratePipelinedTransformerVisitor(simpleManyToManySchema);
 
-      expect(visitor.models.Human.fields.length).toEqual(5);
-      expect(visitor.models.Human.fields[2].directives[0].name).toEqual('hasMany');
-      expect(visitor.models.Human.fields[2].directives[0].arguments.fields.length).toEqual(1);
-      expect(visitor.models.Human.fields[2].directives[0].arguments.fields[0]).toEqual('governmentID');
-      expect(visitor.models.Human.fields[2].directives[0].arguments.indexName).toEqual('byHuman');
+      expect(visitor.models.Human.fields.length).toEqual(4);
+      expect(visitor.models.Human.fields[1].directives[0].name).toEqual('hasMany');
+      expect(visitor.models.Human.fields[1].directives[0].arguments.fields.length).toEqual(1);
+      expect(visitor.models.Human.fields[1].directives[0].arguments.fields[0]).toEqual('governmentID');
+      expect(visitor.models.Human.fields[1].directives[0].arguments.indexName).toEqual('byHuman');
       expect(visitor.models.PetFriend).toBeDefined();
       expect(visitor.models.PetFriend.fields.length).toEqual(5);
       expect(visitor.models.PetFriend.fields[2].directives[0].name).toEqual('belongsTo');

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -60,15 +60,11 @@ export class AppSyncModelJavascriptVisitor<
         .map(typeObj => this.generateModelDeclaration(typeObj, true))
         .join('\n\n');
 
-      if (!this.config.isTimestampFieldsAdded) {
-        return [imports, enumDeclarations, nonModelDeclarations, modelDeclarations].join('\n\n');
-      } else {
-        const modelMetaData = Object.values(this.modelMap)
-          .map(typeObj => this.generateModelMetaData(typeObj))
-          .join('\n\n');
+      const modelMetaData = Object.values(this.modelMap)
+        .map(typeObj => this.generateModelMetaData(typeObj))
+        .join('\n\n');
 
-        return [imports, enumDeclarations, nonModelDeclarations, modelMetaData, modelDeclarations].join('\n\n');
-      }
+      return [imports, enumDeclarations, nonModelDeclarations, modelMetaData, modelDeclarations].join('\n\n');
     } else {
       const imports = this.generateImportsJavaScriptImplementation();
       const enumDeclarations = Object.values(this.enumMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -33,8 +33,7 @@ export class AppSyncModelJavascriptVisitor<
   TPluginConfig extends ParsedAppSyncModelJavaScriptConfig = ParsedAppSyncModelJavaScriptConfig
 > extends AppSyncModelTypeScriptVisitor<TRawConfig, TPluginConfig> {
   protected IMPORT_STATEMENTS = [
-    'import { ModelInit, MutableModel, PersistentModelConstructor } from "@aws-amplify/datastore";',
-    'import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from "@aws-amplify/datastore";',
+    'import { ModelInit, MutableModel, PersistentModelConstructor, ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from "@aws-amplify/datastore";',
   ];
 
   constructor(

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -32,7 +32,10 @@ export class AppSyncModelJavascriptVisitor<
   TRawConfig extends RawAppSyncModelJavaScriptConfig = RawAppSyncModelJavaScriptConfig,
   TPluginConfig extends ParsedAppSyncModelJavaScriptConfig = ParsedAppSyncModelJavaScriptConfig
 > extends AppSyncModelTypeScriptVisitor<TRawConfig, TPluginConfig> {
-  protected IMPORT_STATEMENTS = ['import { ModelInit, MutableModel, PersistentModelConstructor } from "@aws-amplify/datastore";'];
+  protected IMPORT_STATEMENTS = [
+    'import { ModelInit, MutableModel, PersistentModelConstructor } from "@aws-amplify/datastore";',
+    'import { ManagedIdentifier, OptionallyManagedIdentifier, CustomIdentifier } from "@aws-amplify/datastore";',
+  ];
 
   constructor(
     schema: GraphQLSchema,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -5,6 +5,7 @@ import {
   CodeGenEnum,
   CodeGenField,
   CodeGenModel,
+  CodeGenPrimaryKeyType,
   ParsedAppSyncModelConfig,
   RawAppSyncModelConfig,
 } from './appsync-visitor';
@@ -76,6 +77,8 @@ export class AppSyncModelTypeScriptVisitor<
       .withName(`${modelName}MetaData`)
       .export(false);
 
+    modelDeclarations.addProperty('identifier', this.constructIdentifier(modelObj));
+
     const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
     let readOnlyFieldNames: string[] = [];
 
@@ -84,9 +87,25 @@ export class AppSyncModelTypeScriptVisitor<
         readOnlyFieldNames.push(`'${field.name}'`);
       }
     });
-    modelDeclarations.addProperty('readOnlyFields', readOnlyFieldNames.join(' | '));
+    if (readOnlyFieldNames.length) {
+      modelDeclarations.addProperty('readOnlyFields', readOnlyFieldNames.join(' | '));
+    }
 
     return modelDeclarations.string;
+  }
+
+  protected constructIdentifier(modelObj: CodeGenModel): string {
+    const primaryKeyField = modelObj.fields.find(f => f.primaryKeyInfo)!;
+    const { primaryKeyType, sortKeyFields } = primaryKeyField.primaryKeyInfo!;
+    switch (primaryKeyType) {
+      case CodeGenPrimaryKeyType.ManagedId:
+        return 'ManagedIdentifier';
+      case CodeGenPrimaryKeyType.OptionallyManagedId:
+        return 'OptionallyManagedIdentifier';
+      case CodeGenPrimaryKeyType.CustomId:
+        const identifierFields: string[] = [primaryKeyField.name, ...sortKeyFields].filter(f => f);
+        return `CustomIdentifier<${identifierFields.map(fieldStr => `'${fieldStr}'`).join(' | ')}>`;
+    }
   }
 
   /**

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -263,7 +263,6 @@ export class AppSyncModelVisitor<
         fields,
       };
       this.ensurePrimaryKeyField(model, directives);
-      // this.ensureIdField(model);
       this.addTimestampFields(model, modelDirective);
       this.sortFields(model);
       this.modelMap[node.name.value] = model;
@@ -506,6 +505,11 @@ export class AppSyncModelVisitor<
     }, [] as CodeGenField[]);
   }
 
+  /**
+   * Check out if primary key field exists in the model and generate primary key info
+   * @param model type defined with model directives
+   * @param directives directives defined at the type level of the model above
+   */
   protected ensurePrimaryKeyField(model: CodeGenModel, directives: CodeGenDirective[]) {
     let primaryKeyFieldName: string;
     let primaryKeyField: CodeGenField;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -23,7 +23,7 @@ import {
 } from 'graphql';
 import { addFieldToModel, getDirective, removeFieldFromModel } from '../utils/fieldUtils';
 import { getTypeInfo } from '../utils/get-type-info';
-import { CodeGenConnectionType, CodeGenFieldConnection, processConnections } from '../utils/process-connections';
+import { CodeGenConnectionType, CodeGenFieldConnection, flattenFieldDirectives, processConnections } from '../utils/process-connections';
 import { sortFields } from '../utils/sort';
 import { printWarning } from '../utils/warn';
 import { processAuthDirective } from '../utils/process-auth';
@@ -153,7 +153,17 @@ export type CodeGenField = TypeInfo & {
   directives: CodeGenDirectives;
   connectionInfo?: CodeGenFieldConnection;
   isReadOnly?: boolean;
+  primaryKeyInfo?: CodeGenPrimaryKeyFieldInfo;
 };
+export type CodeGenPrimaryKeyFieldInfo = {
+  primaryKeyType: CodeGenPrimaryKeyType;
+  sortKeyFields: string[];
+};
+export enum CodeGenPrimaryKeyType {
+  ManagedId = 'ManagedId',
+  OptionallyManagedId = 'OptionallyManagedId',
+  CustomId = 'CustomId',
+}
 export type TypeInfo = {
   type: string;
   isList: boolean;
@@ -252,7 +262,8 @@ export class AppSyncModelVisitor<
         directives,
         fields,
       };
-      this.ensureIdField(model);
+      this.ensurePrimaryKeyField(model, directives);
+      // this.ensureIdField(model);
       this.addTimestampFields(model, modelDirective);
       this.sortFields(model);
       this.modelMap[node.name.value] = model;
@@ -493,6 +504,69 @@ export class AppSyncModelVisitor<
       }
       return acc;
     }, [] as CodeGenField[]);
+  }
+
+  protected ensurePrimaryKeyField(model: CodeGenModel, directives: CodeGenDirective[]) {
+    let primaryKeyFieldName: string;
+    let primaryKeyField: CodeGenField;
+    //Transformer V2
+    if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
+      const fieldWithPrimaryKeyDirective = model.fields.find(f => f.directives.find(dir => dir.name === 'primaryKey'));
+      //No @primaryKey found, default to 'id' field
+      if (!fieldWithPrimaryKeyDirective) {
+        primaryKeyFieldName = 'id';
+        this.ensureIdField(model);
+        primaryKeyField = this.getPrimaryKeyFieldByName(model, primaryKeyFieldName);
+        //Managed Id Type
+        primaryKeyField.primaryKeyInfo = {
+          primaryKeyType: CodeGenPrimaryKeyType.ManagedId,
+          sortKeyFields: [],
+        };
+      } else {
+        primaryKeyFieldName = fieldWithPrimaryKeyDirective.name;
+        primaryKeyField = this.getPrimaryKeyFieldByName(model, primaryKeyFieldName);
+        const sortKeyFields = flattenFieldDirectives(model).find(d => d.name === 'primaryKey')?.arguments.sortKeyFields;
+        primaryKeyField.primaryKeyInfo = {
+          primaryKeyType: primaryKeyFieldName === 'id' ? CodeGenPrimaryKeyType.OptionallyManagedId : CodeGenPrimaryKeyType.CustomId,
+          sortKeyFields: sortKeyFields ?? [],
+        };
+      }
+    }
+    //Transformer V1
+    else {
+      const keyDirective = directives.find(d => d.name === 'key' && !d.arguments.name);
+      if (keyDirective) {
+        primaryKeyFieldName = keyDirective.arguments.fields[0]!;
+        primaryKeyField = this.getPrimaryKeyFieldByName(model, primaryKeyFieldName);
+        const sortKeyFields = keyDirective.arguments.fields.slice(1);
+        primaryKeyField.primaryKeyInfo = {
+          primaryKeyType: primaryKeyFieldName === 'id' ? CodeGenPrimaryKeyType.OptionallyManagedId : CodeGenPrimaryKeyType.CustomId,
+          sortKeyFields,
+        };
+      }
+      //default primary key field as id
+      else {
+        primaryKeyFieldName = 'id';
+        this.ensureIdField(model);
+        primaryKeyField = this.getPrimaryKeyFieldByName(model, primaryKeyFieldName);
+        //Managed Id Type
+        primaryKeyField.primaryKeyInfo = {
+          primaryKeyType: CodeGenPrimaryKeyType.ManagedId,
+          sortKeyFields: [],
+        };
+      }
+    }
+  }
+
+  protected getPrimaryKeyFieldByName(model: CodeGenModel, primaryKeyFieldName: string): CodeGenField {
+    const primaryKeyField = model.fields.find(f => f.name === primaryKeyFieldName);
+    if (!primaryKeyField) {
+      throw new Error(`Cannot find primary key field in type ${model.name}`);
+    }
+    if (primaryKeyField.isNullable) {
+      throw new Error(`The primary key on type '${model.name}' must reference non-null fields.`);
+    }
+    return primaryKeyField;
   }
 
   protected ensureIdField(model: CodeGenModel) {

--- a/packages/graphql-types-generator/package.json
+++ b/packages/graphql-types-generator/package.json
@@ -74,8 +74,7 @@
     ],
     "testMatch": [
       "**/test/**/*.(js|ts)",
-      "**/test/*.(js|ts)",
-      "**/__tests__/*.(js|ts)"
+      "**/test/*.(js|ts)"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add custom primary key support for datastore modelgen

- Fixed the bug that 'id' field is auto-generated even if the different primary key is defined
- Introduced three types of primary key and being processed as model metadata
  - `ManagedId`
  - `OptionallyManagedId`
  - `CustomId`
- Added primary key support code snippet in type declaration for Amplify JS

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Related JS PR: https://github.com/aws-amplify/amplify-js/pull/9380


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.