### PR TITLE
fix(modelgen): remove timestamps if defined null in @model

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -680,6 +680,21 @@ describe('AppSyncModelVisitor', () => {
       const updatedAtField = postFields.find(field => field.name === 'updatedOn');
       expect(updatedAtField).toMatchObject(updatedAtFieldObj);
     });
+    it('should not generate timestamp fields if "timestamps:null" is defined in @model', () => {
+      const schema = /* GraphQL */ `
+        type Post @model(timestamps: null) {
+          id: ID!
+        }
+      `;
+      const visitor = createAndGenerateVisitor(schema);
+      expect(visitor.models.Post).toBeDefined();
+
+      const postFields = visitor.models.Post.fields;
+      const createdAtField = postFields.find(field => field.name === 'createdAt');
+      expect(createdAtField).not.toBeDefined();
+      const updatedAtField = postFields.find(field => field.name === 'updatedAt');
+      expect(updatedAtField).not.toBeDefined();
+    });
   });
 
   describe('manyToMany testing', () => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -761,6 +761,10 @@ export class AppSyncModelVisitor<
     if (directive.name !== 'model') {
       return;
     }
+    //when the '{timestamps: null}' is defined in @model, the timestamp fields should not be generated
+    if (directive.arguments && directive.arguments.hasOwnProperty('timestamps') && directive.arguments.timestamps === null) {
+      return;
+    }
     const timestamps = directive.arguments.timestamps;
     const createdAtField: CodeGenField = {
       name: timestamps?.createdAt || DEFAULT_CREATED_TIME,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Remove the timestamp fields if it is defined `null` explicitly in `@model`.
**Example schema:**
```GraphQL
type Post @model(timestamps: null) {
  id: ID!
}
```
Timestamp fields `createdAt` and `updatedAt` will not be generated, which is consistent with the `@model` transformer behavior.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.