### PR TITLE
fix: update expected messages per change to CLI https://github.com/aws-amplify/amplify-cli/pull/8573

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-codegen-e2e-tests/src/environment/env.ts
@@ -157,7 +157,7 @@ export function addEnvironmentHostedUI(cwd: string, settings: { envName: string 
       .sendLine(AMAZON_APP_ID)
       .wait('Enter your Amazon App Secret for your OAuth flow:')
       .sendLine(AMAZON_APP_SECRET)
-      .wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything')
+      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
           resolve();

--- a/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
@@ -86,7 +86,7 @@ async function initWorkflow(cwd: string, settings: { accessKeyId: string; secret
 
     singleSelect(chain, settings.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify publish" to deploy everything').run((err: Error) => {
+    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
       if (!err) {
         resolve();
       } else {


### PR DESCRIPTION
#### Description of changes
E2E tests started failing w/ CLI version 7.6.7, looks like it's because we're waiting on a response message which isn't coming since it was renamed in https://github.com/aws-amplify/amplify-cli/pull/8573

#### Issue #, if available
N/A

#### Description of how you validated changes
Will validate in E2E workflow runs.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.