### PR TITLE
feat: use sub as default identity claim

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -86,6 +86,7 @@ async function generateModels(context) {
   const emitAuthProvider = readFeatureFlag('codegen.emitAuthProvider');
   const usePipelinedTransformer = readFeatureFlag('graphQLTransformer.useExperimentalPipelinedTransformer')
   const transformerVersion = readNumericFeatureFlag('graphQLTransformer.transformerVersion');
+  const useSubForDefaultIdentityClaim = readFeatureFlag('graphQLTransformer.useSubForDefaultIdentityClaim');
 
   let isTimestampFieldsAdded = readFeatureFlag('codegen.addTimestampFields');
   let enableDartNullSafety = readFeatureFlag('codegen.enableDartNullSafety');
@@ -124,6 +125,7 @@ async function generateModels(context) {
       usePipelinedTransformer,
       enableDartZeroThreeFeatures,
       transformerVersion,
+      useSubForDefaultIdentityClaim
     },
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-auth.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-auth.test.ts
@@ -116,6 +116,19 @@ describe('process auth directive', () => {
         provider: AuthProvider.userPools,
       });
     });
+
+    it('should use sub as default identity claim instead of username if "useSubDefaultIdentityClaim" is true', () => {
+      ownerAuthRule.operations = [AuthModelOperation.read];
+      ownerAuthRule.provider = AuthProvider.userPools;
+      ownerAuthRule.ownerField = 'owner';
+
+      const directives: CodeGenDirectives = [buildAuthDirective(ownerAuthRule)];
+      const processedAuthDirective = processAuthDirective(directives, true);
+      expect(processedAuthDirective[0].arguments.rules[0]).toEqual({
+        ...ownerAuthRule,
+        identityClaim: 'sub',
+      });
+    })
   });
 
   describe('Group auth', () => {

--- a/packages/appsync-modelgen-plugin/src/utils/process-auth.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-auth.ts
@@ -26,7 +26,6 @@ export enum AuthModelMutation {
 }
 
 const DEFAULT_GROUP_CLAIM = 'cognito:groups';
-const DEFAULT_IDENTITY_CLAIM = 'username';
 const DEFAULT_OPERATIONS = [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete, AuthModelOperation.read];
 const DEFAULT_AUTH_PROVIDER = AuthProvider.userPools;
 const DEFAULT_OWNER_FIELD = 'owner';
@@ -51,9 +50,9 @@ export type AuthDirective = CodeGenDirective & {
   };
 };
 
-export function processAuthDirective(directives: CodeGenDirectives): AuthDirective[] {
+export function processAuthDirective(directives: CodeGenDirectives, useSubForDefaultIdentityClaim: boolean = false): AuthDirective[] {
   const authDirectives = directives.filter(d => d.name === 'auth');
-
+  const DEFAULT_IDENTITY_CLAIM = useSubForDefaultIdentityClaim ? 'sub' : 'username';
   return authDirectives.map(d => {
     // filter dynamic groups as they are not supported in subscription
     const authRules: AuthRule[] = d.arguments.rules || [];

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -124,6 +124,12 @@ export interface RawAppSyncModelConfig extends RawConfig {
    * @descriptions optional number which determines which version of the GraphQL transformer to use
    */
   transformerVersion?: number;
+  /**
+   * @name useSubForDefaultIdentityClaim
+   * @type boolean
+   * @descriptions optional boolean which determines whether to use sub as default identity claim
+   */
+  useSubForDefaultIdentityClaim?: boolean;
 }
 
 // Todo: need to figure out how to share config
@@ -135,6 +141,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   handleListNullabilityTransparently?: boolean;
   usePipelinedTransformer?: boolean;
   transformerVersion?: number;
+  useSubForDefaultIdentityClaim?: boolean;
 }
 export type CodeGenArgumentsMap = Record<string, any>;
 
@@ -225,6 +232,7 @@ export class AppSyncModelVisitor<
       handleListNullabilityTransparently: rawConfig.handleListNullabilityTransparently,
       usePipelinedTransformer: rawConfig.usePipelinedTransformer,
       transformerVersion: rawConfig.transformerVersion,
+      useSubForDefaultIdentityClaim: rawConfig.useSubForDefaultIdentityClaim,
     });
 
     const typesUsedInDirectives: string[] = [];
@@ -826,13 +834,13 @@ export class AppSyncModelVisitor<
     //model @auth process
     Object.values(this.modelMap).forEach(model => {
       const filteredDirectives = model.directives.filter(d => d.name !== 'auth');
-      const authDirectives = processAuthDirective(model.directives);
+      const authDirectives = processAuthDirective(model.directives, this.config.useSubForDefaultIdentityClaim);
       model.directives = [...filteredDirectives, ...authDirectives];
 
       //field @auth process
       model.fields.forEach(field => {
         const nonAuthDirectives = field.directives.filter(d => d.name != 'auth');
-        const authDirectives = processAuthDirective(field.directives);
+        const authDirectives = processAuthDirective(field.directives, this.config.useSubForDefaultIdentityClaim);
         field.directives = [...nonAuthDirectives, ...authDirectives];
       });
     });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use `sub` as the default identity claim value instead of `username`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.