### PR TITLE
fix(modelgen-js): rm readonly fields check for type metadata

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -111,7 +111,7 @@ describe('Javascript visitor', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType>);
+          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
         }
 
         type SimpleModelMetaData = {
@@ -127,15 +127,15 @@ describe('Javascript visitor', () => {
           readonly name?: string;
           readonly bar?: string;
           readonly foo?: Bar[];
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }
 
         export declare class Bar {
           readonly id: string;
           readonly simpleModelFooId?: string;
-          constructor(init: ModelInit<Bar>);
-          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar>) => MutableModel<Bar> | void): Bar;
+          constructor(init: ModelInit<Bar, BarMetaData>);
+          static copyOf(source: Bar, mutator: (draft: MutableModel<Bar, BarMetaData>) => MutableModel<Bar, BarMetaData> | void): Bar;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -168,7 +168,7 @@ describe('Javascript visitor', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType>);
+          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
         }
 
         type SimpleModelMetaData = {
@@ -302,7 +302,7 @@ describe('Javascript visitor with default owner auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType>);
+          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
         }
 
         type SimpleModelMetaData = {
@@ -313,8 +313,8 @@ describe('Javascript visitor with default owner auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -375,7 +375,7 @@ describe('Javascript visitor with custom owner field auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType>);
+          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
         }
 
         type SimpleModelMetaData = {
@@ -386,8 +386,8 @@ describe('Javascript visitor with custom owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -450,7 +450,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType>);
+          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
         }
 
         type SimpleModelMetaData = {
@@ -461,8 +461,8 @@ describe('Javascript visitor with multiple owner field auth', () => {
           readonly id: string;
           readonly name?: string;
           readonly bar?: string;
-          constructor(init: ModelInit<SimpleModel>);
-          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel>) => MutableModel<SimpleModel> | void): SimpleModel;
+          constructor(init: ModelInit<SimpleModel, SimpleModelMetaData>);
+          static copyOf(source: SimpleModel, mutator: (draft: MutableModel<SimpleModel, SimpleModelMetaData>) => MutableModel<SimpleModel, SimpleModelMetaData> | void): SimpleModel;
         }"
       `);
       expect(generateImportSpy).toBeCalledTimes(1);
@@ -520,8 +520,8 @@ describe('Javascript visitor with auth directives in field level', () => {
           readonly name: string;
           readonly address: string;
           readonly ssn?: string;
-          constructor(init: ModelInit<Employee>);
-          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee>) => MutableModel<Employee> | void): Employee;
+          constructor(init: ModelInit<Employee, EmployeeMetaData>);
+          static copyOf(source: Employee, mutator: (draft: MutableModel<Employee, EmployeeMetaData>) => MutableModel<Employee, EmployeeMetaData> | void): Employee;
         }"
       `);
 
@@ -609,7 +609,7 @@ describe('Javascript visitor with custom primary key', () => {
 
       export declare class WorkItem6 {
         readonly id: string;
-        constructor(init: ModelInit<WorkItem6>);
+        constructor(init: ModelInit<WorkItem6, WorkItem6MetaData>);
       }
 
       type WorkItem0MetaData = {
@@ -707,7 +707,7 @@ describe('Javascript visitor with custom primary key', () => {
 
       export declare class WorkItem6 {
         readonly id: string;
-        constructor(init: ModelInit<WorkItem6>);
+        constructor(init: ModelInit<WorkItem6, WorkItem6MetaData>);
       }
 
       type WorkItem0MetaData = {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -111,7 +111,7 @@ describe('Javascript visitor', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
+          constructor(init: ModelInit<SimpleNonModelType>);
         }
 
         type SimpleModelMetaData = {
@@ -147,7 +147,7 @@ describe('Javascript visitor', () => {
       expect(generateModelDeclarationSpy).toBeCalledTimes(3);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).modelMap['Bar'], true);
-      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(3, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(3, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true, false);
     });
 
     it('should generate Javascript declaration with model metadata types', () => {
@@ -168,7 +168,7 @@ describe('Javascript visitor', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
+          constructor(init: ModelInit<SimpleNonModelType>);
         }
 
         type SimpleModelMetaData = {
@@ -210,7 +210,7 @@ describe('Javascript visitor', () => {
       expect(generateModelDeclarationSpy).toBeCalledTimes(3);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).modelMap['Bar'], true);
-      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(3, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(3, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true, false);
     });
   });
 
@@ -302,7 +302,7 @@ describe('Javascript visitor with default owner auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
+          constructor(init: ModelInit<SimpleNonModelType>);
         }
 
         type SimpleModelMetaData = {
@@ -325,7 +325,7 @@ describe('Javascript visitor with default owner auth', () => {
 
       expect(generateModelDeclarationSpy).toBeCalledTimes(2);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
-      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true, false);
     });
   });
 });
@@ -375,7 +375,7 @@ describe('Javascript visitor with custom owner field auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
+          constructor(init: ModelInit<SimpleNonModelType>);
         }
 
         type SimpleModelMetaData = {
@@ -398,7 +398,7 @@ describe('Javascript visitor with custom owner field auth', () => {
 
       expect(generateModelDeclarationSpy).toBeCalledTimes(2);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
-      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true, false);
     });
   });
 });
@@ -450,7 +450,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
         export declare class SimpleNonModelType {
           readonly id: string;
           readonly names?: (string | null)[];
-          constructor(init: ModelInit<SimpleNonModelType, SimpleNonModelTypeMetaData>);
+          constructor(init: ModelInit<SimpleNonModelType>);
         }
 
         type SimpleModelMetaData = {
@@ -473,7 +473,7 @@ describe('Javascript visitor with multiple owner field auth', () => {
 
       expect(generateModelDeclarationSpy).toBeCalledTimes(2);
       expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(1, (declarationVisitor as any).modelMap['SimpleModel'], true);
-      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true);
+      expect(generateModelDeclarationSpy).toHaveBeenNthCalledWith(2, (declarationVisitor as any).nonModelMap['SimpleNonModelType'], true, false);
     });
   });
 });
@@ -609,7 +609,7 @@ describe('Javascript visitor with custom primary key', () => {
 
       export declare class WorkItem6 {
         readonly id: string;
-        constructor(init: ModelInit<WorkItem6, WorkItem6MetaData>);
+        constructor(init: ModelInit<WorkItem6>);
       }
 
       type WorkItem0MetaData = {
@@ -707,7 +707,7 @@ describe('Javascript visitor with custom primary key', () => {
 
       export declare class WorkItem6 {
         readonly id: string;
-        constructor(init: ModelInit<WorkItem6, WorkItem6MetaData>);
+        constructor(init: ModelInit<WorkItem6>);
       }
 
       type WorkItem0MetaData = {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -34,16 +34,16 @@ export declare class Post {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Comment {
   readonly id: string;
   readonly content: string;
   readonly post?: Post;
-  constructor(init: ModelInit<Comment>);
-  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+  constructor(init: ModelInit<Comment, CommentMetaData>);
+  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment, CommentMetaData>) => MutableModel<Comment, CommentMetaData> | void): Comment;
 }"
 `;
 
@@ -81,16 +81,16 @@ export declare class Post {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Comment {
   readonly id: string;
   readonly content: string;
   readonly post?: Post;
-  constructor(init: ModelInit<Comment>);
-  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+  constructor(init: ModelInit<Comment, CommentMetaData>);
+  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment, CommentMetaData>) => MutableModel<Comment, CommentMetaData> | void): Comment;
 }"
 `;
 
@@ -129,16 +129,16 @@ export declare class Project2 {
   readonly name?: string;
   readonly team?: Team2;
   readonly project2TeamId?: string;
-  constructor(init: ModelInit<Project2>);
-  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2>) => MutableModel<Project2> | void): Project2;
+  constructor(init: ModelInit<Project2, Project2MetaData>);
+  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2, Project2MetaData>) => MutableModel<Project2, Project2MetaData> | void): Project2;
 }
 
 export declare class Team2 {
   readonly id: string;
   readonly name: string;
   readonly project?: Project2;
-  constructor(init: ModelInit<Team2>);
-  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2>) => MutableModel<Team2> | void): Team2;
+  constructor(init: ModelInit<Team2, Team2MetaData>);
+  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2, Team2MetaData>) => MutableModel<Team2, Team2MetaData> | void): Team2;
 }"
 `;
 
@@ -177,16 +177,16 @@ export declare class Project2 {
   readonly name?: string;
   readonly team?: Team2;
   readonly project2TeamId?: string;
-  constructor(init: ModelInit<Project2>);
-  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2>) => MutableModel<Project2> | void): Project2;
+  constructor(init: ModelInit<Project2, Project2MetaData>);
+  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2, Project2MetaData>) => MutableModel<Project2, Project2MetaData> | void): Project2;
 }
 
 export declare class Team2 {
   readonly id: string;
   readonly name: string;
   readonly project?: Project2;
-  constructor(init: ModelInit<Team2>);
-  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2>) => MutableModel<Team2> | void): Team2;
+  constructor(init: ModelInit<Team2, Team2MetaData>);
+  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2, Team2MetaData>) => MutableModel<Team2, Team2MetaData> | void): Team2;
 }"
 `;
 
@@ -229,8 +229,8 @@ export declare class Blog7V2 {
   readonly id: string;
   readonly name: string;
   readonly posts?: (Post7V2 | null)[];
-  constructor(init: ModelInit<Blog7V2>);
-  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2>) => MutableModel<Blog7V2> | void): Blog7V2;
+  constructor(init: ModelInit<Blog7V2, Blog7V2MetaData>);
+  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2, Blog7V2MetaData>) => MutableModel<Blog7V2, Blog7V2MetaData> | void): Blog7V2;
 }
 
 export declare class Post7V2 {
@@ -238,16 +238,16 @@ export declare class Post7V2 {
   readonly title: string;
   readonly blog?: Blog7V2;
   readonly comments?: (Comment7V2 | null)[];
-  constructor(init: ModelInit<Post7V2>);
-  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2>) => MutableModel<Post7V2> | void): Post7V2;
+  constructor(init: ModelInit<Post7V2, Post7V2MetaData>);
+  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2, Post7V2MetaData>) => MutableModel<Post7V2, Post7V2MetaData> | void): Post7V2;
 }
 
 export declare class Comment7V2 {
   readonly id: string;
   readonly content?: string;
   readonly post?: Post7V2;
-  constructor(init: ModelInit<Comment7V2>);
-  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2>) => MutableModel<Comment7V2> | void): Comment7V2;
+  constructor(init: ModelInit<Comment7V2, Comment7V2MetaData>);
+  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2, Comment7V2MetaData>) => MutableModel<Comment7V2, Comment7V2MetaData> | void): Comment7V2;
 }"
 `;
 
@@ -290,8 +290,8 @@ export declare class Blog7V2 {
   readonly id: string;
   readonly name: string;
   readonly posts?: (Post7V2 | null)[];
-  constructor(init: ModelInit<Blog7V2>);
-  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2>) => MutableModel<Blog7V2> | void): Blog7V2;
+  constructor(init: ModelInit<Blog7V2, Blog7V2MetaData>);
+  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2, Blog7V2MetaData>) => MutableModel<Blog7V2, Blog7V2MetaData> | void): Blog7V2;
 }
 
 export declare class Post7V2 {
@@ -299,16 +299,16 @@ export declare class Post7V2 {
   readonly title: string;
   readonly blog?: Blog7V2;
   readonly comments?: (Comment7V2 | null)[];
-  constructor(init: ModelInit<Post7V2>);
-  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2>) => MutableModel<Post7V2> | void): Post7V2;
+  constructor(init: ModelInit<Post7V2, Post7V2MetaData>);
+  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2, Post7V2MetaData>) => MutableModel<Post7V2, Post7V2MetaData> | void): Post7V2;
 }
 
 export declare class Comment7V2 {
   readonly id: string;
   readonly content?: string;
   readonly post?: Post7V2;
-  constructor(init: ModelInit<Comment7V2>);
-  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2>) => MutableModel<Comment7V2> | void): Comment7V2;
+  constructor(init: ModelInit<Comment7V2, Comment7V2MetaData>);
+  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2, Comment7V2MetaData>) => MutableModel<Comment7V2, Comment7V2MetaData> | void): Comment7V2;
 }"
 `;
 
@@ -351,8 +351,8 @@ export declare class Blog7V2 {
   readonly id: string;
   readonly name: string;
   readonly posts?: (Post7V2 | null)[];
-  constructor(init: ModelInit<Blog7V2>);
-  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2>) => MutableModel<Blog7V2> | void): Blog7V2;
+  constructor(init: ModelInit<Blog7V2, Blog7V2MetaData>);
+  static copyOf(source: Blog7V2, mutator: (draft: MutableModel<Blog7V2, Blog7V2MetaData>) => MutableModel<Blog7V2, Blog7V2MetaData> | void): Blog7V2;
 }
 
 export declare class Post7V2 {
@@ -360,16 +360,16 @@ export declare class Post7V2 {
   readonly title: string;
   readonly blog?: Blog7V2;
   readonly comments?: (Comment7V2 | null)[];
-  constructor(init: ModelInit<Post7V2>);
-  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2>) => MutableModel<Post7V2> | void): Post7V2;
+  constructor(init: ModelInit<Post7V2, Post7V2MetaData>);
+  static copyOf(source: Post7V2, mutator: (draft: MutableModel<Post7V2, Post7V2MetaData>) => MutableModel<Post7V2, Post7V2MetaData> | void): Post7V2;
 }
 
 export declare class Comment7V2 {
   readonly id: string;
   readonly content?: string;
   readonly post?: Post7V2;
-  constructor(init: ModelInit<Comment7V2>);
-  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2>) => MutableModel<Comment7V2> | void): Comment7V2;
+  constructor(init: ModelInit<Comment7V2, Comment7V2MetaData>);
+  static copyOf(source: Comment7V2, mutator: (draft: MutableModel<Comment7V2, Comment7V2MetaData>) => MutableModel<Comment7V2, Comment7V2MetaData> | void): Comment7V2;
 }"
 `;
 
@@ -408,16 +408,16 @@ export declare class Project {
   readonly name?: string;
   readonly team?: Team;
   readonly projectTeamId?: string;
-  constructor(init: ModelInit<Project>);
-  static copyOf(source: Project, mutator: (draft: MutableModel<Project>) => MutableModel<Project> | void): Project;
+  constructor(init: ModelInit<Project, ProjectMetaData>);
+  static copyOf(source: Project, mutator: (draft: MutableModel<Project, ProjectMetaData>) => MutableModel<Project, ProjectMetaData> | void): Project;
 }
 
 export declare class Team {
   readonly id: string;
   readonly name: string;
   readonly project?: Project;
-  constructor(init: ModelInit<Team>);
-  static copyOf(source: Team, mutator: (draft: MutableModel<Team>) => MutableModel<Team> | void): Team;
+  constructor(init: ModelInit<Team, TeamMetaData>);
+  static copyOf(source: Team, mutator: (draft: MutableModel<Team, TeamMetaData>) => MutableModel<Team, TeamMetaData> | void): Team;
 }"
 `;
 
@@ -456,16 +456,16 @@ export declare class Project {
   readonly name?: string;
   readonly team?: Team;
   readonly projectTeamId?: string;
-  constructor(init: ModelInit<Project>);
-  static copyOf(source: Project, mutator: (draft: MutableModel<Project>) => MutableModel<Project> | void): Project;
+  constructor(init: ModelInit<Project, ProjectMetaData>);
+  static copyOf(source: Project, mutator: (draft: MutableModel<Project, ProjectMetaData>) => MutableModel<Project, ProjectMetaData> | void): Project;
 }
 
 export declare class Team {
   readonly id: string;
   readonly name: string;
   readonly project?: Project;
-  constructor(init: ModelInit<Team>);
-  static copyOf(source: Team, mutator: (draft: MutableModel<Team>) => MutableModel<Team> | void): Team;
+  constructor(init: ModelInit<Team, TeamMetaData>);
+  static copyOf(source: Team, mutator: (draft: MutableModel<Team, TeamMetaData>) => MutableModel<Team, TeamMetaData> | void): Team;
 }"
 `;
 
@@ -509,24 +509,24 @@ export declare class Post {
   readonly title: string;
   readonly content?: string;
   readonly tags?: (PostTags | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Tag {
   readonly id: string;
   readonly label: string;
   readonly posts?: (PostTags | null)[];
-  constructor(init: ModelInit<Tag>);
-  static copyOf(source: Tag, mutator: (draft: MutableModel<Tag>) => MutableModel<Tag> | void): Tag;
+  constructor(init: ModelInit<Tag, TagMetaData>);
+  static copyOf(source: Tag, mutator: (draft: MutableModel<Tag, TagMetaData>) => MutableModel<Tag, TagMetaData> | void): Tag;
 }
 
 export declare class PostTags {
   readonly id: string;
   readonly post: Post;
   readonly tag: Tag;
-  constructor(init: ModelInit<PostTags>);
-  static copyOf(source: PostTags, mutator: (draft: MutableModel<PostTags>) => MutableModel<PostTags> | void): PostTags;
+  constructor(init: ModelInit<PostTags, PostTagsMetaData>);
+  static copyOf(source: PostTags, mutator: (draft: MutableModel<PostTags, PostTagsMetaData>) => MutableModel<PostTags, PostTagsMetaData> | void): PostTags;
 }"
 `;
 
@@ -570,24 +570,24 @@ export declare class Post {
   readonly title: string;
   readonly content?: string;
   readonly tags?: (PostTags | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Tag {
   readonly id: string;
   readonly label: string;
   readonly posts?: (PostTags | null)[];
-  constructor(init: ModelInit<Tag>);
-  static copyOf(source: Tag, mutator: (draft: MutableModel<Tag>) => MutableModel<Tag> | void): Tag;
+  constructor(init: ModelInit<Tag, TagMetaData>);
+  static copyOf(source: Tag, mutator: (draft: MutableModel<Tag, TagMetaData>) => MutableModel<Tag, TagMetaData> | void): Tag;
 }
 
 export declare class PostTags {
   readonly id: string;
   readonly post: Post;
   readonly tag: Tag;
-  constructor(init: ModelInit<PostTags>);
-  static copyOf(source: PostTags, mutator: (draft: MutableModel<PostTags>) => MutableModel<PostTags> | void): PostTags;
+  constructor(init: ModelInit<PostTags, PostTagsMetaData>);
+  static copyOf(source: PostTags, mutator: (draft: MutableModel<PostTags, PostTagsMetaData>) => MutableModel<PostTags, PostTagsMetaData> | void): PostTags;
 }"
 `;
 
@@ -619,8 +619,8 @@ type TodoMetaData = {
 export declare class Todo {
   readonly id: string;
   readonly content?: string;
-  constructor(init: ModelInit<Todo>);
-  static copyOf(source: Todo, mutator: (draft: MutableModel<Todo>) => MutableModel<Todo> | void): Todo;
+  constructor(init: ModelInit<Todo, TodoMetaData>);
+  static copyOf(source: Todo, mutator: (draft: MutableModel<Todo, TodoMetaData>) => MutableModel<Todo, TodoMetaData> | void): Todo;
 }"
 `;
 
@@ -658,16 +658,16 @@ export declare class Post2 {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment2 | null)[];
-  constructor(init: ModelInit<Post2>);
-  static copyOf(source: Post2, mutator: (draft: MutableModel<Post2>) => MutableModel<Post2> | void): Post2;
+  constructor(init: ModelInit<Post2, Post2MetaData>);
+  static copyOf(source: Post2, mutator: (draft: MutableModel<Post2, Post2MetaData>) => MutableModel<Post2, Post2MetaData> | void): Post2;
 }
 
 export declare class Comment2 {
   readonly id: string;
   readonly postID: string;
   readonly content: string;
-  constructor(init: ModelInit<Comment2>);
-  static copyOf(source: Comment2, mutator: (draft: MutableModel<Comment2>) => MutableModel<Comment2> | void): Comment2;
+  constructor(init: ModelInit<Comment2, Comment2MetaData>);
+  static copyOf(source: Comment2, mutator: (draft: MutableModel<Comment2, Comment2MetaData>) => MutableModel<Comment2, Comment2MetaData> | void): Comment2;
 }"
 `;
 
@@ -705,16 +705,16 @@ export declare class Post2 {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment2 | null)[];
-  constructor(init: ModelInit<Post2>);
-  static copyOf(source: Post2, mutator: (draft: MutableModel<Post2>) => MutableModel<Post2> | void): Post2;
+  constructor(init: ModelInit<Post2, Post2MetaData>);
+  static copyOf(source: Post2, mutator: (draft: MutableModel<Post2, Post2MetaData>) => MutableModel<Post2, Post2MetaData> | void): Post2;
 }
 
 export declare class Comment2 {
   readonly id: string;
   readonly postID: string;
   readonly content: string;
-  constructor(init: ModelInit<Comment2>);
-  static copyOf(source: Comment2, mutator: (draft: MutableModel<Comment2>) => MutableModel<Comment2> | void): Comment2;
+  constructor(init: ModelInit<Comment2, Comment2MetaData>);
+  static copyOf(source: Comment2, mutator: (draft: MutableModel<Comment2, Comment2MetaData>) => MutableModel<Comment2, Comment2MetaData> | void): Comment2;
 }"
 `;
 
@@ -753,15 +753,15 @@ export declare class Project2 {
   readonly name?: string;
   readonly teamID?: string;
   readonly team?: Team2;
-  constructor(init: ModelInit<Project2>);
-  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2>) => MutableModel<Project2> | void): Project2;
+  constructor(init: ModelInit<Project2, Project2MetaData>);
+  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2, Project2MetaData>) => MutableModel<Project2, Project2MetaData> | void): Project2;
 }
 
 export declare class Team2 {
   readonly id: string;
   readonly name: string;
-  constructor(init: ModelInit<Team2>);
-  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2>) => MutableModel<Team2> | void): Team2;
+  constructor(init: ModelInit<Team2, Team2MetaData>);
+  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2, Team2MetaData>) => MutableModel<Team2, Team2MetaData> | void): Team2;
 }"
 `;
 
@@ -800,15 +800,15 @@ export declare class Project2 {
   readonly name?: string;
   readonly teamID?: string;
   readonly team?: Team2;
-  constructor(init: ModelInit<Project2>);
-  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2>) => MutableModel<Project2> | void): Project2;
+  constructor(init: ModelInit<Project2, Project2MetaData>);
+  static copyOf(source: Project2, mutator: (draft: MutableModel<Project2, Project2MetaData>) => MutableModel<Project2, Project2MetaData> | void): Project2;
 }
 
 export declare class Team2 {
   readonly id: string;
   readonly name: string;
-  constructor(init: ModelInit<Team2>);
-  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2>) => MutableModel<Team2> | void): Team2;
+  constructor(init: ModelInit<Team2, Team2MetaData>);
+  static copyOf(source: Team2, mutator: (draft: MutableModel<Team2, Team2MetaData>) => MutableModel<Team2, Team2MetaData> | void): Team2;
 }"
 `;
 
@@ -846,16 +846,16 @@ export declare class Post {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Comment {
   readonly id: string;
   readonly content: string;
   readonly postCommentsId?: string;
-  constructor(init: ModelInit<Comment>);
-  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+  constructor(init: ModelInit<Comment, CommentMetaData>);
+  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment, CommentMetaData>) => MutableModel<Comment, CommentMetaData> | void): Comment;
 }"
 `;
 
@@ -893,16 +893,16 @@ export declare class Post {
   readonly id: string;
   readonly title: string;
   readonly comments?: (Comment | null)[];
-  constructor(init: ModelInit<Post>);
-  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+  constructor(init: ModelInit<Post, PostMetaData>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post, PostMetaData>) => MutableModel<Post, PostMetaData> | void): Post;
 }
 
 export declare class Comment {
   readonly id: string;
   readonly content: string;
   readonly postCommentsId?: string;
-  constructor(init: ModelInit<Comment>);
-  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+  constructor(init: ModelInit<Comment, CommentMetaData>);
+  static copyOf(source: Comment, mutator: (draft: MutableModel<Comment, CommentMetaData>) => MutableModel<Comment, CommentMetaData> | void): Comment;
 }"
 `;
 
@@ -941,15 +941,15 @@ export declare class Project {
   readonly name?: string;
   readonly team?: Team;
   readonly projectTeamId?: string;
-  constructor(init: ModelInit<Project>);
-  static copyOf(source: Project, mutator: (draft: MutableModel<Project>) => MutableModel<Project> | void): Project;
+  constructor(init: ModelInit<Project, ProjectMetaData>);
+  static copyOf(source: Project, mutator: (draft: MutableModel<Project, ProjectMetaData>) => MutableModel<Project, ProjectMetaData> | void): Project;
 }
 
 export declare class Team {
   readonly id: string;
   readonly name: string;
-  constructor(init: ModelInit<Team>);
-  static copyOf(source: Team, mutator: (draft: MutableModel<Team>) => MutableModel<Team> | void): Team;
+  constructor(init: ModelInit<Team, TeamMetaData>);
+  static copyOf(source: Team, mutator: (draft: MutableModel<Team, TeamMetaData>) => MutableModel<Team, TeamMetaData> | void): Team;
 }"
 `;
 
@@ -988,15 +988,15 @@ export declare class Project {
   readonly name?: string;
   readonly team?: Team;
   readonly projectTeamId?: string;
-  constructor(init: ModelInit<Project>);
-  static copyOf(source: Project, mutator: (draft: MutableModel<Project>) => MutableModel<Project> | void): Project;
+  constructor(init: ModelInit<Project, ProjectMetaData>);
+  static copyOf(source: Project, mutator: (draft: MutableModel<Project, ProjectMetaData>) => MutableModel<Project, ProjectMetaData> | void): Project;
 }
 
 export declare class Team {
   readonly id: string;
   readonly name: string;
-  constructor(init: ModelInit<Team>);
-  static copyOf(source: Team, mutator: (draft: MutableModel<Team>) => MutableModel<Team> | void): Team;
+  constructor(init: ModelInit<Team, TeamMetaData>);
+  static copyOf(source: Team, mutator: (draft: MutableModel<Team, TeamMetaData>) => MutableModel<Team, TeamMetaData> | void): Team;
 }"
 `;
 
@@ -1030,7 +1030,7 @@ export declare class Customer {
   readonly name: string;
   readonly phoneNumber?: string;
   readonly accountRepresentativeID: string;
-  constructor(init: ModelInit<Customer>);
-  static copyOf(source: Customer, mutator: (draft: MutableModel<Customer>) => MutableModel<Customer> | void): Customer;
+  constructor(init: ModelInit<Customer, CustomerMetaData>);
+  static copyOf(source: Customer, mutator: (draft: MutableModel<Customer, CustomerMetaData>) => MutableModel<Customer, CustomerMetaData> | void): Customer;
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -61,7 +61,7 @@ export class AppSyncModelJavascriptVisitor<
         .join('\n\n');
 
       const nonModelDeclarations = Object.values(this.nonModelMap)
-        .map(typeObj => this.generateModelDeclaration(typeObj, true))
+        .map(typeObj => this.generateModelDeclaration(typeObj, true, false))
         .join('\n\n');
 
       const modelMetaData = Object.values(this.modelMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -48,7 +48,7 @@ export class AppSyncModelTypeScriptVisitor<
       .join('\n\n');
 
     const nonModelDeclarations = Object.values(this.nonModelMap)
-      .map(typeObj => this.generateModelDeclaration(typeObj))
+      .map(typeObj => this.generateModelDeclaration(typeObj, true, false))
       .join('\n\n');
 
     const modelInitialization = this.generateModelInitialization([...Object.values(this.modelMap), ...Object.values(this.nonModelMap)]);
@@ -115,7 +115,7 @@ export class AppSyncModelTypeScriptVisitor<
    * @param modelObj CodeGenModel object
    * @param isDeclaration flag indicates if the class needs to be exported
    */
-  protected generateModelDeclaration(modelObj: CodeGenModel, isDeclaration: boolean = true): string {
+  protected generateModelDeclaration(modelObj: CodeGenModel, isDeclaration: boolean = true, isModelType: boolean = true): string {
     const modelName = this.generateModelTypeDeclarationName(modelObj);
     const modelDeclarations = new TypeScriptDeclarationBlock()
       .asKind('class')
@@ -125,7 +125,7 @@ export class AppSyncModelTypeScriptVisitor<
 
     const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
     let readOnlyFieldNames: string[] = [];
-    const modelMetaDataDeclaration: string = `, ${modelName}MetaData`;
+    const modelMetaDataDeclaration: string = isModelType ? `, ${modelName}MetaData` : '';
 
     modelObj.fields.forEach((field: CodeGenField) => {
       modelDeclarations.addProperty(this.getFieldName(field), this.getNativeType(field), undefined, 'DEFAULT', {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -125,8 +125,7 @@ export class AppSyncModelTypeScriptVisitor<
 
     const isTimestampFeatureFlagEnabled = this.config.isTimestampFieldsAdded;
     let readOnlyFieldNames: string[] = [];
-    let modelMetaDataFormatted: string | undefined;
-    let modelMetaDataDeclaration: string = '';
+    const modelMetaDataDeclaration: string = `, ${modelName}MetaData`;
 
     modelObj.fields.forEach((field: CodeGenField) => {
       modelDeclarations.addProperty(this.getFieldName(field), this.getNativeType(field), undefined, 'DEFAULT', {
@@ -137,11 +136,6 @@ export class AppSyncModelTypeScriptVisitor<
         readOnlyFieldNames.push(`'${field.name}'`);
       }
     });
-
-    if (isTimestampFeatureFlagEnabled) {
-      modelMetaDataFormatted = `, ${modelName}MetaData`;
-      modelMetaDataDeclaration = readOnlyFieldNames.length > 0 ? modelMetaDataFormatted : '';
-    }
 
     // Constructor
     modelDeclarations.addClassMethod(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Fix the bug that metadata type is not correctly generated in constructor and copyOf

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.