### PR TITLE
fix: rm amplify-prompts and use console log

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -37,8 +37,7 @@
     "js-yaml": "^4.0.0",
     "ora": "^4.0.3",
     "semver": "^7.3.5",
-    "slash": "^3.0.0",
-    "amplify-prompts": "^1.6.2"
+    "slash": "^3.0.0"
   },
   "peerDependencies": {
     "amplify-cli-core": "^2.3.0",

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
@@ -2,7 +2,6 @@ const yaml = require('js-yaml');
 const path = require('path');
 const fs = require('fs-extra');
 const semver = require('semver');
-const { printer } = require('amplify-prompts');
 
 const PUBSPEC_LOCK_FILE_NAME = 'pubspec.lock';
 const MINIMUM_VERSION_CONSTRAIN = '>= 0.3.0 || >= 0.3.0-rc.2';
@@ -21,11 +20,11 @@ function validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot) {
     return false;
   } catch (e) {
     if (e.stack) {
-      printer.error(e.stack);
-      printer.error(e.message);
+      console.log(e.stack);
+      console.log(e.message);
     }
 
-    printer.error('An error occurred while parsing ' + PUBSPEC_LOCK_FILE_NAME + '.');
+    console.log('An error occurred while parsing ' + PUBSPEC_LOCK_FILE_NAME + '.');
     return false;
   }
 }

--- a/packages/amplify-codegen/tests/utils/validateAmplifyFlutterCapableForNonModel.test.js
+++ b/packages/amplify-codegen/tests/utils/validateAmplifyFlutterCapableForNonModel.test.js
@@ -6,17 +6,11 @@ const {
 const mockFs = require('mock-fs');
 const { join } = require('path');
 const yaml = require('js-yaml');
-const { printer } = require('amplify-prompts');
-
-jest.mock('amplify-prompts', () => ({
-  printer: {
-    error: jest.fn()
-  },
-}));
 
 const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PUBSPEC_FILE_PATH = join(MOCK_PROJECT_ROOT, PUBSPEC_LOCK_FILE_NAME);
-const mockErrorPrinter = printer.error;
+global.console = {log: jest.fn()}
+const mockErrorPrinter = console.log;
 
 describe('Validate amplify flutter version tests', () => {
   afterEach(() => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use `console.log` instead for error printing and remove `amplify-prompts` dependency

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.