### PR TITLE
[Dart] Update imports generated for flutter datastore plugin dependency

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -109,7 +109,7 @@ async function generateModels(context) {
     // override isTimestampFieldsAdded to true when using amplify-flutter > 0.3.0 || > 0.3.0-rc.2
     isTimestampFieldsAdded = validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot);
     enableDartZeroThreeFeatures = validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot);
-    // This feature is supported only for users using amplify-flutter > 0.4.0 || > 0.4.0-rc.2
+    // This feature is supported only for users using amplify-flutter > 0.4.0 || > 0.4.0-rc.1
     dartUpdateAmplifyCoreDependency = validateAmplifyFlutterCoreLibraryDependency(projectRoot);
   }
 

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -7,6 +7,7 @@ const gqlCodeGen = require('@graphql-codegen/core');
 const { getModelgenPackage } = require('../utils/getModelgenPackage');
 const { validateDartSDK } = require('../utils/validateDartSDK');
 const { validateAmplifyFlutterCapableZeroThreeFeatures } = require('../utils/validateAmplifyFlutterCapableZeroThreeFeatures');
+const { validateAmplifyFlutterCoreLibraryDependency } = require('../utils/validateAmplifyFlutterCoreLibraryDependency');
 
 const platformToLanguageMap = {
   android: 'java',
@@ -90,6 +91,7 @@ async function generateModels(context) {
   let isTimestampFieldsAdded = readFeatureFlag('codegen.addTimestampFields');
   let enableDartNullSafety = readFeatureFlag('codegen.enableDartNullSafety');
   let enableDartZeroThreeFeatures = false;
+  let dartUpdateAmplifyCoreDependency = false;
 
   if (projectConfig.frontend === 'flutter') {
     const isMinimumDartVersionSatisfied = validateDartSDK(context, projectRoot);
@@ -107,6 +109,8 @@ async function generateModels(context) {
     // override isTimestampFieldsAdded to true when using amplify-flutter > 0.3.0 || > 0.3.0-rc.2
     isTimestampFieldsAdded = validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot);
     enableDartZeroThreeFeatures = validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot);
+    // This feature is supported only for users using amplify-flutter > 0.4.0 || > 0.4.0-rc.2
+    dartUpdateAmplifyCoreDependency = validateAmplifyFlutterCoreLibraryDependency(projectRoot);
   }
 
   const handleListNullabilityTransparently = readFeatureFlag('codegen.handleListNullabilityTransparently');
@@ -124,6 +128,7 @@ async function generateModels(context) {
       usePipelinedTransformer,
       enableDartZeroThreeFeatures,
       transformerVersion,
+      dartUpdateAmplifyCoreDependency
     },
   });
 

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
@@ -1,4 +1,4 @@
-const validateAmplifyFlutterVersion = require('./validateAmplifyFlutterVersion');
+const { validateAmplifyFlutterVersion } = require('./validateAmplifyFlutterVersion');
 
 const MINIMUM_VERSION_CONSTRAINT = '>= 0.3.0 || >= 0.3.0-rc.2';
 

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCapableZeroThreeFeatures.js
@@ -1,32 +1,9 @@
-const yaml = require('js-yaml');
-const path = require('path');
-const fs = require('fs-extra');
-const semver = require('semver');
+const validateAmplifyFlutterVersion = require('./validateAmplifyFlutterVersion');
 
-const PUBSPEC_LOCK_FILE_NAME = 'pubspec.lock';
-const MINIMUM_VERSION_CONSTRAIN = '>= 0.3.0 || >= 0.3.0-rc.2';
+const MINIMUM_VERSION_CONSTRAINT = '>= 0.3.0 || >= 0.3.0-rc.2';
 
 function validateAmplifyFlutterCapableZeroThreeFeatures(projectRoot) {
-  try {
-    const lockFile = yaml.load(fs.readFileSync(path.join(projectRoot, PUBSPEC_LOCK_FILE_NAME), 'utf8'));
-    // check resolved dependency version written pubspec.lock file
-    const { version } = lockFile.packages.amplify_flutter || {};
-    // For this util function it check only if the amplify_flutter version is great than the minimum version
-    // and it's not concerned with prerelease range, hence including prerelease to ensure
-    // 0.4.0-rc.2 > 0.3.0-rc.2 is true
-    if (semver.satisfies(version, MINIMUM_VERSION_CONSTRAIN, { includePrerelease: true })) {
-      return true;
-    }
-    return false;
-  } catch (e) {
-    if (e.stack) {
-      console.log(e.stack);
-      console.log(e.message);
-    }
-
-    console.log('An error occurred while parsing ' + PUBSPEC_LOCK_FILE_NAME + '.');
-    return false;
-  }
+  return validateAmplifyFlutterVersion(projectRoot, MINIMUM_VERSION_CONSTRAINT);
 }
 
-module.exports = { validateAmplifyFlutterCapableZeroThreeFeatures, PUBSPEC_LOCK_FILE_NAME, MINIMUM_VERSION_CONSTRAIN };
+module.exports = { validateAmplifyFlutterCapableZeroThreeFeatures };

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
@@ -1,0 +1,9 @@
+const validateAmplifyFlutterVersion = require('./validateAmplifyFlutterVersion');
+
+const MINIMUM_VERSION_CONSTRAINT = '>= 0.4.0 || >= 0.4.0-rc.2';
+
+function validateAmplifyFlutterCoreLibraryDependency(projectRoot) {
+  return validateAmplifyFlutterVersion(projectRoot, MINIMUM_VERSION_CONSTRAINT);
+}
+
+module.exports = { validateAmplifyFlutterCoreLibraryDependency };

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
@@ -1,4 +1,4 @@
-const validateAmplifyFlutterVersion = require('./validateAmplifyFlutterVersion');
+const { validateAmplifyFlutterVersion } = require('./validateAmplifyFlutterVersion');
 
 const MINIMUM_VERSION_CONSTRAINT = '>= 0.4.0 || >= 0.4.0-rc.2';
 

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterCoreLibraryDependency.js
@@ -1,6 +1,6 @@
 const { validateAmplifyFlutterVersion } = require('./validateAmplifyFlutterVersion');
 
-const MINIMUM_VERSION_CONSTRAINT = '>= 0.4.0 || >= 0.4.0-rc.2';
+const MINIMUM_VERSION_CONSTRAINT = '>= 0.4.0 || >= 0.4.0-rc.1';
 
 function validateAmplifyFlutterCoreLibraryDependency(projectRoot) {
   return validateAmplifyFlutterVersion(projectRoot, MINIMUM_VERSION_CONSTRAINT);

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterVersion.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterVersion.js
@@ -26,4 +26,4 @@ function validateAmplifyFlutterVersion(projectRoot, versionConstraint) {
   }
 }
 
-module.exports = { validateAmplifyFlutterVersion };
+module.exports = { validateAmplifyFlutterVersion, PUBSPEC_LOCK_FILE_NAME };

--- a/packages/amplify-codegen/src/utils/validateAmplifyFlutterVersion.js
+++ b/packages/amplify-codegen/src/utils/validateAmplifyFlutterVersion.js
@@ -1,0 +1,29 @@
+const yaml = require('js-yaml');
+const path = require('path');
+const fs = require('fs-extra');
+const semver = require('semver');
+
+const PUBSPEC_LOCK_FILE_NAME = 'pubspec.lock';
+
+function validateAmplifyFlutterVersion(projectRoot, versionConstraint) {
+  try {
+    const lockFile = yaml.load(fs.readFileSync(path.join(projectRoot, PUBSPEC_LOCK_FILE_NAME), 'utf8'));
+    // check resolved dependency version written pubspec.lock file
+    const { version } = lockFile.packages.amplify_flutter || {};
+    // For this util function it check only if the amplify_flutter version satisfies the given version constraint
+    if (semver.satisfies(version, versionConstraint, { includePrerelease: true })) {
+      return true;
+    }
+    return false;
+  } catch (e) {
+    if (e.stack) {
+      console.log(e.stack);
+      console.log(e.message);
+    }
+
+    console.log('An error occurred while parsing ' + PUBSPEC_LOCK_FILE_NAME + '.');
+    return false;
+  }
+}
+
+module.exports = { validateAmplifyFlutterVersion };

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -31,7 +31,6 @@ const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PROJECT_NAME = 'myapp';
 const MOCK_BACKEND_DIRECTORY = 'backend';
 const MOCK_GENERATED_CODE = 'This code is auto-generated!';
-const MOCK_PRE_EXISTING_FILE = 'preexisting.txt';
 
 // Mock the Feature flag to use migrated moldegen
 jest.mock('amplify-cli-core', MOCK_PROJECT_ROOT => {
@@ -104,89 +103,6 @@ describe('command-models-generates models in expected output path', () => {
       // assert model files are generated in expected output directory
       expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
     });
-  }
-
-  afterEach(mockFs.restore);
-});
-
-describe('codegen models respects cleanGeneratedModelsDirectory', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-    addMocksToContext();
-    graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
-  });
-
-  for (const frontend in OUTPUT_PATHS) {
-    it(frontend + ': Should clear the output directory before generation if cleanGeneratedModelsDirectory is true', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-        if (name === 'codegen.useappsyncmodelgenplugin' || name === 'codegen.cleanGeneratedModelsDirectory') {
-          return true;
-        }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
-
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
-
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0);
-
-      // assert that the pre-existing file is deleted
-      expect(fs.existsSync(preExistingFilePath)).toBeFalsy;
-    });
-
-    it(frontend + ': Should not clear the output directory before generation if cleanGeneratedModelsDirectory is false', async () => {
-      MOCK_CONTEXT.amplify.getProjectConfig.mockReturnValue({ frontend: frontend });
-      require('amplify-cli-core').FeatureFlags.getBoolean.mockImplementation((name, defaultValue) => {
-        if (name === 'codegen.useappsyncmodelgenplugin') {
-          return true;
-        }
-        if (name === 'codegen.cleanGeneratedModelsDirectory') {
-          return false;
-        }
-      });
-
-      const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
-      const preExistingFilePath = path.join(outputDirectory, MOCK_PRE_EXISTING_FILE);
-      createMockFS(outputDirectory);
-
-      // assert output directory has a mock file to be cleared
-      expect(fs.readdirSync(outputDirectory).length).toEqual(1);
-      expect(fs.existsSync(preExistingFilePath));
-
-      await generateModels(MOCK_CONTEXT);
-
-      // assert model generation succeeds
-      expect(graphqlCodegen.codegen).toBeCalled();
-
-      // assert that codegen generated in correct place
-      expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(1);
-
-      // assert that the pre-existing file is retained
-      expect(fs.existsSync(preExistingFilePath)).toBeTruthy;
-    });
-  }
-
-  function createMockFS(outputDirectory) {
-    // mock the input and output file structure
-    const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
-    const mockedFiles = {};
-    mockedFiles[schemaFilePath] = {
-      'schema.graphql': ' type SimpleModel { id: ID! status: String } ',
-    };
-    mockedFiles[outputDirectory] = {};
-    mockedFiles[outputDirectory][MOCK_PRE_EXISTING_FILE] = 'A pre-existing mock file';
-    mockFs(mockedFiles);
   }
 
   afterEach(mockFs.restore);

--- a/packages/amplify-codegen/tests/utils/validateAmplifyFlutterCapableForNonModel.test.js
+++ b/packages/amplify-codegen/tests/utils/validateAmplifyFlutterCapableForNonModel.test.js
@@ -1,14 +1,14 @@
 const {
-  validateAmplifyFlutterCapableZeroThreeFeatures,
-  PUBSPEC_LOCK_FILE_NAME,
-  MINIMUM_VERSION_CONSTRAIN,
+  validateAmplifyFlutterCapableZeroThreeFeatures
 } = require('../../src/utils/validateAmplifyFlutterCapableZeroThreeFeatures');
+const { PUBSPEC_LOCK_FILE_NAME } = require('../../src/utils/validateAmplifyFlutterVersion');
 const mockFs = require('mock-fs');
 const { join } = require('path');
 const yaml = require('js-yaml');
 
 const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PUBSPEC_FILE_PATH = join(MOCK_PROJECT_ROOT, PUBSPEC_LOCK_FILE_NAME);
+const MINIMUM_VERSION_CONSTRAINT = '>= 0.3.0 || >= 0.3.0-rc.2';
 global.console = {log: jest.fn()}
 const mockErrorPrinter = console.log;
 
@@ -17,7 +17,7 @@ describe('Validate amplify flutter version tests', () => {
     mockFs.restore();
   });
 
-  describe(`should return true if the resolved version meets the version constrain: ${MINIMUM_VERSION_CONSTRAIN}`, () => {
+  describe(`should return true if the resolved version meets the version constrain: ${MINIMUM_VERSION_CONSTRAINT}`, () => {
     ['0.3.0', '0.3.1', '1.0.0', '0.3.0-rc.2', '0.4.0', '0.4.0-rc.2'].forEach(version => {
       test(`when the resolved version is ${version}`, () => {
         const lockFile = {
@@ -33,7 +33,7 @@ describe('Validate amplify flutter version tests', () => {
     });
   });
 
-  describe(`should return false if the resolved version does NOT meet the version constrain: ${MINIMUM_VERSION_CONSTRAIN}`, () => {
+  describe(`should return false if the resolved version does NOT meet the version constrain: ${MINIMUM_VERSION_CONSTRAINT}`, () => {
     ['0.2.0', '0.2.9', '0.3.0-rc.1'].forEach(version => {
       test(`when the resolved version is ${version}`, () => {
         const lockFile = {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1333,7 +1333,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1395,7 +1395,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1802,7 +1802,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should not generate c
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1855,7 +1855,7 @@ exports[`AppSync Dart Visitor Dart Specific Tests should generate the model prov
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'SimpleModel.dart';
 
 export 'SimpleModel.dart';

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -22,7 +22,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Address type in your schema. */
@@ -173,7 +173,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -190,10 +190,10 @@ class Address {
     try {
       return _line1!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -207,10 +207,10 @@ class Address {
     try {
       return _city!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -220,10 +220,10 @@ class Address {
     try {
       return _state!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -233,10 +233,10 @@ class Address {
     try {
       return _postalCode!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -366,7 +366,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -502,7 +502,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -518,10 +518,10 @@ class Contact {
     try {
       return _contactName!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -531,10 +531,10 @@ class Contact {
     try {
       return _phone!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -653,7 +653,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -715,7 +715,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -771,7 +771,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -941,7 +941,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -967,10 +967,10 @@ class Person extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -980,10 +980,10 @@ class Person extends Model {
     try {
       return _phone!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -1122,7 +1122,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should not generate c
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1175,7 +1175,7 @@ exports[`AppSync Dart Visitor Dart Specific Tests should generate the model prov
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'SimpleModel.dart';
 
 export 'SimpleModel.dart';
@@ -1226,7 +1226,7 @@ exports[`AppSync Dart Visitor Enum Generation should generate a class for enum t
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -1361,7 +1361,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for app
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1674,7 +1674,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for enu
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1930,7 +1930,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for reg
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2179,7 +2179,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2556,7 +2556,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2582,10 +2582,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2724,10 +2724,10 @@ class Tag extends Model {
     try {
       return _label!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2850,10 +2850,10 @@ class PostTags extends Model {
     try {
       return _post!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2863,10 +2863,10 @@ class PostTags extends Model {
     try {
       return _tag!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2991,7 +2991,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a Simp
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3113,7 +3113,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a mode
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3235,7 +3235,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the TodoWithAuth type in your schema. */
@@ -3399,7 +3399,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -3424,10 +3424,10 @@ class TodoWithAuth extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -3585,7 +3585,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -3720,7 +3720,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -3857,7 +3857,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the dynamicGroups type in your schema. */
@@ -3992,7 +3992,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the simpleOwnerAuth type in your schema. */
@@ -4127,7 +4127,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the allowRead type in your schema. */
@@ -4261,7 +4261,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the privateType type in your schema. */
@@ -4392,7 +4392,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the publicType type in your schema. */
@@ -4523,7 +4523,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the staticGroups type in your schema. */
@@ -4660,7 +4660,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should include authRules
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -4798,7 +4798,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should support multiple 
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -4950,7 +4950,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5072,7 +5072,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Task type in your schema. */
@@ -5187,7 +5187,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5343,7 +5343,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Comment type in your schema. */
@@ -5476,7 +5476,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5636,7 +5636,7 @@ exports[`AppSync Dart Visitor Model with Key Directive should generate a class f
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the authorBook type in your schema. */
@@ -5807,7 +5807,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct internal
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -5911,7 +5911,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5936,10 +5936,10 @@ class Blog extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6066,7 +6066,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -6094,10 +6094,10 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6218,7 +6218,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6244,10 +6244,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6394,7 +6394,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6423,10 +6423,10 @@ class TestModel extends Model {
     try {
       return _floatVal!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6440,10 +6440,10 @@ class TestModel extends Model {
     try {
       return _floatList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6457,10 +6457,10 @@ class TestModel extends Model {
     try {
       return _nullableFloatList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6631,7 +6631,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6666,10 +6666,10 @@ class TestModel extends Model {
     try {
       return _floatVal!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6683,10 +6683,10 @@ class TestModel extends Model {
     try {
       return _floatList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6700,10 +6700,10 @@ class TestModel extends Model {
     try {
       return _nullableFloatList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6717,10 +6717,10 @@ class TestModel extends Model {
     try {
       return _intVal!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6734,10 +6734,10 @@ class TestModel extends Model {
     try {
       return _intList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -6751,10 +6751,10 @@ class TestModel extends Model {
     try {
       return _nullableIntList!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -7001,7 +7001,7 @@ exports[`AppSync Dart Visitor Read-only Field Tests should generate the read-onl
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -7141,7 +7141,7 @@ exports[`AppSync Dart Visitor Read-only and Null Safety Combined Tests should ge
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -23,7 +23,7 @@ exports[`AppSync Dart Visitor Amplify Core dependency used in imports Should use
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -51,11 +51,11 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new AmplifyCodeGenModelException(
-              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-              recoverySuggestion:
-                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-              underlyingException: e.toString()
-            );
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
     }
   }
   
@@ -64,11 +64,11 @@ class Post extends Model {
       return _rating!;
     } catch(e) {
       throw new AmplifyCodeGenModelException(
-              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-              recoverySuggestion:
-                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-              underlyingException: e.toString()
-            );
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
     }
   }
   
@@ -77,11 +77,11 @@ class Post extends Model {
       return _status!;
     } catch(e) {
       throw new AmplifyCodeGenModelException(
-              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-              recoverySuggestion:
-                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-              underlyingException: e.toString()
-            );
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
     }
   }
   
@@ -227,11 +227,11 @@ class Comment extends Model {
       return _post!;
     } catch(e) {
       throw new AmplifyCodeGenModelException(
-              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-              recoverySuggestion:
-                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-              underlyingException: e.toString()
-            );
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
     }
   }
   
@@ -240,11 +240,11 @@ class Comment extends Model {
       return _content!;
     } catch(e) {
       throw new AmplifyCodeGenModelException(
-              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-              recoverySuggestion:
-                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-              underlyingException: e.toString()
-            );
+          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
     }
   }
   
@@ -363,7 +363,7 @@ exports[`AppSync Dart Visitor Amplify Core dependency used in imports Should use
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -391,10 +391,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -404,10 +404,10 @@ class Post extends Model {
       return _rating!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -417,10 +417,10 @@ class Post extends Model {
       return _status!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -567,10 +567,10 @@ class Comment extends Model {
       return _post!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -580,10 +580,10 @@ class Comment extends Model {
       return _content!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -702,7 +702,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Address type in your schema. */
@@ -853,7 +853,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -871,10 +871,10 @@ class Address {
       return _line1!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -888,10 +888,10 @@ class Address {
       return _city!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -901,10 +901,10 @@ class Address {
       return _state!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -914,10 +914,10 @@ class Address {
       return _postalCode!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1046,7 +1046,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1182,7 +1182,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1199,10 +1199,10 @@ class Contact {
       return _contactName!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1212,10 +1212,10 @@ class Contact {
       return _phone!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1333,7 +1333,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1395,7 +1395,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1451,7 +1451,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1621,7 +1621,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1648,10 +1648,10 @@ class Person extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1661,10 +1661,10 @@ class Person extends Model {
       return _phone!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1802,7 +1802,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should not generate c
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1855,7 +1855,7 @@ exports[`AppSync Dart Visitor Dart Specific Tests should generate the model prov
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart.dart';
 import 'SimpleModel.dart';
 
 export 'SimpleModel.dart';
@@ -1906,7 +1906,7 @@ exports[`AppSync Dart Visitor Enum Generation should generate a class for enum t
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -2041,7 +2041,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for app
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2354,7 +2354,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for enu
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2610,7 +2610,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for reg
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2859,7 +2859,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -3236,7 +3236,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -3263,10 +3263,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3405,10 +3405,10 @@ class Tag extends Model {
       return _label!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3531,10 +3531,10 @@ class PostTags extends Model {
       return _post!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3544,10 +3544,10 @@ class PostTags extends Model {
       return _tag!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3671,7 +3671,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a Simp
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3793,7 +3793,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a mode
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3915,7 +3915,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the TodoWithAuth type in your schema. */
@@ -4079,7 +4079,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -4105,10 +4105,10 @@ class TodoWithAuth extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -4265,7 +4265,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -4400,7 +4400,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -4537,7 +4537,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the dynamicGroups type in your schema. */
@@ -4672,7 +4672,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the simpleOwnerAuth type in your schema. */
@@ -4807,7 +4807,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the allowRead type in your schema. */
@@ -4941,7 +4941,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the privateType type in your schema. */
@@ -5072,7 +5072,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the publicType type in your schema. */
@@ -5203,7 +5203,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the staticGroups type in your schema. */
@@ -5340,7 +5340,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should include authRules
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -5478,7 +5478,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should support multiple 
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -5630,7 +5630,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5752,7 +5752,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Task type in your schema. */
@@ -5867,7 +5867,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6023,7 +6023,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Comment type in your schema. */
@@ -6156,7 +6156,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6316,7 +6316,7 @@ exports[`AppSync Dart Visitor Model with Key Directive should generate a class f
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the authorBook type in your schema. */
@@ -6487,7 +6487,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct internal
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -6591,7 +6591,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6617,10 +6617,10 @@ class Blog extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -6746,7 +6746,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -6775,10 +6775,10 @@ class Comment extends Model {
       return _content!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -6898,7 +6898,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6925,10 +6925,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7074,7 +7074,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -7104,10 +7104,10 @@ class TestModel extends Model {
       return _floatVal!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7121,10 +7121,10 @@ class TestModel extends Model {
       return _floatList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7138,10 +7138,10 @@ class TestModel extends Model {
       return _nullableFloatList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7311,7 +7311,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -7347,10 +7347,10 @@ class TestModel extends Model {
       return _floatVal!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7364,10 +7364,10 @@ class TestModel extends Model {
       return _floatList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7381,10 +7381,10 @@ class TestModel extends Model {
       return _nullableFloatList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7398,10 +7398,10 @@ class TestModel extends Model {
       return _intVal!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7415,10 +7415,10 @@ class TestModel extends Model {
       return _intList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7432,10 +7432,10 @@ class TestModel extends Model {
       return _nullableIntList!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -7681,7 +7681,7 @@ exports[`AppSync Dart Visitor Read-only Field Tests should generate the read-onl
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -7821,7 +7821,7 @@ exports[`AppSync Dart Visitor Read-only and Null Safety Combined Tests should ge
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1,5 +1,685 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AppSync Dart Visitor Amplify Core dependency used in imports Should use the amplify_core dependency if dartUpdateAmplifyCoreDependency is true 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
+
+import 'ModelProvider.dart';
+import 'package:amplify_core/amplify_core';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+
+/** This is an auto generated class representing the Post type in your schema. */
+@immutable
+class Post extends Model {
+  static const classType = const _PostModelType();
+  final String id;
+  final String? _title;
+  final int? _rating;
+  final PostStatus? _status;
+  final List<Comment>? _comments;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  String get title {
+    try {
+      return _title!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+              recoverySuggestion:
+                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+              underlyingException: e.toString()
+            );
+    }
+  }
+  
+  int get rating {
+    try {
+      return _rating!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+              recoverySuggestion:
+                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+              underlyingException: e.toString()
+            );
+    }
+  }
+  
+  PostStatus get status {
+    try {
+      return _status!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+              recoverySuggestion:
+                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+              underlyingException: e.toString()
+            );
+    }
+  }
+  
+  List<Comment>? get comments {
+    return _comments;
+  }
+  
+  const Post._internal({required this.id, required title, required rating, required status, comments}): _title = title, _rating = rating, _status = status, _comments = comments;
+  
+  factory Post({String? id, required String title, required int rating, required PostStatus status, List<Comment>? comments}) {
+    return Post._internal(
+      id: id == null ? UUID.getUUID() : id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments != null ? List<Comment>.unmodifiable(comments) : comments);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Post &&
+      id == other.id &&
+      _title == other._title &&
+      _rating == other._rating &&
+      _status == other._status &&
+      DeepCollectionEquality().equals(_comments, other._comments);
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Post {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"title=\\" + \\"$_title\\" + \\", \\");
+    buffer.write(\\"rating=\\" + (_rating != null ? _rating!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"status=\\" + (_status != null ? enumToString(_status)! : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Post copyWith({String? id, String? title, int? rating, PostStatus? status, List<Comment>? comments}) {
+    return Post(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      rating: rating ?? this.rating,
+      status: status ?? this.status,
+      comments: comments ?? this.comments);
+  }
+  
+  Post.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _title = json['title'],
+      _rating = (json['rating'] as num?)?.toInt(),
+      _status = enumFromString<PostStatus>(json['status'], PostStatus.values),
+      _comments = json['comments'] is List
+        ? (json['comments'] as List)
+          .where((e) => e?['serializedData'] != null)
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .toList()
+        : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField TITLE = QueryField(fieldName: \\"title\\");
+  static final QueryField RATING = QueryField(fieldName: \\"rating\\");
+  static final QueryField STATUS = QueryField(fieldName: \\"status\\");
+  static final QueryField COMMENTS = QueryField(
+    fieldName: \\"comments\\",
+    fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Comment).toString()));
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Post\\";
+    modelSchemaDefinition.pluralName = \\"Posts\\";
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.TITLE,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.RATING,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.int)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.STATUS,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.enumeration)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+      key: Post.COMMENTS,
+      isRequired: false,
+      ofModelName: (Comment).toString(),
+      associatedKey: Comment.POST
+    ));
+  });
+}
+
+class _PostModelType extends ModelType<Post> {
+  const _PostModelType();
+  
+  @override
+  Post fromJson(Map<String, dynamic> jsonData) {
+    return Post.fromJson(jsonData);
+  }
+}
+
+/** This is an auto generated class representing the Comment type in your schema. */
+@immutable
+class Comment extends Model {
+  static const classType = const _CommentModelType();
+  final String id;
+  final Post? _post;
+  final String? _content;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  Post get post {
+    try {
+      return _post!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+              recoverySuggestion:
+                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+              underlyingException: e.toString()
+            );
+    }
+  }
+  
+  String get content {
+    try {
+      return _content!;
+    } catch(e) {
+      throw new AmplifyCodeGenModelException(
+              AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+              recoverySuggestion:
+                AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+              underlyingException: e.toString()
+            );
+    }
+  }
+  
+  const Comment._internal({required this.id, required post, required content}): _post = post, _content = content;
+  
+  factory Comment({String? id, required Post post, required String content}) {
+    return Comment._internal(
+      id: id == null ? UUID.getUUID() : id,
+      post: post,
+      content: content);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Comment &&
+      id == other.id &&
+      _post == other._post &&
+      _content == other._content;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Comment {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"post=\\" + (_post != null ? _post!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"content=\\" + \\"$_content\\");
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Comment copyWith({String? id, Post? post, String? content}) {
+    return Comment(
+      id: id ?? this.id,
+      post: post ?? this.post,
+      content: content ?? this.content);
+  }
+  
+  Comment.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _post = json['post']?['serializedData'] != null
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        : null,
+      _content = json['content'];
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'post': _post?.toJson(), 'content': _content
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField POST = QueryField(
+    fieldName: \\"post\\",
+    fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
+  static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Comment\\";
+    modelSchemaDefinition.pluralName = \\"Comments\\";
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
+      key: Comment.POST,
+      isRequired: true,
+      targetName: \\"postID\\",
+      ofModelName: (Post).toString()
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Comment.CONTENT,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+  });
+}
+
+class _CommentModelType extends ModelType<Comment> {
+  const _CommentModelType();
+  
+  @override
+  Comment fromJson(Map<String, dynamic> jsonData) {
+    return Comment.fromJson(jsonData);
+  }
+}"
+`;
+
+exports[`AppSync Dart Visitor Amplify Core dependency used in imports Should use the older flutter datastore interface dependency if dartUpdateAmplifyCoreDependency is false 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
+
+import 'ModelProvider.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+
+/** This is an auto generated class representing the Post type in your schema. */
+@immutable
+class Post extends Model {
+  static const classType = const _PostModelType();
+  final String id;
+  final String? _title;
+  final int? _rating;
+  final PostStatus? _status;
+  final List<Comment>? _comments;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  String get title {
+    try {
+      return _title!;
+    } catch(e) {
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
+    }
+  }
+  
+  int get rating {
+    try {
+      return _rating!;
+    } catch(e) {
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
+    }
+  }
+  
+  PostStatus get status {
+    try {
+      return _status!;
+    } catch(e) {
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
+    }
+  }
+  
+  List<Comment>? get comments {
+    return _comments;
+  }
+  
+  const Post._internal({required this.id, required title, required rating, required status, comments}): _title = title, _rating = rating, _status = status, _comments = comments;
+  
+  factory Post({String? id, required String title, required int rating, required PostStatus status, List<Comment>? comments}) {
+    return Post._internal(
+      id: id == null ? UUID.getUUID() : id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments != null ? List<Comment>.unmodifiable(comments) : comments);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Post &&
+      id == other.id &&
+      _title == other._title &&
+      _rating == other._rating &&
+      _status == other._status &&
+      DeepCollectionEquality().equals(_comments, other._comments);
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Post {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"title=\\" + \\"$_title\\" + \\", \\");
+    buffer.write(\\"rating=\\" + (_rating != null ? _rating!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"status=\\" + (_status != null ? enumToString(_status)! : \\"null\\"));
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Post copyWith({String? id, String? title, int? rating, PostStatus? status, List<Comment>? comments}) {
+    return Post(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      rating: rating ?? this.rating,
+      status: status ?? this.status,
+      comments: comments ?? this.comments);
+  }
+  
+  Post.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _title = json['title'],
+      _rating = (json['rating'] as num?)?.toInt(),
+      _status = enumFromString<PostStatus>(json['status'], PostStatus.values),
+      _comments = json['comments'] is List
+        ? (json['comments'] as List)
+          .where((e) => e?['serializedData'] != null)
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .toList()
+        : null;
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField TITLE = QueryField(fieldName: \\"title\\");
+  static final QueryField RATING = QueryField(fieldName: \\"rating\\");
+  static final QueryField STATUS = QueryField(fieldName: \\"status\\");
+  static final QueryField COMMENTS = QueryField(
+    fieldName: \\"comments\\",
+    fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Comment).toString()));
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Post\\";
+    modelSchemaDefinition.pluralName = \\"Posts\\";
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.TITLE,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.RATING,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.int)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Post.STATUS,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.enumeration)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.hasMany(
+      key: Post.COMMENTS,
+      isRequired: false,
+      ofModelName: (Comment).toString(),
+      associatedKey: Comment.POST
+    ));
+  });
+}
+
+class _PostModelType extends ModelType<Post> {
+  const _PostModelType();
+  
+  @override
+  Post fromJson(Map<String, dynamic> jsonData) {
+    return Post.fromJson(jsonData);
+  }
+}
+
+/** This is an auto generated class representing the Comment type in your schema. */
+@immutable
+class Comment extends Model {
+  static const classType = const _CommentModelType();
+  final String id;
+  final Post? _post;
+  final String? _content;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  Post get post {
+    try {
+      return _post!;
+    } catch(e) {
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
+    }
+  }
+  
+  String get content {
+    try {
+      return _content!;
+    } catch(e) {
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
+    }
+  }
+  
+  const Comment._internal({required this.id, required post, required content}): _post = post, _content = content;
+  
+  factory Comment({String? id, required Post post, required String content}) {
+    return Comment._internal(
+      id: id == null ? UUID.getUUID() : id,
+      post: post,
+      content: content);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is Comment &&
+      id == other.id &&
+      _post == other._post &&
+      _content == other._content;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"Comment {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"post=\\" + (_post != null ? _post!.toString() : \\"null\\") + \\", \\");
+    buffer.write(\\"content=\\" + \\"$_content\\");
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  Comment copyWith({String? id, Post? post, String? content}) {
+    return Comment(
+      id: id ?? this.id,
+      post: post ?? this.post,
+      content: content ?? this.content);
+  }
+  
+  Comment.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _post = json['post']?['serializedData'] != null
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        : null,
+      _content = json['content'];
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'post': _post?.toJson(), 'content': _content
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField POST = QueryField(
+    fieldName: \\"post\\",
+    fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
+  static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"Comment\\";
+    modelSchemaDefinition.pluralName = \\"Comments\\";
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
+      key: Comment.POST,
+      isRequired: true,
+      targetName: \\"postID\\",
+      ofModelName: (Post).toString()
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: Comment.CONTENT,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+  });
+}
+
+class _CommentModelType extends ModelType<Comment> {
+  const _CommentModelType();
+  
+  @override
+  Comment fromJson(Map<String, dynamic> jsonData) {
+    return Comment.fromJson(jsonData);
+  }
+}"
+`;
+
 exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated correct dart class for Address with nullsafety disabled 1`] = `
 "/*
 * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -22,7 +702,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Address type in your schema. */
@@ -173,7 +853,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -190,12 +870,12 @@ class Address {
     try {
       return _line1!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -207,12 +887,12 @@ class Address {
     try {
       return _city!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -220,12 +900,12 @@ class Address {
     try {
       return _state!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -233,12 +913,12 @@ class Address {
     try {
       return _postalCode!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -366,7 +1046,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -502,7 +1182,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -518,12 +1198,12 @@ class Contact {
     try {
       return _contactName!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -531,12 +1211,12 @@ class Contact {
     try {
       return _phone!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -653,7 +1333,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -715,7 +1395,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -771,7 +1451,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -941,7 +1621,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should generated corr
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -967,12 +1647,12 @@ class Person extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -980,12 +1660,12 @@ class Person extends Model {
     try {
       return _phone!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -1122,7 +1802,7 @@ exports[`AppSync Dart Visitor CustomType (non-model) Tests should not generate c
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'Person.dart';
 import 'Address.dart';
 import 'Contact.dart';
@@ -1175,7 +1855,7 @@ exports[`AppSync Dart Visitor Dart Specific Tests should generate the model prov
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'SimpleModel.dart';
 
 export 'SimpleModel.dart';
@@ -1226,7 +1906,7 @@ exports[`AppSync Dart Visitor Enum Generation should generate a class for enum t
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -1361,7 +2041,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for app
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1674,7 +2354,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for enu
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1930,7 +2610,7 @@ exports[`AppSync Dart Visitor Field tests should generate correct output for reg
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2179,7 +2859,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2556,7 +3236,7 @@ exports[`AppSync Dart Visitor Many To Many V2 Tests Should generate the intermed
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2582,12 +3262,12 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2724,12 +3404,12 @@ class Tag extends Model {
     try {
       return _label!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2850,12 +3530,12 @@ class PostTags extends Model {
     try {
       return _post!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2863,12 +3543,12 @@ class PostTags extends Model {
     try {
       return _tag!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2991,7 +3671,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a Simp
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3113,7 +3793,7 @@ exports[`AppSync Dart Visitor Model Directive should generate a class for a mode
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -3235,7 +3915,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the TodoWithAuth type in your schema. */
@@ -3399,7 +4079,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate AuthRule
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -3424,12 +4104,12 @@ class TodoWithAuth extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -3585,7 +4265,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -3720,7 +4400,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the customClaim type in your schema. */
@@ -3857,7 +4537,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the dynamicGroups type in your schema. */
@@ -3992,7 +4672,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the simpleOwnerAuth type in your schema. */
@@ -4127,7 +4807,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the allowRead type in your schema. */
@@ -4261,7 +4941,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the privateType type in your schema. */
@@ -4392,7 +5072,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the publicType type in your schema. */
@@ -4523,7 +5203,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should generate class wi
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the staticGroups type in your schema. */
@@ -4660,7 +5340,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should include authRules
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -4798,7 +5478,7 @@ exports[`AppSync Dart Visitor Model with Auth Directive should support multiple 
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Post type in your schema. */
@@ -4950,7 +5630,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5072,7 +5752,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should generate cl
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Task type in your schema. */
@@ -5187,7 +5867,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5343,7 +6023,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the Comment type in your schema. */
@@ -5476,7 +6156,7 @@ exports[`AppSync Dart Visitor Model with Connection Directive should support con
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5636,7 +6316,7 @@ exports[`AppSync Dart Visitor Model with Key Directive should generate a class f
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the authorBook type in your schema. */
@@ -5807,7 +6487,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct internal
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -5911,7 +6591,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -5936,12 +6616,12 @@ class Blog extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6066,7 +6746,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -6094,12 +6774,12 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6218,7 +6898,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct model fi
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6244,12 +6924,12 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6394,7 +7074,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6423,12 +7103,12 @@ class TestModel extends Model {
     try {
       return _floatVal!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6440,12 +7120,12 @@ class TestModel extends Model {
     try {
       return _floatList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6457,12 +7137,12 @@ class TestModel extends Model {
     try {
       return _nullableFloatList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6631,7 +7311,7 @@ exports[`AppSync Dart Visitor Null Safety Tests should generate correct null saf
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -6666,12 +7346,12 @@ class TestModel extends Model {
     try {
       return _floatVal!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6683,12 +7363,12 @@ class TestModel extends Model {
     try {
       return _floatList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6700,12 +7380,12 @@ class TestModel extends Model {
     try {
       return _nullableFloatList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6717,12 +7397,12 @@ class TestModel extends Model {
     try {
       return _intVal!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6734,12 +7414,12 @@ class TestModel extends Model {
     try {
       return _intList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -6751,12 +7431,12 @@ class TestModel extends Model {
     try {
       return _nullableIntList!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -7001,7 +7681,7 @@ exports[`AppSync Dart Visitor Read-only Field Tests should generate the read-onl
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 /** This is an auto generated class representing the SimpleModel type in your schema. */
@@ -7141,7 +7821,7 @@ exports[`AppSync Dart Visitor Read-only and Null Safety Combined Tests should ge
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -23,7 +23,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -48,10 +48,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -178,7 +178,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -202,10 +202,10 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -330,7 +330,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -489,7 +489,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -513,10 +513,10 @@ class Team2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -641,7 +641,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -666,10 +666,10 @@ class Blog7V2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -796,7 +796,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -822,10 +822,10 @@ class Post7V2 extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -973,7 +973,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1116,7 +1116,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1275,7 +1275,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1299,10 +1299,10 @@ class Team extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -1427,7 +1427,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1453,10 +1453,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -1599,7 +1599,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1624,10 +1624,10 @@ class Tag extends Model {
     try {
       return _label!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -1753,7 +1753,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on record creation an
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1874,7 +1874,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1899,10 +1899,10 @@ class Post2 extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2028,7 +2028,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2052,10 +2052,10 @@ class Comment2 extends Model {
     try {
       return _postID!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2065,10 +2065,10 @@ class Comment2 extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2184,7 +2184,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2342,7 +2342,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2365,10 +2365,10 @@ class Team2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2472,7 +2472,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2497,10 +2497,10 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2626,7 +2626,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2650,10 +2650,10 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -2773,7 +2773,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2931,7 +2931,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2954,10 +2954,10 @@ class Team extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -3060,7 +3060,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works when configuring a se
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:amplify_core/amplify_core.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -3085,10 +3085,10 @@ class Customer extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }
@@ -3102,10 +3102,10 @@ class Customer extends Model {
     try {
       return _accountRepresentativeID!;
     } catch(e) {
-      throw new DataStoreException(
-      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      throw new AmplifyCodeGenModelException(
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
       recoverySuggestion:
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
       underlyingException: e.toString()
     );
     }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -23,7 +23,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -48,12 +48,12 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -178,7 +178,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -202,12 +202,12 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -330,7 +330,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -489,7 +489,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -513,12 +513,12 @@ class Team2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -641,7 +641,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -666,12 +666,12 @@ class Blog7V2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -796,7 +796,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -822,12 +822,12 @@ class Post7V2 extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -973,7 +973,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -1116,7 +1116,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -1275,7 +1275,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -1299,12 +1299,12 @@ class Team extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -1427,7 +1427,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1453,12 +1453,12 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -1599,7 +1599,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1624,12 +1624,12 @@ class Tag extends Model {
     try {
       return _label!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -1753,7 +1753,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on record creation an
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -1874,7 +1874,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1899,12 +1899,12 @@ class Post2 extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2028,7 +2028,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2052,12 +2052,12 @@ class Comment2 extends Model {
     try {
       return _postID!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2065,12 +2065,12 @@ class Comment2 extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2184,7 +2184,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2342,7 +2342,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2365,12 +2365,12 @@ class Team2 extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2472,7 +2472,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2497,12 +2497,12 @@ class Post extends Model {
     try {
       return _title!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2626,7 +2626,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2650,12 +2650,12 @@ class Comment extends Model {
     try {
       return _content!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -2773,7 +2773,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2931,7 +2931,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -2954,12 +2954,12 @@ class Team extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -3060,7 +3060,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works when configuring a se
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_core/amplify_core.dart';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
 import 'package:flutter/foundation.dart';
 
 
@@ -3085,12 +3085,12 @@ class Customer extends Model {
     try {
       return _name!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   
@@ -3102,12 +3102,12 @@ class Customer extends Model {
     try {
       return _accountRepresentativeID!;
     } catch(e) {
-      throw new AmplifyCodeGenModelException(
-      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-      recoverySuggestion:
-        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-      underlyingException: e.toString()
-    );
+      throw new DataStoreException(
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+            recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+            underlyingException: e.toString()
+          );
     }
   }
   

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -23,7 +23,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -49,10 +49,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -178,7 +178,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -203,10 +203,10 @@ class Comment extends Model {
       return _content!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -330,7 +330,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -489,7 +489,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on explicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -514,10 +514,10 @@ class Team2 extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -641,7 +641,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -667,10 +667,10 @@ class Blog7V2 extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -796,7 +796,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -823,10 +823,10 @@ class Post7V2 extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -973,7 +973,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasMany b
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1116,7 +1116,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1275,7 +1275,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on implicit hasOne be
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1300,10 +1300,10 @@ class Team extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1427,7 +1427,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1454,10 +1454,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1599,7 +1599,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on many to many relat
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1625,10 +1625,10 @@ class Tag extends Model {
       return _label!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -1753,7 +1753,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on record creation an
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -1874,7 +1874,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -1900,10 +1900,10 @@ class Post2 extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2028,7 +2028,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2053,10 +2053,10 @@ class Comment2 extends Model {
       return _postID!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2066,10 +2066,10 @@ class Comment2 extends Model {
       return _content!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2184,7 +2184,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2342,7 +2342,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional ex
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2366,10 +2366,10 @@ class Team2 extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2472,7 +2472,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
@@ -2498,10 +2498,10 @@ class Post extends Model {
       return _title!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2626,7 +2626,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2651,10 +2651,10 @@ class Comment extends Model {
       return _content!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -2773,7 +2773,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
 import 'ModelProvider.dart';
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2931,7 +2931,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works on uni-directional im
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -2955,10 +2955,10 @@ class Team extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3060,7 +3060,7 @@ exports[`AppSyncDartVisitor - GQLv2 Regression Tests Works when configuring a se
 
 // ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
 
-import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
 import 'package:flutter/foundation.dart';
 
 
@@ -3086,10 +3086,10 @@ class Customer extends Model {
       return _name!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }
@@ -3103,10 +3103,10 @@ class Customer extends Model {
       return _accountRepresentativeID!;
     } catch(e) {
       throw new DataStoreException(
-            DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-            recoverySuggestion:
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
             DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-            underlyingException: e.toString()
+          underlyingException: e.toString()
           );
     }
   }

--- a/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
+++ b/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
@@ -1,8 +1,5 @@
 export const LOADER_CLASS_NAME = 'ModelProvider';
-export const BASE_IMPORT_PACKAGES = [
-  'package:flutter/foundation.dart',
-  'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart',
-];
+export const BASE_IMPORT_PACKAGES = ['package:flutter/foundation.dart', 'package:amplify_core/amplify_core.dart'];
 export const COLLECTION_PACKAGE = 'package:collection/collection.dart';
 
 export const CUSTOM_LINTS_MESSAGE = `// NOTE: This file is generated and may not follow lint rules defined in your app

--- a/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
+++ b/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
@@ -1,5 +1,7 @@
 export const LOADER_CLASS_NAME = 'ModelProvider';
-export const BASE_IMPORT_PACKAGES = ['package:flutter/foundation.dart', 'package:amplify_core/amplify_core.dart'];
+export const FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT = 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+export const FLUTTER_AMPLIFY_CORE_IMPORT = 'package:amplify_core/amplify_core';
+export const BASE_IMPORT_PACKAGES = ['package:flutter/foundation.dart'];
 export const COLLECTION_PACKAGE = 'package:collection/collection.dart';
 
 export const CUSTOM_LINTS_MESSAGE = `// NOTE: This file is generated and may not follow lint rules defined in your app

--- a/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
+++ b/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
@@ -1,6 +1,6 @@
 export const LOADER_CLASS_NAME = 'ModelProvider';
-export const FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT = 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
-export const FLUTTER_AMPLIFY_CORE_IMPORT = 'package:amplify_core/amplify_core.dart';
+export const FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT = 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
+export const FLUTTER_AMPLIFY_CORE_IMPORT = 'package:amplify_core/amplify_core';
 export const BASE_IMPORT_PACKAGES = ['package:flutter/foundation.dart'];
 export const COLLECTION_PACKAGE = 'package:collection/collection.dart';
 

--- a/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
+++ b/packages/appsync-modelgen-plugin/src/configs/dart-config.ts
@@ -1,6 +1,6 @@
 export const LOADER_CLASS_NAME = 'ModelProvider';
-export const FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT = 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface';
-export const FLUTTER_AMPLIFY_CORE_IMPORT = 'package:amplify_core/amplify_core';
+export const FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT = 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+export const FLUTTER_AMPLIFY_CORE_IMPORT = 'package:amplify_core/amplify_core.dart';
 export const BASE_IMPORT_PACKAGES = ['package:flutter/foundation.dart'];
 export const COLLECTION_PACKAGE = 'package:collection/collection.dart';
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -20,7 +20,7 @@ import {
   DART_RESERVED_KEYWORDS,
   typeToEnumMap,
   IGNORE_FOR_FILE,
-  CUSTOM_LINTS_MESSAGE
+  CUSTOM_LINTS_MESSAGE,
 } from '../configs/dart-config';
 import dartStyle from 'dart-style';
 import { generateLicense } from '../utils/generateLicense';
@@ -129,7 +129,8 @@ export class AppSyncModelDartVisitor<
     //Ignore for file
     result.push(IGNORE_FOR_FILE);
     //Packages for import
-    const flutterDatastorePackage = this.config.dartUpdateAmplifyCoreDependency === true ? FLUTTER_AMPLIFY_CORE_IMPORT : FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT;
+    const flutterDatastorePackage =
+      this.config.dartUpdateAmplifyCoreDependency === true ? FLUTTER_AMPLIFY_CORE_IMPORT : FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT;
     const packageImports: string[] = [flutterDatastorePackage, ...modelNames, ...nonModelNames];
     //Packages for export
     const packageExports: string[] = [...exportClasses];
@@ -251,9 +252,15 @@ export class AppSyncModelDartVisitor<
         }
       });
     });
-    const flutterDatastorePackage = this.config.dartUpdateAmplifyCoreDependency === true ? FLUTTER_AMPLIFY_CORE_IMPORT : FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT;
+    const flutterDatastorePackage =
+      this.config.dartUpdateAmplifyCoreDependency === true ? FLUTTER_AMPLIFY_CORE_IMPORT : FLUTTER_DATASTORE_PLUGIN_INTERFACE_IMPORT;
     return (
-      [...BASE_IMPORT_PACKAGES, flutterDatastorePackage, usingCollection ? COLLECTION_PACKAGE : '', usingOtherClass ? `${LOADER_CLASS_NAME}.dart` : '']
+      [
+        ...BASE_IMPORT_PACKAGES,
+        `${flutterDatastorePackage}.dart`,
+        usingCollection ? COLLECTION_PACKAGE : '',
+        usingOtherClass ? `${LOADER_CLASS_NAME}.dart` : '',
+      ]
         .filter(f => f)
         .sort()
         .map(pckg => `import '${pckg}';`)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -369,18 +369,18 @@ export class AppSyncModelDartVisitor<
     //other getters
     if (this.isNullSafety()) {
       let forceCastException = `throw new DataStoreException(
-        DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-        recoverySuggestion:
+      DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      recoverySuggestion:
         DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-        underlyingException: e.toString()
+      underlyingException: e.toString()
       );`;
       if (this.config.dartUpdateAmplifyCoreDependency === true) {
         forceCastException = `throw new AmplifyCodeGenModelException(
-          AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-        );`;
+      AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+      recoverySuggestion:
+        AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+      underlyingException: e.toString()
+      );`;
       }
       
       model.fields.forEach(field => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -382,7 +382,7 @@ export class AppSyncModelDartVisitor<
       underlyingException: e.toString()
       );`;
       }
-      
+
       model.fields.forEach(field => {
         const fieldName = this.getFieldName(field);
         const fieldType = this.getNativeType(field);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Context as mentioned in [this PR](https://github.com/aws-amplify/amplify-codegen/pull/380):
Changes flutter (dart) codegen so that generated models will import from amplify_core, rather than datastore. This is to support a feature in 0.4.0 amplify-flutter where API users can generate models without a datastore dependency. For this reason, the models need to import from core, as implemented here.

The codegen files here would depend on a version of amplify-flutter with the deps moved (0.4.0+). 0.4.0 will continue to export the same things from datastore to maintain compatibility with older codegen files, but the new codegen files with this change will need a newer version of amplify-flutter to correctly resolve dependencies.

These changes:
- Add a version check to determine the relevant datastore library to import. `v>=0.4.0` Amplify Flutter library users will be able to import the new `amplify_core` package.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Added relevant unit test with snapshots



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.