### PR TITLE
feat(appsync-dart-visitor): attach index info to model schema

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -313,6 +313,10 @@ class Comment extends Model {
     modelSchemaDefinition.name = \\"Comment\\";
     modelSchemaDefinition.pluralName = \\"Comments\\";
     
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
+    
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
@@ -652,6 +656,10 @@ class Comment extends Model {
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Comment\\";
     modelSchemaDefinition.pluralName = \\"Comments\\";
+    
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
     
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
@@ -6107,6 +6115,10 @@ class Comment extends Model {
     modelSchemaDefinition.name = \\"Comment\\";
     modelSchemaDefinition.pluralName = \\"Comments\\";
 
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
+
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
 
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
@@ -6261,6 +6273,10 @@ class Post extends Model {
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
     modelSchemaDefinition.pluralName = \\"Posts\\";
+
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"blogID\\"], name: \\"byBlog\\")
+    ];
 
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
 
@@ -6429,6 +6445,11 @@ class authorBook extends Model {
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"authorBook\\";
     modelSchemaDefinition.pluralName = \\"authorBooks\\";
+
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"author_id\\"], name: \\"byAuthor\\"),
+      ModelIndex(fields: [\\"book_id\\"], name: \\"byBook\\")
+    ];
 
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
 
@@ -6848,6 +6869,10 @@ class Comment extends Model {
     modelSchemaDefinition.name = \\"Comment\\";
     modelSchemaDefinition.pluralName = \\"Comments\\";
     
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
+    
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
     modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
@@ -7017,6 +7042,10 @@ class Post extends Model {
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Post\\";
     modelSchemaDefinition.pluralName = \\"Posts\\";
+    
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"blogID\\"], name: \\"byBlog\\")
+    ];
     
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -650,7 +650,7 @@ describe('AppSync Dart Visitor', () => {
         ACTIVE
         INACTIVE
       }
-      
+
       type Post @model {
         id: ID!
         title: String!
@@ -659,7 +659,7 @@ describe('AppSync Dart Visitor', () => {
         # New field with @hasMany
         comments: [Comment] @hasMany(indexName: "byPost", fields: ["id"])
       }
-      
+
       # New model
       type Comment @model {
         id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -280,6 +280,10 @@ class Comment extends Model {
     modelSchemaDefinition.name = \\"Comment\\";
     modelSchemaDefinition.pluralName = \\"Comments\\";
     
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
+    
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
     modelSchemaDefinition.addField(ModelFieldDefinition.field(
@@ -2135,6 +2139,10 @@ class Comment2 extends Model {
     modelSchemaDefinition.name = \\"Comment2\\";
     modelSchemaDefinition.pluralName = \\"Comment2s\\";
     
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+    ];
+    
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
     modelSchemaDefinition.addField(ModelFieldDefinition.field(
@@ -3178,6 +3186,10 @@ class Customer extends Model {
     modelSchemaDefinition.name = \\"Customer\\";
     modelSchemaDefinition.pluralName = \\"Customers\\";
     
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"accountRepresentativeID\\"], name: \\"byRepresentative\\")
+    ];
+    
     modelSchemaDefinition.addField(ModelFieldDefinition.id());
     
     modelSchemaDefinition.addField(ModelFieldDefinition.field(
@@ -3206,6 +3218,236 @@ class _CustomerModelType extends ModelType<Customer> {
   @override
   Customer fromJson(Map<String, dynamic> jsonData) {
     return Customer.fromJson(jsonData);
+  }
+}"
+`;
+
+exports[`AppSyncDartVisitor - GQLv2 Regression Tests model indexes should correct indexes for @primaryKey and @index directive 1`] = `
+"/*
+* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the \\"License\\").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the \\"license\\" file accompanying this file. This file is distributed
+* on an \\"AS IS\\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+// NOTE: This file is generated and may not follow lint rules defined in your app
+// Generated files can be excluded from analysis in analysis_options.yaml
+// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis
+
+// ignore_for_file: public_member_api_docs, file_names, unnecessary_new, prefer_if_null_operators, prefer_const_constructors, slash_for_doc_comments, annotate_overrides, non_constant_identifier_names, unnecessary_string_interpolations, prefer_adjacent_string_concatenation, unnecessary_const, dead_code
+
+import 'package:amplify_datastore_plugin_interface/amplify_datastore_plugin_interface.dart';
+import 'package:flutter/foundation.dart';
+
+
+/** This is an auto generated class representing the ModelWithPrimaryKey type in your schema. */
+@immutable
+class ModelWithPrimaryKey extends Model {
+  static const classType = const _ModelWithPrimaryKeyModelType();
+  final String id;
+  final String? _productID;
+  final String? _name;
+  final String? _content;
+  final String? _albumID;
+  final String? _categoryID;
+
+  @override
+  getInstanceType() => classType;
+  
+  @override
+  String getId() {
+    return id;
+  }
+  
+  String get productID {
+    try {
+      return _productID!;
+    } catch(e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  String get name {
+    try {
+      return _name!;
+    } catch(e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  String? get content {
+    return _content;
+  }
+  
+  String get albumID {
+    try {
+      return _albumID!;
+    } catch(e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  String get categoryID {
+    try {
+      return _categoryID!;
+    } catch(e) {
+      throw new DataStoreException(
+          DataStoreExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
+          recoverySuggestion:
+            DataStoreExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
+          underlyingException: e.toString()
+          );
+    }
+  }
+  
+  const ModelWithPrimaryKey._internal({required this.id, required productID, required name, content, required albumID, required categoryID}): _productID = productID, _name = name, _content = content, _albumID = albumID, _categoryID = categoryID;
+  
+  factory ModelWithPrimaryKey({String? id, required String productID, required String name, String? content, required String albumID, required String categoryID}) {
+    return ModelWithPrimaryKey._internal(
+      id: id == null ? UUID.getUUID() : id,
+      productID: productID,
+      name: name,
+      content: content,
+      albumID: albumID,
+      categoryID: categoryID);
+  }
+  
+  bool equals(Object other) {
+    return this == other;
+  }
+  
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ModelWithPrimaryKey &&
+      id == other.id &&
+      _productID == other._productID &&
+      _name == other._name &&
+      _content == other._content &&
+      _albumID == other._albumID &&
+      _categoryID == other._categoryID;
+  }
+  
+  @override
+  int get hashCode => toString().hashCode;
+  
+  @override
+  String toString() {
+    var buffer = new StringBuffer();
+    
+    buffer.write(\\"ModelWithPrimaryKey {\\");
+    buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
+    buffer.write(\\"productID=\\" + \\"$_productID\\" + \\", \\");
+    buffer.write(\\"name=\\" + \\"$_name\\" + \\", \\");
+    buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
+    buffer.write(\\"albumID=\\" + \\"$_albumID\\" + \\", \\");
+    buffer.write(\\"categoryID=\\" + \\"$_categoryID\\");
+    buffer.write(\\"}\\");
+    
+    return buffer.toString();
+  }
+  
+  ModelWithPrimaryKey copyWith({String? id, String? productID, String? name, String? content, String? albumID, String? categoryID}) {
+    return ModelWithPrimaryKey(
+      id: id ?? this.id,
+      productID: productID ?? this.productID,
+      name: name ?? this.name,
+      content: content ?? this.content,
+      albumID: albumID ?? this.albumID,
+      categoryID: categoryID ?? this.categoryID);
+  }
+  
+  ModelWithPrimaryKey.fromJson(Map<String, dynamic> json)  
+    : id = json['id'],
+      _productID = json['productID'],
+      _name = json['name'],
+      _content = json['content'],
+      _albumID = json['albumID'],
+      _categoryID = json['categoryID'];
+  
+  Map<String, dynamic> toJson() => {
+    'id': id, 'productID': _productID, 'name': _name, 'content': _content, 'albumID': _albumID, 'categoryID': _categoryID
+  };
+
+  static final QueryField ID = QueryField(fieldName: \\"modelWithPrimaryKey.id\\");
+  static final QueryField PRODUCTID = QueryField(fieldName: \\"productID\\");
+  static final QueryField NAME = QueryField(fieldName: \\"name\\");
+  static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
+  static final QueryField ALBUMID = QueryField(fieldName: \\"albumID\\");
+  static final QueryField CATEGORYID = QueryField(fieldName: \\"categoryID\\");
+  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
+    modelSchemaDefinition.name = \\"ModelWithPrimaryKey\\";
+    modelSchemaDefinition.pluralName = \\"ModelWithPrimaryKeys\\";
+    
+    modelSchemaDefinition.indexes = [
+      ModelIndex(fields: [\\"productID\\"], name: null),
+      ModelIndex(fields: [\\"albumID\\", \\"name\\"], name: \\"byAlbum\\"),
+      ModelIndex(fields: [\\"categoryID\\", \\"name\\", \\"content\\"], name: \\"byCategory\\")
+    ];
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.id());
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: ModelWithPrimaryKey.PRODUCTID,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: ModelWithPrimaryKey.NAME,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: ModelWithPrimaryKey.CONTENT,
+      isRequired: false,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: ModelWithPrimaryKey.ALBUMID,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+    
+    modelSchemaDefinition.addField(ModelFieldDefinition.field(
+      key: ModelWithPrimaryKey.CATEGORYID,
+      isRequired: true,
+      ofType: ModelFieldType(ModelFieldTypeEnum.string)
+    ));
+  });
+}
+
+class _ModelWithPrimaryKeyModelType extends ModelType<ModelWithPrimaryKey> {
+  const _ModelWithPrimaryKeyModelType();
+  
+  @override
+  ModelWithPrimaryKey fromJson(Map<String, dynamic> jsonData) {
+    return ModelWithPrimaryKey.fromJson(jsonData);
   }
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/appsync-dart-visitor.test.ts
@@ -234,4 +234,21 @@ describe('AppSyncDartVisitor - GQLv2 Regression Tests', () => {
     expect(getGQLv2Visitor(schema, 'Post7V2').generate()).toMatchSnapshot();
     expect(getGQLv2Visitor(schema, 'Comment7V2').generate()).toMatchSnapshot();
   });
+
+  describe('model indexes', () => {
+    it('should correct indexes for @primaryKey and @index directive', () => {
+      const schema = /* GraphQL */ `
+        type ModelWithPrimaryKey @model {
+          productID: ID! @primaryKey
+          name: String!
+          content: String
+          albumID: ID! @index(name: "byAlbum", sortKeyFields: ["name"])
+          categoryID: ID! @index(name: "byCategory", sortKeyFields: ["name", "content"])
+        }
+      `;
+
+      const generatedCode = getGQLv2Visitor(schema, 'ModelWithPrimaryKey').generate();
+      expect(generatedCode).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -767,6 +767,7 @@ export class AppSyncModelDartVisitor<
             model,
           )}";`,
           this.generateAuthRules(model),
+          this.generateIndexes(model),
           isNonModel ? this.generateNonModelAddFields(model) : this.generateAddFields(model),
         ]
           .filter(f => f)
@@ -821,6 +822,22 @@ export class AppSyncModelDartVisitor<
         return ['modelSchemaDefinition.authRules = [', indentMultiline(rules.join(',\n')), '];'].join('\n');
       }
     }
+    return '';
+  }
+
+  protected generateIndexes(model: CodeGenModel): string {
+    const indexes = model.directives
+      .filter(directive => directive.name === 'key')
+      .map(directive => {
+        const name = directive.arguments.name ? `"${directive.arguments.name}"` : 'null';
+        const fields: string = directive.arguments.fields.map((field: string) => `"${field}"`).join(', ');
+        return `ModelIndex(fields: [${fields}], name: ${name})`;
+      });
+
+    if (indexes.length) {
+      return ['modelSchemaDefinition.indexes = [', indentMultiline(indexes.join(',\n')), '];'].join('\n');
+    }
+
     return '';
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Add a generator to generate `indexes` in model schema. This is an existing feature in the swift and java visitors.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

* Unit tests in amplify-codegen
* Sample App testing with amplify-flutter, based on this PR https://github.com/aws-amplify/amplify-flutter/pull/1366

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.