### PR TITLE
feat(appsync-modelgen-plugin): add sort key field in manyToMany models

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -928,7 +928,7 @@ describe('AppSyncModelVisitor', () => {
     `;
     const { models } = createAndGeneratePipelinedTransformerVisitor(schema);
     const { ModelAModelB } = models;
-    it.only('should generate correct fields and secondary keys for intermediate type', () => {
+    it('should generate correct fields and secondary keys for intermediate type', () => {
       expect(ModelAModelB).toBeDefined();
       expect(ModelAModelB.fields.length).toEqual(7);
       const modelASortKeyField = ModelAModelB.fields.find(f => f.name === 'modelAsortId');

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -579,9 +579,7 @@ export class AppSyncModelVisitor<
               name: 'index',
               arguments: {
                 name: 'by' + firstModel.name,
-                sortKeyFields: firstModelSortKeyFields.length
-                  ? firstModelSortKeyFields.map(f => this.generateIntermediateModelSortKeyFieldName(firstModel, f))
-                  : [secondModelKeyFieldName],
+                sortKeyFields: firstModelSortKeyFields.map(f => this.generateIntermediateModelSortKeyFieldName(firstModel, f)),
               },
             },
           ],
@@ -605,9 +603,7 @@ export class AppSyncModelVisitor<
               name: 'index',
               arguments: {
                 name: 'by' + secondModel.name,
-                sortKeyFields: secondModelSortKeyFields.length
-                  ? secondModelSortKeyFields.map(f => this.generateIntermediateModelSortKeyFieldName(secondModel, f))
-                  : [firstModelKeyFieldName],
+                sortKeyFields: secondModelSortKeyFields.map(f => this.generateIntermediateModelSortKeyFieldName(secondModel, f)),
               },
             },
           ],

--- a/packages/graphql-types-generator/package.json
+++ b/packages/graphql-types-generator/package.json
@@ -74,8 +74,7 @@
     ],
     "testMatch": [
       "**/test/**/*.(js|ts)",
-      "**/test/*.(js|ts)",
-      "**/__tests__/*.(js|ts)"
+      "**/test/*.(js|ts)"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The following changes are made in response to https://github.com/aws-amplify/amplify-cli/pull/9580

- Add sort key fields in the joint model of `manyToMany` when they are defined in the original model
- Add the secondary key infos in joint model
- Add the sort key fields from original model in joint model secondary key sort key fields

Example GraphQL Schema
```GraphQL
type ModelA @model {
  id: ID! @primaryKey(sortKeyFields: ["sortId"])
  sortId: ID!
  models: [ModelB] @manyToMany(relationName: "ModelAModelB")
}
type ModelB @model {
  id: ID! @primaryKey(sortKeyFields: ["sortId"])
  sortId: ID!
  models: [ModelA] @manyToMany(relationName: "ModelAModelB")
}
```
Schema after manyToMany process
```GraphQL
type ModelA @model {
  id: ID! @primaryKey(sortKeyFields: ["sortId"])
  sortId: ID!
  models: [ModelAModelB] @hasMany(indexName: "byModelA", fields:["id"])
}
type ModelB @model {
  id: ID! @primaryKey(sortKeyFields: ["sortId"])
  sortId: ID!
  models: [ModelAModelB] @hasMany(indexName: "byModelB", fields:["id"])
}
type ModelAModelB @model {
  id: ID!
  modelAID: ID! @index(name: "byModelA", sortKeyFields:["modelAsortId"])
  modelBID: ID! @index(name: "byModelB", sortKeyFields:["modelBsortId"])
  modelAsortId: ID!              # ========> new field
  modelBsortId: ID!              # ========> new field
  modelA: ModelA! @belongsTo(fields: ["modelAID"])
  modelB: ModelB! @belongsTo(fields:["modelBID"])
}
```
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.