### PR TITLE
feat(modelgen-swift): custom primary key support for ios

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -392,7 +392,7 @@ extension Project {
     model.fields(
       .field(project.projectId, is: .required, ofType: .string),
       .field(project.name, is: .required, ofType: .string),
-      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"])),
+      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.projectTeamTeamId, is: .optional, ofType: .string)
@@ -479,7 +479,7 @@ extension Team {
     model.fields(
       .field(team.teamId, is: .required, ofType: .string),
       .field(team.name, is: .required, ofType: .string),
-      .belongsTo(team.project, is: .optional, ofType: Project.self, targetNames: [\\"teamProjectProjectId\\", \\"teamProjectName\\"])),
+      .belongsTo(team.project, is: .optional, ofType: Project.self, targetNames: [\\"teamProjectProjectId\\", \\"teamProjectName\\"]),
       .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -320,6 +320,185 @@ extension ModelImplicitDefaultPk: ModelIdentifiable {
 }"
 `;
 
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate targetNames in hasOne/belongsTo relation for models with a composite PK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Project: Model {
+  public let projectId: String
+  public let name: String
+  public var team: Team?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var projectTeamTeamId: String?
+  
+  public init(projectId: String,
+      name: String,
+      team: Team? = nil,
+      projectTeamTeamId: String? = nil) {
+    self.init(projectId: projectId,
+      name: name,
+      team: team,
+      createdAt: nil,
+      updatedAt: nil,
+      projectTeamTeamId: projectTeamTeamId)
+  }
+  internal init(projectId: String,
+      name: String,
+      team: Team? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      projectTeamTeamId: String? = nil) {
+      self.projectId = projectId
+      self.name = name
+      self.team = team
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.projectTeamTeamId = projectTeamTeamId
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate targetNames in hasOne/belongsTo relation for models with a composite PK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Project {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case projectId
+    case name
+    case team
+    case createdAt
+    case updatedAt
+    case projectTeamTeamId
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let project = Project.keys
+    
+    model.pluralName = \\"Projects\\"
+    
+    model.attributes(
+      .index(fields: [\\"projectId\\", \\"name\\"], name: nil),
+      .primaryKey(fields: [project.projectId, project.name])
+    )
+    
+    model.fields(
+      .field(project.projectId, is: .required, ofType: .string),
+      .field(project.name, is: .required, ofType: .string),
+      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"])),
+      .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(project.projectTeamTeamId, is: .optional, ofType: .string)
+    )
+    }
+}
+
+extension Project: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Project.Identifier {
+  public static func identifier(projectId: String,
+      name: String) -> Self {
+    .make(fields:[(name: \\"projectId\\", value: projectId), (name: \\"name\\", value: name)])
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate targetNames in hasOne/belongsTo relation for models with a composite PK 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Team: Model {
+  public let teamId: String
+  public let name: String
+  public var project: Project?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(teamId: String,
+      name: String,
+      project: Project? = nil) {
+    self.init(teamId: teamId,
+      name: name,
+      project: project,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(teamId: String,
+      name: String,
+      project: Project? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.teamId = teamId
+      self.name = name
+      self.project = project
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate targetNames in hasOne/belongsTo relation for models with a composite PK 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Team {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case teamId
+    case name
+    case project
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let team = Team.keys
+    
+    model.pluralName = \\"Teams\\"
+    
+    model.attributes(
+      .index(fields: [\\"teamId\\", \\"name\\"], name: nil),
+      .primaryKey(fields: [team.teamId, team.name])
+    )
+    
+    model.fields(
+      .field(team.teamId, is: .required, ofType: .string),
+      .field(team.name, is: .required, ofType: .string),
+      .belongsTo(team.project, is: .optional, ofType: Project.self, targetNames: [\\"teamProjectProjectId\\", \\"teamProjectName\\"])),
+      .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Team: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Team.Identifier {
+  public static func identifier(teamId: String,
+      name: String) -> Self {
+    .make(fields:[(name: \\"teamId\\", value: teamId), (name: \\"name\\", value: name)])
+  }
+}"
+`;
+
 exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `
 "// swiftlint:disable all
 import Amplify

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -577,7 +577,7 @@ extension Project {
     model.fields(
       .field(project.projectId, is: .required, ofType: .string),
       .field(project.name, is: .required, ofType: .string),
-      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
+      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.project, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.projectTeamTeamId, is: .optional, ofType: .string),

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -7,6 +7,62 @@ import Foundation
 "
 `;
 
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a composite PK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a composite PK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a custom PK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a custom PK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with explicit PK named id 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with explicit PK named id 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with implicit PK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with implicit PK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+"
+`;
+
 exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `
 "// swiftlint:disable all
 import Amplify
@@ -101,8 +157,12 @@ extension ListContainer {
     
     model.pluralName = \\"ListContainers\\"
     
+    model.attributes(
+      .primaryKey(fields: [listContainer.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(listContainer.id, is: .required, ofType: .string),
       .field(listContainer.name, is: .optional, ofType: .string),
       .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: Int.self)),
       .field(listContainer.requiredList, is: .required, ofType: .embeddedCollection(of: String.self)),
@@ -115,6 +175,10 @@ extension ListContainer {
       .field(listContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension ListContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -208,8 +272,12 @@ extension Todo {
     
     model.pluralName = \\"Todos\\"
     
+    model.attributes(
+      .primaryKey(fields: [todo.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todo.id, is: .required, ofType: .string),
       .field(todo.title, is: .required, ofType: .string),
       .hasMany(todo.requiredListOfTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
       .hasMany(todo.listOfRequiredTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
@@ -219,6 +287,10 @@ extension Todo {
       .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Todo: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -280,13 +352,21 @@ extension task {
     
     model.pluralName = \\"tasks\\"
     
+    model.attributes(
+      .primaryKey(fields: [task.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(task.id, is: .required, ofType: .string),
       .field(task.title, is: .required, ofType: .string),
       .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
       .field(task.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension task: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -11,56 +11,309 @@ exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadat
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+public struct ModelCompositePk: Model {
+  public let id: String
+  public var dob: Temporal.DateTime
+  public var name: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      dob: Temporal.DateTime,
+      name: String? = nil) {
+    self.init(id: id,
+      dob: dob,
+      name: name,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      dob: Temporal.DateTime,
+      name: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.dob = dob
+      self.name = name
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a composite PK 2`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+extension ModelCompositePk {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case dob
+    case name
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let modelCompositePk = ModelCompositePk.keys
+    
+    model.pluralName = \\"ModelCompositePks\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\", \\"dob\\"], name: nil),
+      .primaryKey(fields: [modelCompositePk.id, modelCompositePk.dob])
+    )
+    
+    model.fields(
+      .field(modelCompositePk.id, is: .required, ofType: .string),
+      .field(modelCompositePk.dob, is: .required, ofType: .dateTime),
+      .field(modelCompositePk.name, is: .optional, ofType: .string),
+      .field(modelCompositePk.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(modelCompositePk.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+extension ModelCompositePk: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension ModelCompositePk.Identifier {
+  public static func identifier(id: String,
+      dob: Temporal.DateTime) -> Self {
+    .make(fields:[(name: \\"id\\", value: id), (name: \\"dob\\", value: dob)])
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a custom PK 1`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+public struct ModelExplicitCustomPk: Model {
+  public var userId: String
+  public var name: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(userId: String,
+      name: String? = nil) {
+    self.init(userId: userId,
+      name: name,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(userId: String,
+      name: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.userId = userId
+      self.name = name
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a custom PK 2`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+extension ModelExplicitCustomPk {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case userId
+    case name
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let modelExplicitCustomPk = ModelExplicitCustomPk.keys
+    
+    model.pluralName = \\"ModelExplicitCustomPks\\"
+    
+    model.attributes(
+      .index(fields: [\\"userId\\"], name: nil),
+      .primaryKey(fields: [modelExplicitCustomPk.userId])
+    )
+    
+    model.fields(
+      .field(modelExplicitCustomPk.userId, is: .required, ofType: .string),
+      .field(modelExplicitCustomPk.name, is: .optional, ofType: .string),
+      .field(modelExplicitCustomPk.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(modelExplicitCustomPk.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+extension ModelExplicitCustomPk: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension ModelExplicitCustomPk.Identifier {
+  public static func identifier(userId: String) -> Self {
+    .make(fields:[(name: \\"userId\\", value: userId)])
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with explicit PK named id 1`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+public struct ModelExplicitDefaultPk: Model {
+  public let id: String
+  public var name: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      name: String? = nil) {
+    self.init(id: id,
+      name: name,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      name: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.name = name
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with explicit PK named id 2`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+extension ModelExplicitDefaultPk {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let modelExplicitDefaultPk = ModelExplicitDefaultPk.keys
+    
+    model.pluralName = \\"ModelExplicitDefaultPks\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\"], name: nil),
+      .primaryKey(fields: [modelExplicitDefaultPk.id])
+    )
+    
+    model.fields(
+      .field(modelExplicitDefaultPk.id, is: .required, ofType: .string),
+      .field(modelExplicitDefaultPk.name, is: .optional, ofType: .string),
+      .field(modelExplicitDefaultPk.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(modelExplicitDefaultPk.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+extension ModelExplicitDefaultPk: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension ModelExplicitDefaultPk.Identifier {
+  public static func identifier(id: String) -> Self {
+    .make(fields:[(name: \\"id\\", value: id)])
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with implicit PK 1`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+public struct ModelImplicitDefaultPk: Model {
+  public let id: String
+  public var name: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      name: String? = nil) {
+    self.init(id: id,
+      name: name,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      name: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.name = name
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with implicit PK 2`] = `
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+extension ModelImplicitDefaultPk {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case name
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let modelImplicitDefaultPk = ModelImplicitDefaultPk.keys
+    
+    model.pluralName = \\"ModelImplicitDefaultPks\\"
+    
+    model.attributes(
+      .primaryKey(fields: [modelImplicitDefaultPk.id])
+    )
+    
+    model.fields(
+      .field(modelImplicitDefaultPk.id, is: .required, ofType: .string),
+      .field(modelImplicitDefaultPk.name, is: .optional, ofType: .string),
+      .field(modelImplicitDefaultPk.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(modelImplicitDefaultPk.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+extension ModelImplicitDefaultPk: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Should handle nullability of lists appropriately 1`] = `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -780,7 +780,7 @@ extension ListContainer {
     model.pluralName = \\"ListContainers\\"
     
     model.fields(
-      .field(listContainer.id, is: .required, ofType: .string),
+      .id(),
       .field(listContainer.name, is: .optional, ofType: .string),
       .field(listContainer.list, is: .optional, ofType: .embeddedCollection(of: Int.self)),
       .field(listContainer.requiredList, is: .required, ofType: .embeddedCollection(of: String.self)),
@@ -887,7 +887,7 @@ extension Todo {
     model.pluralName = \\"Todos\\"
     
     model.fields(
-      .field(todo.id, is: .required, ofType: .string),
+      .id(),
       .field(todo.title, is: .required, ofType: .string),
       .hasMany(todo.requiredListOfTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
       .hasMany(todo.listOfRequiredTasks, is: .optional, ofType: task.self, associatedWith: task.keys.todo),
@@ -959,7 +959,7 @@ extension task {
     model.pluralName = \\"tasks\\"
     
     model.fields(
-      .field(task.id, is: .required, ofType: .string),
+      .id(),
       .field(task.title, is: .required, ofType: .string),
       .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
       .field(task.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -79,6 +79,7 @@ extension ModelCompositePk {
     )
     }
 }
+
 extension ModelCompositePk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
   public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
@@ -157,6 +158,7 @@ extension ModelExplicitCustomPk {
     )
     }
 }
+
 extension ModelExplicitCustomPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
   public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
@@ -234,6 +236,7 @@ extension ModelExplicitDefaultPk {
     )
     }
 }
+
 extension ModelExplicitDefaultPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
   public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
@@ -310,6 +313,7 @@ extension ModelImplicitDefaultPk {
     )
     }
 }
+
 extension ModelImplicitDefaultPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -429,6 +433,7 @@ extension ListContainer {
     )
     }
 }
+
 extension ListContainer: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -541,6 +546,7 @@ extension Todo {
     )
     }
 }
+
 extension Todo: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -618,6 +624,7 @@ extension task {
     )
     }
 }
+
 extension task: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -14,7 +14,7 @@ import Foundation
 
 public struct ModelCompositePk: Model {
   public let id: String
-  public var dob: Temporal.DateTime
+  public let dob: Temporal.DateTime
   public var name: String?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
@@ -99,7 +99,7 @@ import Amplify
 import Foundation
 
 public struct ModelExplicitCustomPk: Model {
-  public var userId: String
+  public let userId: String
   public var name: String?
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -779,10 +779,6 @@ extension ListContainer {
     
     model.pluralName = \\"ListContainers\\"
     
-    model.attributes(
-      .primaryKey(fields: [listContainer.id])
-    )
-    
     model.fields(
       .field(listContainer.id, is: .required, ofType: .string),
       .field(listContainer.name, is: .optional, ofType: .string),
@@ -797,11 +793,6 @@ extension ListContainer {
       .field(listContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension ListContainer: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -895,10 +886,6 @@ extension Todo {
     
     model.pluralName = \\"Todos\\"
     
-    model.attributes(
-      .primaryKey(fields: [todo.id])
-    )
-    
     model.fields(
       .field(todo.id, is: .required, ofType: .string),
       .field(todo.title, is: .required, ofType: .string),
@@ -910,11 +897,6 @@ extension Todo {
       .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Todo: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -976,10 +958,6 @@ extension task {
     
     model.pluralName = \\"tasks\\"
     
-    model.attributes(
-      .primaryKey(fields: [task.id])
-    )
-    
     model.fields(
       .field(task.id, is: .required, ofType: .string),
       .field(task.title, is: .required, ofType: .string),
@@ -988,10 +966,5 @@ extension task {
       .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension task: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -7,6 +7,185 @@ import Foundation
 "
 `;
 
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let id: String
+  public let title: String
+  public var comments: List<Comment>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<Comment>? = []) {
+    self.init(id: id,
+      title: title,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<Comment>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post = Post.keys
+    
+    model.pluralName = \\"Posts\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\", \\"title\\"], name: nil),
+      .primaryKey(fields: [post.id, post.title])
+    )
+    
+    model.fields(
+      .field(post.id, is: .required, ofType: .string),
+      .field(post.title, is: .required, ofType: .string),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.postCommentsId),
+      .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post.Identifier {
+  public static func identifier(id: String,
+      title: String) -> Self {
+    .make(fields:[(name: \\"id\\", value: id), (name: \\"title\\", value: title)])
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment: Model {
+  public let id: String
+  public let content: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var postCommentsId: String?
+  public var postCommentsTitle: String?
+  
+  public init(id: String = UUID().uuidString,
+      content: String,
+      postCommentsId: String? = nil,
+      postCommentsTitle: String? = nil) {
+    self.init(id: id,
+      content: content,
+      createdAt: nil,
+      updatedAt: nil,
+      postCommentsId: postCommentsId,
+      postCommentsTitle: postCommentsTitle)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      postCommentsId: String? = nil,
+      postCommentsTitle: String? = nil) {
+      self.id = id
+      self.content = content
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.postCommentsId = postCommentsId
+      self.postCommentsTitle = postCommentsTitle
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case createdAt
+    case updatedAt
+    case postCommentsId
+    case postCommentsTitle
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment = Comment.keys
+    
+    model.pluralName = \\"Comments\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\", \\"content\\"], name: nil),
+      .primaryKey(fields: [comment.id, comment.content])
+    )
+    
+    model.fields(
+      .field(comment.id, is: .required, ofType: .string),
+      .field(comment.content, is: .required, ofType: .string),
+      .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.postCommentsId, is: .optional, ofType: .string),
+      .field(comment.postCommentsTitle, is: .optional, ofType: .string)
+    )
+    }
+}
+
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Comment.Identifier {
+  public static func identifier(id: String,
+      content: String) -> Self {
+    .make(fields:[(name: \\"id\\", value: id), (name: \\"content\\", value: content)])
+  }
+}"
+`;
+
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate model and metadata for a model with a composite PK 1`] = `
 "// swiftlint:disable all
 import Amplify

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -511,30 +511,35 @@ public struct Project: Model {
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
   public var projectTeamTeamId: String?
+  public var projectTeamName: String?
   
   public init(projectId: String,
       name: String,
       team: Team? = nil,
-      projectTeamTeamId: String? = nil) {
+      projectTeamTeamId: String? = nil,
+      projectTeamName: String? = nil) {
     self.init(projectId: projectId,
       name: name,
       team: team,
       createdAt: nil,
       updatedAt: nil,
-      projectTeamTeamId: projectTeamTeamId)
+      projectTeamTeamId: projectTeamTeamId,
+      projectTeamName: projectTeamName)
   }
   internal init(projectId: String,
       name: String,
       team: Team? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil,
-      projectTeamTeamId: String? = nil) {
+      projectTeamTeamId: String? = nil,
+      projectTeamName: String? = nil) {
       self.projectId = projectId
       self.name = name
       self.team = team
       self.createdAt = createdAt
       self.updatedAt = updatedAt
       self.projectTeamTeamId = projectTeamTeamId
+      self.projectTeamName = projectTeamName
   }
 }"
 `;
@@ -553,6 +558,7 @@ extension Project {
     case createdAt
     case updatedAt
     case projectTeamTeamId
+    case projectTeamName
   }
   
   public static let keys = CodingKeys.self
@@ -574,7 +580,8 @@ extension Project {
       .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(project.projectTeamTeamId, is: .optional, ofType: .string)
+      .field(project.projectTeamTeamId, is: .optional, ofType: .string),
+      .field(project.projectTeamName, is: .optional, ofType: .string)
     )
     }
 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -10,8 +10,8 @@ const defaultIosVisitorSetings = {
   generateIndexRules: true,
   handleListNullabilityTransparently: true,
   transformerVersion: 1,
-  respectPrimaryKeyAttributesOnConnectionField: false
-}
+  respectPrimaryKeyAttributesOnConnectionField: false,
+};
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
 };
@@ -31,7 +31,7 @@ const getVisitor = (
       directives,
       target: 'swift',
       scalars: SWIFT_SCALAR_MAP,
-      ...visitorConfig
+      ...visitorConfig,
     },
     { selectedType, generate },
   );
@@ -43,14 +43,9 @@ const getVisitorPipelinedTransformer = (
   schema: string,
   selectedType?: string,
   generate: CodeGenGenerateEnum = CodeGenGenerateEnum.code,
-  settings: any = {}
+  settings: any = {},
 ) => {
-  return getVisitor(
-    schema,
-    selectedType,
-    generate,
-    { ...settings, transformerVersion: 2 }
-  );
+  return getVisitor(schema, selectedType, generate, { ...settings, transformerVersion: 2 });
 };
 
 describe('AppSyncSwiftVisitor', () => {
@@ -124,10 +119,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"SimpleModels\\"
           
-          model.attributes(
-            .primaryKey(fields: [simpleModel.id])
-          )
-          
           model.fields(
             .field(simpleModel.id, is: .required, ofType: .string),
             .field(simpleModel.name, is: .optional, ofType: .string),
@@ -136,11 +127,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(simpleModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension SimpleModel: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -239,10 +225,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"snake_cases\\"
           
-          model.attributes(
-            .primaryKey(fields: [snake_case.id])
-          )
-          
           model.fields(
             .field(snake_case.id, is: .required, ofType: .string),
             .field(snake_case.name, is: .optional, ofType: .string),
@@ -250,11 +232,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(snake_case.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension snake_case: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -386,8 +363,7 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.attributes(
             .index(fields: [\\"author_id\\"], name: \\"byAuthor\\"),
-            .index(fields: [\\"book_id\\"], name: \\"byBook\\"),
-            .primaryKey(fields: [authorBook.id])
+            .index(fields: [\\"book_id\\"], name: \\"byBook\\")
           )
           
           model.fields(
@@ -400,11 +376,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(authorBook.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension authorBook: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -668,10 +639,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Todos\\"
               
-              model.attributes(
-                .primaryKey(fields: [todo.id])
-              )
-              
               model.fields(
                 .field(todo.id, is: .required, ofType: .string),
                 .field(todo.title, is: .required, ofType: .string),
@@ -685,11 +652,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Todo: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -775,10 +737,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"tasks\\"
               
-              model.attributes(
-                .primaryKey(fields: [task.id])
-              )
-              
               model.fields(
                 .field(task.id, is: .required, ofType: .string),
                 .field(task.title, is: .required, ofType: .string),
@@ -790,11 +748,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension task: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -920,10 +873,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -932,11 +881,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
 
@@ -1000,10 +944,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1012,11 +952,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1125,10 +1060,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"ObjectWithNativeTypes\\"
           
-          model.attributes(
-            .primaryKey(fields: [objectWithNativeTypes.id])
-          )
-          
           model.fields(
             .field(objectWithNativeTypes.id, is: .required, ofType: .string),
             .field(objectWithNativeTypes.intArr, is: .optional, ofType: .embeddedCollection(of: Int.self)),
@@ -1141,11 +1072,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(objectWithNativeTypes.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension ObjectWithNativeTypes: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -1256,10 +1182,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Attractions\\"
           
-          model.attributes(
-            .primaryKey(fields: [attraction.id])
-          )
-          
           model.fields(
             .field(attraction.id, is: .required, ofType: .string),
             .field(attraction.name, is: .required, ofType: .string),
@@ -1272,11 +1194,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(attraction.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension Attraction: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
 
@@ -1514,10 +1431,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1526,11 +1439,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1572,10 +1480,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1584,11 +1488,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1631,10 +1530,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1643,11 +1538,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1690,10 +1580,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1702,11 +1588,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1746,10 +1627,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1757,11 +1634,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1801,10 +1673,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1812,11 +1680,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1863,10 +1726,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
-              model.attributes(
-                .primaryKey(fields: [post.id])
-              )
-              
               model.fields(
                 .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
@@ -1876,11 +1735,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Post: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1925,10 +1779,6 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Employees\\"
               
-              model.attributes(
-                .primaryKey(fields: [employee.id])
-              )
-              
               model.fields(
                 .field(employee.id, is: .required, ofType: .string),
                 .field(employee.name, is: .required, ofType: .string),
@@ -1938,11 +1788,6 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(employee.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
-          }
-
-          extension Employee: ModelIdentifiable {
-            public typealias IdentifierFormat = ModelIdentifierFormat.Default
-            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1985,10 +1830,6 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
-            model.attributes(
-              .primaryKey(fields: [post.id])
-            )
-            
             model.fields(
               .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
@@ -1996,11 +1837,6 @@ describe('AppSyncSwiftVisitor', () => {
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
-        }
-
-        extension Post: ModelIdentifiable {
-          public typealias IdentifierFormat = ModelIdentifierFormat.Default
-          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2042,10 +1878,6 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
-            model.attributes(
-              .primaryKey(fields: [post.id])
-            )
-            
             model.fields(
               .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
@@ -2054,11 +1886,6 @@ describe('AppSyncSwiftVisitor', () => {
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
-        }
-
-        extension Post: ModelIdentifiable {
-          public typealias IdentifierFormat = ModelIdentifierFormat.Default
-          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2099,10 +1926,6 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
-            model.attributes(
-              .primaryKey(fields: [post.id])
-            )
-            
             model.fields(
               .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
@@ -2110,11 +1933,6 @@ describe('AppSyncSwiftVisitor', () => {
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
-        }
-
-        extension Post: ModelIdentifiable {
-          public typealias IdentifierFormat = ModelIdentifierFormat.Default
-          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2155,10 +1973,6 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
-            model.attributes(
-              .primaryKey(fields: [post.id])
-            )
-            
             model.fields(
               .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
@@ -2166,11 +1980,6 @@ describe('AppSyncSwiftVisitor', () => {
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
-        }
-
-        extension Post: ModelIdentifiable {
-          public typealias IdentifierFormat = ModelIdentifierFormat.Default
-          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2210,10 +2019,6 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
-            model.attributes(
-              .primaryKey(fields: [post.id])
-            )
-            
             model.fields(
               .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
@@ -2221,11 +2026,6 @@ describe('AppSyncSwiftVisitor', () => {
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
-        }
-
-        extension Post: ModelIdentifiable {
-          public typealias IdentifierFormat = ModelIdentifierFormat.Default
-          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2278,10 +2078,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Posts\\"
           
-          model.attributes(
-            .primaryKey(fields: [post.id])
-          )
-          
           model.fields(
             .field(post.id, is: .required, ofType: .string),
             .field(post.title, is: .required, ofType: .string),
@@ -2290,11 +2086,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension Post: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -2347,10 +2138,6 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Posts\\"
           
-          model.attributes(
-            .primaryKey(fields: [post.id])
-          )
-          
           model.fields(
             .field(post.id, is: .required, ofType: .string),
             .field(post.title, is: .required, ofType: .string),
@@ -2359,11 +2146,6 @@ describe('AppSyncSwiftVisitor', () => {
             .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
-      }
-
-      extension Post: ModelIdentifiable {
-        public typealias IdentifierFormat = ModelIdentifierFormat.Default
-        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -2504,10 +2286,14 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCode).toMatchSnapshot();
 
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2518,9 +2304,13 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2531,9 +2321,13 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2545,9 +2339,13 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2564,10 +2362,18 @@ describe('AppSyncSwiftVisitor', () => {
           project: Project @belongsTo
         }
       `;
-      const generatedCodeProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedMetaProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedCodeTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedMetaTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedCodeProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedCodeTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCodeProject).toMatchSnapshot();
       expect(generatedMetaProject).toMatchSnapshot();
       expect(generatedCodeTeam).toMatchSnapshot();
@@ -2581,16 +2387,24 @@ describe('AppSyncSwiftVisitor', () => {
           title: String!
           comments: [Comment] @hasMany
         }
-        
+
         type Comment @model {
           id: ID! @primaryKey(sortKeyFields: ["content"])
           content: String!
         }
       `;
-      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
-      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
       expect(generatedCodePost).toMatchSnapshot();
       expect(generatedMetaPost).toMatchSnapshot();
       expect(generatedCodeComment).toMatchSnapshot();

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -16,7 +16,7 @@ const getVisitor = (
   emitAuthProvider: boolean = true,
   generateIndexRules: boolean = true,
   handleListNullabilityTransparently: boolean = true,
-  transformerVersion: number = 1
+  transformerVersion: number = 1,
 ) => {
   const ast = parse(schema);
   const builtSchema = buildSchemaWithDirectives(schema);
@@ -30,7 +30,7 @@ const getVisitor = (
       emitAuthProvider,
       generateIndexRules,
       handleListNullabilityTransparently,
-      transformerVersion: transformerVersion
+      transformerVersion: transformerVersion,
     },
     { selectedType, generate },
   );
@@ -45,10 +45,19 @@ const getVisitorPipelinedTransformer = (
   isTimestampFieldsAdded: boolean = true,
   emitAuthProvider: boolean = true,
   generateIndexRules: boolean = true,
-  handleListNullabilityTransparently: boolean = true
+  handleListNullabilityTransparently: boolean = true,
 ) => {
-  return getVisitor(schema, selectedType, generate, isTimestampFieldsAdded, emitAuthProvider, generateIndexRules, handleListNullabilityTransparently, 2);
-}
+  return getVisitor(
+    schema,
+    selectedType,
+    generate,
+    isTimestampFieldsAdded,
+    emitAuthProvider,
+    generateIndexRules,
+    handleListNullabilityTransparently,
+    2,
+  );
+};
 
 describe('AppSyncSwiftVisitor', () => {
   it('Should generate a class for a Model', () => {
@@ -121,14 +130,22 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"SimpleModels\\"
           
+          model.attributes(
+            .primaryKey(fields: [simpleModel.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(simpleModel.id, is: .required, ofType: .string),
             .field(simpleModel.name, is: .optional, ofType: .string),
             .field(simpleModel.bar, is: .optional, ofType: .string),
             .field(simpleModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
             .field(simpleModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension SimpleModel: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -227,13 +244,21 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"snake_cases\\"
           
+          model.attributes(
+            .primaryKey(fields: [snake_case.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(snake_case.id, is: .required, ofType: .string),
             .field(snake_case.name, is: .optional, ofType: .string),
             .field(snake_case.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
             .field(snake_case.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension snake_case: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -365,11 +390,12 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.attributes(
             .index(fields: [\\"author_id\\"], name: \\"byAuthor\\"),
-            .index(fields: [\\"book_id\\"], name: \\"byBook\\")
+            .index(fields: [\\"book_id\\"], name: \\"byBook\\"),
+            .primaryKey(fields: [authorBook.id])
           )
           
           model.fields(
-            .id(),
+            .field(authorBook.id, is: .required, ofType: .string),
             .field(authorBook.author_id, is: .required, ofType: .string),
             .field(authorBook.book_id, is: .required, ofType: .string),
             .field(authorBook.author, is: .optional, ofType: .string),
@@ -378,6 +404,10 @@ describe('AppSyncSwiftVisitor', () => {
             .field(authorBook.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension authorBook: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -641,8 +671,12 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Todos\\"
               
+              model.attributes(
+                .primaryKey(fields: [todo.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(todo.id, is: .required, ofType: .string),
                 .field(todo.title, is: .required, ofType: .string),
                 .field(todo.done, is: .required, ofType: .bool),
                 .field(todo.description, is: .optional, ofType: .string),
@@ -654,6 +688,10 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(todo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Todo: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -739,8 +777,12 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"tasks\\"
               
+              model.attributes(
+                .primaryKey(fields: [task.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(task.id, is: .required, ofType: .string),
                 .field(task.title, is: .required, ofType: .string),
                 .field(task.done, is: .required, ofType: .bool),
                 .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
@@ -750,6 +792,10 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(task.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension task: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -875,14 +921,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
 
@@ -946,14 +1000,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1062,8 +1124,12 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"ObjectWithNativeTypes\\"
           
+          model.attributes(
+            .primaryKey(fields: [objectWithNativeTypes.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(objectWithNativeTypes.id, is: .required, ofType: .string),
             .field(objectWithNativeTypes.intArr, is: .optional, ofType: .embeddedCollection(of: Int.self)),
             .field(objectWithNativeTypes.strArr, is: .optional, ofType: .embeddedCollection(of: String.self)),
             .field(objectWithNativeTypes.floatArr, is: .optional, ofType: .embeddedCollection(of: Double.self)),
@@ -1074,6 +1140,10 @@ describe('AppSyncSwiftVisitor', () => {
             .field(objectWithNativeTypes.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension ObjectWithNativeTypes: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -1184,8 +1254,12 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Attractions\\"
           
+          model.attributes(
+            .primaryKey(fields: [attraction.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(attraction.id, is: .required, ofType: .string),
             .field(attraction.name, is: .required, ofType: .string),
             .field(attraction.location, is: .required, ofType: .embedded(type: Location.self)),
             .field(attraction.nearByLocations, is: .optional, ofType: .embeddedCollection(of: Location.self)),
@@ -1196,6 +1270,10 @@ describe('AppSyncSwiftVisitor', () => {
             .field(attraction.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension Attraction: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
 
@@ -1433,14 +1511,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.owner, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1482,14 +1568,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1532,14 +1626,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1582,14 +1684,22 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1629,13 +1739,21 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1675,13 +1793,21 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1728,8 +1854,12 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Posts\\"
               
+              model.attributes(
+                .primaryKey(fields: [post.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(post.id, is: .required, ofType: .string),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.editors, is: .optional, ofType: .embeddedCollection(of: String.self)),
@@ -1737,6 +1867,10 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Post: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1781,8 +1915,12 @@ describe('AppSyncSwiftVisitor', () => {
               
               model.pluralName = \\"Employees\\"
               
+              model.attributes(
+                .primaryKey(fields: [employee.id])
+              )
+              
               model.fields(
-                .id(),
+                .field(employee.id, is: .required, ofType: .string),
                 .field(employee.name, is: .required, ofType: .string),
                 .field(employee.address, is: .required, ofType: .string),
                 .field(employee.ssn, is: .optional, ofType: .string),
@@ -1790,6 +1928,10 @@ describe('AppSyncSwiftVisitor', () => {
                 .field(employee.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
               )
               }
+          }
+          extension Employee: ModelIdentifiable {
+            public typealias IdentifierFormat = ModelIdentifierFormat.Default
+            public typealias Identifier = DefaultModelIdentifier<Self>
           }"
         `);
       });
@@ -1832,13 +1974,21 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
+            model.attributes(
+              .primaryKey(fields: [post.id])
+            )
+            
             model.fields(
-              .id(),
+              .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
+        }
+        extension Post: ModelIdentifiable {
+          public typealias IdentifierFormat = ModelIdentifierFormat.Default
+          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -1880,14 +2030,22 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
+            model.attributes(
+              .primaryKey(fields: [post.id])
+            )
+            
             model.fields(
-              .id(),
+              .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
               .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self)),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
+        }
+        extension Post: ModelIdentifiable {
+          public typealias IdentifierFormat = ModelIdentifierFormat.Default
+          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -1928,13 +2086,21 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
+            model.attributes(
+              .primaryKey(fields: [post.id])
+            )
+            
             model.fields(
-              .id(),
+              .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
+        }
+        extension Post: ModelIdentifiable {
+          public typealias IdentifierFormat = ModelIdentifierFormat.Default
+          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -1975,13 +2141,21 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
+            model.attributes(
+              .primaryKey(fields: [post.id])
+            )
+            
             model.fields(
-              .id(),
+              .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
+        }
+        extension Post: ModelIdentifiable {
+          public typealias IdentifierFormat = ModelIdentifierFormat.Default
+          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2021,13 +2195,21 @@ describe('AppSyncSwiftVisitor', () => {
             
             model.pluralName = \\"Posts\\"
             
+            model.attributes(
+              .primaryKey(fields: [post.id])
+            )
+            
             model.fields(
-              .id(),
+              .field(post.id, is: .required, ofType: .string),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
             )
             }
+        }
+        extension Post: ModelIdentifiable {
+          public typealias IdentifierFormat = ModelIdentifierFormat.Default
+          public typealias Identifier = DefaultModelIdentifier<Self>
         }"
       `);
     });
@@ -2080,14 +2262,22 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Posts\\"
           
+          model.attributes(
+            .primaryKey(fields: [post.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(post.id, is: .required, ofType: .string),
             .field(post.title, is: .required, ofType: .string),
             .field(post.owner, is: .required, ofType: .string),
             .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
             .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension Post: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -2140,14 +2330,22 @@ describe('AppSyncSwiftVisitor', () => {
           
           model.pluralName = \\"Posts\\"
           
+          model.attributes(
+            .primaryKey(fields: [post.id])
+          )
+          
           model.fields(
-            .id(),
+            .field(post.id, is: .required, ofType: .string),
             .field(post.title, is: .required, ofType: .string),
             .field(post.owner, is: .required, ofType: .string),
             .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
             .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
           )
           }
+      }
+      extension Post: ModelIdentifiable {
+        public typealias IdentifierFormat = ModelIdentifierFormat.Default
+        public typealias Identifier = DefaultModelIdentifier<Self>
       }"
     `);
   });
@@ -2269,7 +2467,7 @@ describe('AppSyncSwiftVisitor', () => {
           content: String
           tags: [Tag] @manyToMany(relationName: "PostTags")
         }
-        
+
         type Tag @model {
           id: ID!
           label: String!
@@ -2278,6 +2476,61 @@ describe('AppSyncSwiftVisitor', () => {
       `;
       const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
+    });
+  });
+
+  describe('Primary Key Tests', () => {
+    it('Should generate model and metadata for a model with implicit PK', () => {
+      const schema = /* GraphQL */ `
+        type ModelImplicitDefaultPk @model {
+          name: String
+        }
+      `;
+      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      expect(generatedCode).toMatchSnapshot();
+
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      expect(generatedMetadata).toMatchSnapshot();
+    });
+
+    it('Should generate model and metadata for a model with explicit PK named id', () => {
+      const schema = /* GraphQL */ `
+        type ModelExplicitDefaultPk @model {
+          id: ID! @primaryKey
+          name: String
+        }
+      `;
+      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      expect(generatedCode).toMatchSnapshot();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      expect(generatedMetadata).toMatchSnapshot();
+    });
+
+    it('Should generate model and metadata for a model with a custom PK', () => {
+      const schema = /* GraphQL */ `
+        type ModelExplicitCustomPk @model {
+          userId: ID! @primaryKey
+          name: String
+        }
+      `;
+      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      expect(generatedCode).toMatchSnapshot();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      expect(generatedMetadata).toMatchSnapshot();
+    });
+
+    it('Should generate model and metadata for a model with a composite PK', () => {
+      const schema = /* GraphQL */ `
+        type ModelCompositePk @model {
+          id: ID! @primaryKey(sortKeyFields: ["dob"])
+          dob: AWSDateTime!
+          name: String
+        }
+      `;
+      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      expect(generatedCode).toMatchSnapshot();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      expect(generatedMetadata).toMatchSnapshot();
     });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -143,6 +143,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension SimpleModel: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -256,6 +257,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension snake_case: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -405,6 +407,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension authorBook: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -689,6 +692,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Todo: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -793,6 +797,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension task: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -934,6 +939,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1013,6 +1019,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1141,6 +1148,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension ObjectWithNativeTypes: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1271,6 +1279,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension Attraction: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1524,6 +1533,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1581,6 +1591,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1639,6 +1650,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1697,6 +1709,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1751,6 +1764,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1805,6 +1819,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1868,6 +1883,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Post: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1929,6 +1945,7 @@ describe('AppSyncSwiftVisitor', () => {
               )
               }
           }
+
           extension Employee: ModelIdentifiable {
             public typealias IdentifierFormat = ModelIdentifierFormat.Default
             public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1986,6 +2003,7 @@ describe('AppSyncSwiftVisitor', () => {
             )
             }
         }
+
         extension Post: ModelIdentifiable {
           public typealias IdentifierFormat = ModelIdentifierFormat.Default
           public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2043,6 +2061,7 @@ describe('AppSyncSwiftVisitor', () => {
             )
             }
         }
+
         extension Post: ModelIdentifiable {
           public typealias IdentifierFormat = ModelIdentifierFormat.Default
           public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2098,6 +2117,7 @@ describe('AppSyncSwiftVisitor', () => {
             )
             }
         }
+
         extension Post: ModelIdentifiable {
           public typealias IdentifierFormat = ModelIdentifierFormat.Default
           public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2153,6 +2173,7 @@ describe('AppSyncSwiftVisitor', () => {
             )
             }
         }
+
         extension Post: ModelIdentifiable {
           public typealias IdentifierFormat = ModelIdentifierFormat.Default
           public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2207,6 +2228,7 @@ describe('AppSyncSwiftVisitor', () => {
             )
             }
         }
+
         extension Post: ModelIdentifiable {
           public typealias IdentifierFormat = ModelIdentifierFormat.Default
           public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2275,6 +2297,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension Post: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>
@@ -2343,6 +2366,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           }
       }
+
       extension Post: ModelIdentifiable {
         public typealias IdentifierFormat = ModelIdentifierFormat.Default
         public typealias Identifier = DefaultModelIdentifier<Self>

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2573,5 +2573,28 @@ describe('AppSyncSwiftVisitor', () => {
       expect(generatedCodeTeam).toMatchSnapshot();
       expect(generatedMetaTeam).toMatchSnapshot();
     });
+
+    it('Should generate foreign key fields in hasMany uni relation for model with CPK', () => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          id: ID! @primaryKey(sortKeyFields: ["title"])
+          title: String!
+          comments: [Comment] @hasMany
+        }
+        
+        type Comment @model {
+          id: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+        }
+      `;
+      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      expect(generatedCodePost).toMatchSnapshot();
+      expect(generatedMetaPost).toMatchSnapshot();
+      expect(generatedCodeComment).toMatchSnapshot();
+      expect(generatedMetaComment).toMatchSnapshot();
+    });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -120,7 +120,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"SimpleModels\\"
           
           model.fields(
-            .field(simpleModel.id, is: .required, ofType: .string),
+            .id(),
             .field(simpleModel.name, is: .optional, ofType: .string),
             .field(simpleModel.bar, is: .optional, ofType: .string),
             .field(simpleModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -226,7 +226,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"snake_cases\\"
           
           model.fields(
-            .field(snake_case.id, is: .required, ofType: .string),
+            .id(),
             .field(snake_case.name, is: .optional, ofType: .string),
             .field(snake_case.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
             .field(snake_case.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -367,7 +367,7 @@ describe('AppSyncSwiftVisitor', () => {
           )
           
           model.fields(
-            .field(authorBook.id, is: .required, ofType: .string),
+            .id(),
             .field(authorBook.author_id, is: .required, ofType: .string),
             .field(authorBook.book_id, is: .required, ofType: .string),
             .field(authorBook.author, is: .optional, ofType: .string),
@@ -640,7 +640,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Todos\\"
               
               model.fields(
-                .field(todo.id, is: .required, ofType: .string),
+                .id(),
                 .field(todo.title, is: .required, ofType: .string),
                 .field(todo.done, is: .required, ofType: .bool),
                 .field(todo.description, is: .optional, ofType: .string),
@@ -738,7 +738,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"tasks\\"
               
               model.fields(
-                .field(task.id, is: .required, ofType: .string),
+                .id(),
                 .field(task.title, is: .required, ofType: .string),
                 .field(task.done, is: .required, ofType: .bool),
                 .belongsTo(task.todo, is: .optional, ofType: Todo.self, targetName: \\"taskTodoId\\"),
@@ -874,7 +874,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -945,7 +945,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .hasMany(post.editors, is: .optional, ofType: PostEditor.self, associatedWith: PostEditor.keys.id),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1061,7 +1061,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"ObjectWithNativeTypes\\"
           
           model.fields(
-            .field(objectWithNativeTypes.id, is: .required, ofType: .string),
+            .id(),
             .field(objectWithNativeTypes.intArr, is: .optional, ofType: .embeddedCollection(of: Int.self)),
             .field(objectWithNativeTypes.strArr, is: .optional, ofType: .embeddedCollection(of: String.self)),
             .field(objectWithNativeTypes.floatArr, is: .optional, ofType: .embeddedCollection(of: Double.self)),
@@ -1183,7 +1183,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"Attractions\\"
           
           model.fields(
-            .field(attraction.id, is: .required, ofType: .string),
+            .id(),
             .field(attraction.name, is: .required, ofType: .string),
             .field(attraction.location, is: .required, ofType: .embedded(type: Location.self)),
             .field(attraction.nearByLocations, is: .optional, ofType: .embeddedCollection(of: Location.self)),
@@ -1432,7 +1432,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.owner, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1481,7 +1481,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1531,7 +1531,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1581,7 +1581,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1628,7 +1628,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1674,7 +1674,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
                 .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1727,7 +1727,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Posts\\"
               
               model.fields(
-                .field(post.id, is: .required, ofType: .string),
+                .id(),
                 .field(post.title, is: .required, ofType: .string),
                 .field(post.author, is: .required, ofType: .string),
                 .field(post.editors, is: .optional, ofType: .embeddedCollection(of: String.self)),
@@ -1780,7 +1780,7 @@ describe('AppSyncSwiftVisitor', () => {
               model.pluralName = \\"Employees\\"
               
               model.fields(
-                .field(employee.id, is: .required, ofType: .string),
+                .id(),
                 .field(employee.name, is: .required, ofType: .string),
                 .field(employee.address, is: .required, ofType: .string),
                 .field(employee.ssn, is: .optional, ofType: .string),
@@ -1831,7 +1831,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.pluralName = \\"Posts\\"
             
             model.fields(
-              .field(post.id, is: .required, ofType: .string),
+              .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1879,7 +1879,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.pluralName = \\"Posts\\"
             
             model.fields(
-              .field(post.id, is: .required, ofType: .string),
+              .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.groups, is: .required, ofType: .embeddedCollection(of: String.self)),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1927,7 +1927,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.pluralName = \\"Posts\\"
             
             model.fields(
-              .field(post.id, is: .required, ofType: .string),
+              .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1974,7 +1974,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.pluralName = \\"Posts\\"
             
             model.fields(
-              .field(post.id, is: .required, ofType: .string),
+              .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2020,7 +2020,7 @@ describe('AppSyncSwiftVisitor', () => {
             model.pluralName = \\"Posts\\"
             
             model.fields(
-              .field(post.id, is: .required, ofType: .string),
+              .id(),
               .field(post.title, is: .required, ofType: .string),
               .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
               .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2079,7 +2079,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"Posts\\"
           
           model.fields(
-            .field(post.id, is: .required, ofType: .string),
+            .id(),
             .field(post.title, is: .required, ofType: .string),
             .field(post.owner, is: .required, ofType: .string),
             .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -2139,7 +2139,7 @@ describe('AppSyncSwiftVisitor', () => {
           model.pluralName = \\"Posts\\"
           
           model.fields(
-            .field(post.id, is: .required, ofType: .string),
+            .id(),
             .field(post.title, is: .required, ofType: .string),
             .field(post.owner, is: .required, ofType: .string),
             .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -10,7 +10,7 @@ const defaultIosVisitorSetings = {
   generateIndexRules: true,
   handleListNullabilityTransparently: true,
   transformerVersion: 1,
-  useFieldNameForPrimaryKeyConnectionField: false
+  respectPrimaryKeyAttributesOnConnectionField: false
 }
 const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
   return buildSchema([schema, directives, scalars].join('\n'));
@@ -2564,10 +2564,10 @@ describe('AppSyncSwiftVisitor', () => {
           project: Project @belongsTo
         }
       `;
-      const generatedCodeProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedMetaProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedCodeTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedMetaTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      const generatedCodeProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedMetaProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedCodeTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedMetaTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
       expect(generatedCodeProject).toMatchSnapshot();
       expect(generatedMetaProject).toMatchSnapshot();
       expect(generatedCodeTeam).toMatchSnapshot();
@@ -2587,10 +2587,10 @@ describe('AppSyncSwiftVisitor', () => {
           content: String!
         }
       `;
-      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
-      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, { useFieldNameForPrimaryKeyConnectionField: true }).generate();
+      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
+      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, { respectPrimaryKeyAttributesOnConnectionField: true }).generate();
       expect(generatedCodePost).toMatchSnapshot();
       expect(generatedMetaPost).toMatchSnapshot();
       expect(generatedCodeComment).toMatchSnapshot();

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2486,10 +2486,10 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
 
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelImplicitDefaultPk', CodeGenGenerateEnum.metadata).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2500,9 +2500,9 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitDefaultPk', CodeGenGenerateEnum.metadata).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2513,9 +2513,9 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelExplicitCustomPk', CodeGenGenerateEnum.metadata).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
 
@@ -2527,9 +2527,9 @@ describe('AppSyncSwiftVisitor', () => {
           name: String
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
-      const generatedMetadata = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.metadata).generate();
+      const generatedMetadata = getVisitorPipelinedTransformer(schema, 'ModelCompositePk', CodeGenGenerateEnum.metadata).generate();
       expect(generatedMetadata).toMatchSnapshot();
     });
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -58,10 +58,6 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
-    model.attributes(
-      .primaryKey(fields: [post.id])
-    )
-    
     model.fields(
       .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
@@ -70,11 +66,6 @@ extension Post {
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Post: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -137,8 +128,7 @@ extension Comment {
     model.pluralName = \\"Comments\\"
     
     model.attributes(
-      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\"),
-      .primaryKey(fields: [comment.id])
+      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
     )
     
     model.fields(
@@ -149,11 +139,6 @@ extension Comment {
       .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Comment: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -221,10 +206,6 @@ extension Project2 {
     
     model.pluralName = \\"Project2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [project2.id])
-    )
-    
     model.fields(
       .field(project2.id, is: .required, ofType: .string),
       .field(project2.name, is: .optional, ofType: .string),
@@ -234,11 +215,6 @@ extension Project2 {
       .field(project2.project2TeamId, is: .optional, ofType: .string)
     )
     }
-}
-
-extension Project2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -300,10 +276,6 @@ extension Team2 {
     
     model.pluralName = \\"Team2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [team2.id])
-    )
-    
     model.fields(
       .field(team2.id, is: .required, ofType: .string),
       .field(team2.name, is: .required, ofType: .string),
@@ -312,11 +284,6 @@ extension Team2 {
       .field(team2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Team2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -378,10 +345,6 @@ extension Blog7V2 {
     
     model.pluralName = \\"Blog7V2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [blog7V2.id])
-    )
-    
     model.fields(
       .field(blog7V2.id, is: .required, ofType: .string),
       .field(blog7V2.name, is: .required, ofType: .string),
@@ -390,11 +353,6 @@ extension Blog7V2 {
       .field(blog7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Blog7V2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -462,10 +420,6 @@ extension Post7V2 {
     
     model.pluralName = \\"Post7V2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [post7V2.id])
-    )
-    
     model.fields(
       .field(post7V2.id, is: .required, ofType: .string),
       .field(post7V2.title, is: .required, ofType: .string),
@@ -475,11 +429,6 @@ extension Post7V2 {
       .field(post7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Post7V2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -541,10 +490,6 @@ extension Comment7V2 {
     
     model.pluralName = \\"Comment7V2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [comment7V2.id])
-    )
-    
     model.fields(
       .field(comment7V2.id, is: .required, ofType: .string),
       .field(comment7V2.content, is: .optional, ofType: .string),
@@ -553,11 +498,6 @@ extension Comment7V2 {
       .field(comment7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Comment7V2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -625,10 +565,6 @@ extension Project {
     
     model.pluralName = \\"Projects\\"
     
-    model.attributes(
-      .primaryKey(fields: [project.id])
-    )
-    
     model.fields(
       .field(project.id, is: .required, ofType: .string),
       .field(project.name, is: .optional, ofType: .string),
@@ -638,11 +574,6 @@ extension Project {
       .field(project.projectTeamId, is: .optional, ofType: .string)
     )
     }
-}
-
-extension Project: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -704,10 +635,6 @@ extension Team {
     
     model.pluralName = \\"Teams\\"
     
-    model.attributes(
-      .primaryKey(fields: [team.id])
-    )
-    
     model.fields(
       .field(team.id, is: .required, ofType: .string),
       .field(team.name, is: .required, ofType: .string),
@@ -716,11 +643,6 @@ extension Team {
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Team: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -788,10 +710,6 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
-    model.attributes(
-      .primaryKey(fields: [post.id])
-    )
-    
     model.fields(
       .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
@@ -801,11 +719,6 @@ extension Post {
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Post: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -867,10 +780,6 @@ extension Tag {
     
     model.pluralName = \\"Tags\\"
     
-    model.attributes(
-      .primaryKey(fields: [tag.id])
-    )
-    
     model.fields(
       .field(tag.id, is: .required, ofType: .string),
       .field(tag.label, is: .required, ofType: .string),
@@ -879,11 +788,6 @@ extension Tag {
       .field(tag.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Tag: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -939,10 +843,6 @@ extension Todo {
     
     model.pluralName = \\"Todos\\"
     
-    model.attributes(
-      .primaryKey(fields: [todo.id])
-    )
-    
     model.fields(
       .field(todo.id, is: .required, ofType: .string),
       .field(todo.content, is: .optional, ofType: .string),
@@ -950,11 +850,6 @@ extension Todo {
       .field(todo.updatedOn, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Todo: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1016,10 +911,6 @@ extension Post2 {
     
     model.pluralName = \\"Post2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [post2.id])
-    )
-    
     model.fields(
       .field(post2.id, is: .required, ofType: .string),
       .field(post2.title, is: .required, ofType: .string),
@@ -1028,11 +919,6 @@ extension Post2 {
       .field(post2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Post2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1095,8 +981,7 @@ extension Comment2 {
     model.pluralName = \\"Comment2s\\"
     
     model.attributes(
-      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\"),
-      .primaryKey(fields: [comment2.id])
+      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
     )
     
     model.fields(
@@ -1107,11 +992,6 @@ extension Comment2 {
       .field(comment2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Comment2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1179,10 +1059,6 @@ extension Project2 {
     
     model.pluralName = \\"Project2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [project2.id])
-    )
-    
     model.fields(
       .field(project2.id, is: .required, ofType: .string),
       .field(project2.name, is: .optional, ofType: .string),
@@ -1192,11 +1068,6 @@ extension Project2 {
       .field(project2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Project2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1252,10 +1123,6 @@ extension Team2 {
     
     model.pluralName = \\"Team2s\\"
     
-    model.attributes(
-      .primaryKey(fields: [team2.id])
-    )
-    
     model.fields(
       .field(team2.id, is: .required, ofType: .string),
       .field(team2.name, is: .required, ofType: .string),
@@ -1263,11 +1130,6 @@ extension Team2 {
       .field(team2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Team2: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1329,10 +1191,6 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
-    model.attributes(
-      .primaryKey(fields: [post.id])
-    )
-    
     model.fields(
       .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
@@ -1341,11 +1199,6 @@ extension Post {
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Post: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1407,10 +1260,6 @@ extension Comment {
     
     model.pluralName = \\"Comments\\"
     
-    model.attributes(
-      .primaryKey(fields: [comment.id])
-    )
-    
     model.fields(
       .field(comment.id, is: .required, ofType: .string),
       .field(comment.content, is: .required, ofType: .string),
@@ -1419,11 +1268,6 @@ extension Comment {
       .field(comment.postCommentsId, is: .optional, ofType: .string)
     )
     }
-}
-
-extension Comment: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1491,10 +1335,6 @@ extension Project {
     
     model.pluralName = \\"Projects\\"
     
-    model.attributes(
-      .primaryKey(fields: [project.id])
-    )
-    
     model.fields(
       .field(project.id, is: .required, ofType: .string),
       .field(project.name, is: .optional, ofType: .string),
@@ -1504,11 +1344,6 @@ extension Project {
       .field(project.projectTeamId, is: .optional, ofType: .string)
     )
     }
-}
-
-extension Project: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1564,10 +1399,6 @@ extension Team {
     
     model.pluralName = \\"Teams\\"
     
-    model.attributes(
-      .primaryKey(fields: [team.id])
-    )
-    
     model.fields(
       .field(team.id, is: .required, ofType: .string),
       .field(team.name, is: .required, ofType: .string),
@@ -1575,11 +1406,6 @@ extension Team {
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Team: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1648,8 +1474,7 @@ extension Customer {
     model.pluralName = \\"Customers\\"
     
     model.attributes(
-      .index(fields: [\\"accountRepresentativeID\\"], name: \\"byRepresentative\\"),
-      .primaryKey(fields: [customer.id])
+      .index(fields: [\\"accountRepresentativeID\\"], name: \\"byRepresentative\\")
     )
     
     model.fields(
@@ -1661,10 +1486,5 @@ extension Customer {
       .field(customer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
-}
-
-extension Customer: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -59,7 +59,7 @@ extension Post {
     model.pluralName = \\"Posts\\"
     
     model.fields(
-      .field(post.id, is: .required, ofType: .string),
+      .id(),
       .field(post.title, is: .required, ofType: .string),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post),
       .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -132,7 +132,7 @@ extension Comment {
     )
     
     model.fields(
-      .field(comment.id, is: .required, ofType: .string),
+      .id(),
       .field(comment.content, is: .required, ofType: .string),
       .belongsTo(comment.post, is: .optional, ofType: Post.self, targetName: \\"postID\\"),
       .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -207,7 +207,7 @@ extension Project2 {
     model.pluralName = \\"Project2s\\"
     
     model.fields(
-      .field(project2.id, is: .required, ofType: .string),
+      .id(),
       .field(project2.name, is: .optional, ofType: .string),
       .hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.project, targetName: \\"project2TeamId\\"),
       .field(project2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -277,7 +277,7 @@ extension Team2 {
     model.pluralName = \\"Team2s\\"
     
     model.fields(
-      .field(team2.id, is: .required, ofType: .string),
+      .id(),
       .field(team2.name, is: .required, ofType: .string),
       .belongsTo(team2.project, is: .optional, ofType: Project2.self, targetName: \\"projectID\\"),
       .field(team2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -346,7 +346,7 @@ extension Blog7V2 {
     model.pluralName = \\"Blog7V2s\\"
     
     model.fields(
-      .field(blog7V2.id, is: .required, ofType: .string),
+      .id(),
       .field(blog7V2.name, is: .required, ofType: .string),
       .hasMany(blog7V2.posts, is: .optional, ofType: Post7V2.self, associatedWith: Post7V2.keys.blog),
       .field(blog7V2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -421,7 +421,7 @@ extension Post7V2 {
     model.pluralName = \\"Post7V2s\\"
     
     model.fields(
-      .field(post7V2.id, is: .required, ofType: .string),
+      .id(),
       .field(post7V2.title, is: .required, ofType: .string),
       .belongsTo(post7V2.blog, is: .optional, ofType: Blog7V2.self, targetName: \\"blog7V2PostsId\\"),
       .hasMany(post7V2.comments, is: .optional, ofType: Comment7V2.self, associatedWith: Comment7V2.keys.post),
@@ -491,7 +491,7 @@ extension Comment7V2 {
     model.pluralName = \\"Comment7V2s\\"
     
     model.fields(
-      .field(comment7V2.id, is: .required, ofType: .string),
+      .id(),
       .field(comment7V2.content, is: .optional, ofType: .string),
       .belongsTo(comment7V2.post, is: .optional, ofType: Post7V2.self, targetName: \\"post7V2CommentsId\\"),
       .field(comment7V2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -566,7 +566,7 @@ extension Project {
     model.pluralName = \\"Projects\\"
     
     model.fields(
-      .field(project.id, is: .required, ofType: .string),
+      .id(),
       .field(project.name, is: .optional, ofType: .string),
       .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.project, targetName: \\"projectTeamId\\"),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -636,7 +636,7 @@ extension Team {
     model.pluralName = \\"Teams\\"
     
     model.fields(
-      .field(team.id, is: .required, ofType: .string),
+      .id(),
       .field(team.name, is: .required, ofType: .string),
       .belongsTo(team.project, is: .optional, ofType: Project.self, targetName: \\"teamProjectId\\"),
       .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -711,7 +711,7 @@ extension Post {
     model.pluralName = \\"Posts\\"
     
     model.fields(
-      .field(post.id, is: .required, ofType: .string),
+      .id(),
       .field(post.title, is: .required, ofType: .string),
       .field(post.content, is: .optional, ofType: .string),
       .hasMany(post.tags, is: .optional, ofType: PostTags.self, associatedWith: PostTags.keys.post),
@@ -781,7 +781,7 @@ extension Tag {
     model.pluralName = \\"Tags\\"
     
     model.fields(
-      .field(tag.id, is: .required, ofType: .string),
+      .id(),
       .field(tag.label, is: .required, ofType: .string),
       .hasMany(tag.posts, is: .optional, ofType: PostTags.self, associatedWith: PostTags.keys.tag),
       .field(tag.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -844,7 +844,7 @@ extension Todo {
     model.pluralName = \\"Todos\\"
     
     model.fields(
-      .field(todo.id, is: .required, ofType: .string),
+      .id(),
       .field(todo.content, is: .optional, ofType: .string),
       .field(todo.createdOn, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todo.updatedOn, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -912,7 +912,7 @@ extension Post2 {
     model.pluralName = \\"Post2s\\"
     
     model.fields(
-      .field(post2.id, is: .required, ofType: .string),
+      .id(),
       .field(post2.title, is: .required, ofType: .string),
       .hasMany(post2.comments, is: .optional, ofType: Comment2.self, associatedWith: Comment2.keys.postID),
       .field(post2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -985,7 +985,7 @@ extension Comment2 {
     )
     
     model.fields(
-      .field(comment2.id, is: .required, ofType: .string),
+      .id(),
       .field(comment2.postID, is: .required, ofType: .string),
       .field(comment2.content, is: .required, ofType: .string),
       .field(comment2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1060,7 +1060,7 @@ extension Project2 {
     model.pluralName = \\"Project2s\\"
     
     model.fields(
-      .field(project2.id, is: .required, ofType: .string),
+      .id(),
       .field(project2.name, is: .optional, ofType: .string),
       .field(project2.teamID, is: .optional, ofType: .string),
       .hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.id, targetName: \\"teamID\\"),
@@ -1124,7 +1124,7 @@ extension Team2 {
     model.pluralName = \\"Team2s\\"
     
     model.fields(
-      .field(team2.id, is: .required, ofType: .string),
+      .id(),
       .field(team2.name, is: .required, ofType: .string),
       .field(team2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1192,7 +1192,7 @@ extension Post {
     model.pluralName = \\"Posts\\"
     
     model.fields(
-      .field(post.id, is: .required, ofType: .string),
+      .id(),
       .field(post.title, is: .required, ofType: .string),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.postCommentsId),
       .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1261,7 +1261,7 @@ extension Comment {
     model.pluralName = \\"Comments\\"
     
     model.fields(
-      .field(comment.id, is: .required, ofType: .string),
+      .id(),
       .field(comment.content, is: .required, ofType: .string),
       .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1336,7 +1336,7 @@ extension Project {
     model.pluralName = \\"Projects\\"
     
     model.fields(
-      .field(project.id, is: .required, ofType: .string),
+      .id(),
       .field(project.name, is: .optional, ofType: .string),
       .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.id, targetName: \\"projectTeamId\\"),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1400,7 +1400,7 @@ extension Team {
     model.pluralName = \\"Teams\\"
     
     model.fields(
-      .field(team.id, is: .required, ofType: .string),
+      .id(),
       .field(team.name, is: .required, ofType: .string),
       .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1478,7 +1478,7 @@ extension Customer {
     )
     
     model.fields(
-      .field(customer.id, is: .required, ofType: .string),
+      .id(),
       .field(customer.name, is: .required, ofType: .string),
       .field(customer.phoneNumber, is: .optional, ofType: .string),
       .field(customer.accountRepresentativeID, is: .required, ofType: .string),

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -71,6 +71,7 @@ extension Post {
     )
     }
 }
+
 extension Post: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -149,6 +150,7 @@ extension Comment {
     )
     }
 }
+
 extension Comment: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -233,6 +235,7 @@ extension Project2 {
     )
     }
 }
+
 extension Project2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -310,6 +313,7 @@ extension Team2 {
     )
     }
 }
+
 extension Team2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -387,6 +391,7 @@ extension Blog7V2 {
     )
     }
 }
+
 extension Blog7V2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -471,6 +476,7 @@ extension Post7V2 {
     )
     }
 }
+
 extension Post7V2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -548,6 +554,7 @@ extension Comment7V2 {
     )
     }
 }
+
 extension Comment7V2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -632,6 +639,7 @@ extension Project {
     )
     }
 }
+
 extension Project: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -709,6 +717,7 @@ extension Team {
     )
     }
 }
+
 extension Team: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -793,6 +802,7 @@ extension Post {
     )
     }
 }
+
 extension Post: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -870,6 +880,7 @@ extension Tag {
     )
     }
 }
+
 extension Tag: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -940,6 +951,7 @@ extension Todo {
     )
     }
 }
+
 extension Todo: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1017,6 +1029,7 @@ extension Post2 {
     )
     }
 }
+
 extension Post2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1095,6 +1108,7 @@ extension Comment2 {
     )
     }
 }
+
 extension Comment2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1179,6 +1193,7 @@ extension Project2 {
     )
     }
 }
+
 extension Project2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1249,6 +1264,7 @@ extension Team2 {
     )
     }
 }
+
 extension Team2: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1326,6 +1342,7 @@ extension Post {
     )
     }
 }
+
 extension Post: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1403,6 +1420,7 @@ extension Comment {
     )
     }
 }
+
 extension Comment: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1487,6 +1505,7 @@ extension Project {
     )
     }
 }
+
 extension Project: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1557,6 +1576,7 @@ extension Team {
     )
     }
 }
+
 extension Team: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>
@@ -1642,6 +1662,7 @@ extension Customer {
     )
     }
 }
+
 extension Customer: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
   public typealias Identifier = DefaultModelIdentifier<Self>

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -58,14 +58,22 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
+    model.attributes(
+      .primaryKey(fields: [post.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.post),
       .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -128,17 +136,22 @@ extension Comment {
     model.pluralName = \\"Comments\\"
     
     model.attributes(
-      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\"),
+      .primaryKey(fields: [comment.id])
     )
     
     model.fields(
-      .id(),
+      .field(comment.id, is: .required, ofType: .string),
       .field(comment.content, is: .required, ofType: .string),
       .belongsTo(comment.post, is: .optional, ofType: Post.self, targetName: \\"postID\\"),
       .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -206,8 +219,12 @@ extension Project2 {
     
     model.pluralName = \\"Project2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [project2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(project2.id, is: .required, ofType: .string),
       .field(project2.name, is: .optional, ofType: .string),
       .hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.project, targetName: \\"project2TeamId\\"),
       .field(project2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -215,6 +232,10 @@ extension Project2 {
       .field(project2.project2TeamId, is: .optional, ofType: .string)
     )
     }
+}
+extension Project2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -276,14 +297,22 @@ extension Team2 {
     
     model.pluralName = \\"Team2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [team2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(team2.id, is: .required, ofType: .string),
       .field(team2.name, is: .required, ofType: .string),
       .belongsTo(team2.project, is: .optional, ofType: Project2.self, targetName: \\"projectID\\"),
       .field(team2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Team2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -345,14 +374,22 @@ extension Blog7V2 {
     
     model.pluralName = \\"Blog7V2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [blog7V2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(blog7V2.id, is: .required, ofType: .string),
       .field(blog7V2.name, is: .required, ofType: .string),
       .hasMany(blog7V2.posts, is: .optional, ofType: Post7V2.self, associatedWith: Post7V2.keys.blog),
       .field(blog7V2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(blog7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Blog7V2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -420,8 +457,12 @@ extension Post7V2 {
     
     model.pluralName = \\"Post7V2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [post7V2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(post7V2.id, is: .required, ofType: .string),
       .field(post7V2.title, is: .required, ofType: .string),
       .belongsTo(post7V2.blog, is: .optional, ofType: Blog7V2.self, targetName: \\"blog7V2PostsId\\"),
       .hasMany(post7V2.comments, is: .optional, ofType: Comment7V2.self, associatedWith: Comment7V2.keys.post),
@@ -429,6 +470,10 @@ extension Post7V2 {
       .field(post7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Post7V2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -490,14 +535,22 @@ extension Comment7V2 {
     
     model.pluralName = \\"Comment7V2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [comment7V2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(comment7V2.id, is: .required, ofType: .string),
       .field(comment7V2.content, is: .optional, ofType: .string),
       .belongsTo(comment7V2.post, is: .optional, ofType: Post7V2.self, targetName: \\"post7V2CommentsId\\"),
       .field(comment7V2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment7V2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Comment7V2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -565,8 +618,12 @@ extension Project {
     
     model.pluralName = \\"Projects\\"
     
+    model.attributes(
+      .primaryKey(fields: [project.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(project.id, is: .required, ofType: .string),
       .field(project.name, is: .optional, ofType: .string),
       .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.project, targetName: \\"projectTeamId\\"),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -574,6 +631,10 @@ extension Project {
       .field(project.projectTeamId, is: .optional, ofType: .string)
     )
     }
+}
+extension Project: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -635,14 +696,22 @@ extension Team {
     
     model.pluralName = \\"Teams\\"
     
+    model.attributes(
+      .primaryKey(fields: [team.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(team.id, is: .required, ofType: .string),
       .field(team.name, is: .required, ofType: .string),
       .belongsTo(team.project, is: .optional, ofType: Project.self, targetName: \\"teamProjectId\\"),
       .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Team: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -710,8 +779,12 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
+    model.attributes(
+      .primaryKey(fields: [post.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
       .field(post.content, is: .optional, ofType: .string),
       .hasMany(post.tags, is: .optional, ofType: PostTags.self, associatedWith: PostTags.keys.post),
@@ -719,6 +792,10 @@ extension Post {
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -780,14 +857,22 @@ extension Tag {
     
     model.pluralName = \\"Tags\\"
     
+    model.attributes(
+      .primaryKey(fields: [tag.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(tag.id, is: .required, ofType: .string),
       .field(tag.label, is: .required, ofType: .string),
       .hasMany(tag.posts, is: .optional, ofType: PostTags.self, associatedWith: PostTags.keys.tag),
       .field(tag.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(tag.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Tag: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -843,13 +928,21 @@ extension Todo {
     
     model.pluralName = \\"Todos\\"
     
+    model.attributes(
+      .primaryKey(fields: [todo.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todo.id, is: .required, ofType: .string),
       .field(todo.content, is: .optional, ofType: .string),
       .field(todo.createdOn, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todo.updatedOn, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Todo: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -911,14 +1004,22 @@ extension Post2 {
     
     model.pluralName = \\"Post2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [post2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(post2.id, is: .required, ofType: .string),
       .field(post2.title, is: .required, ofType: .string),
       .hasMany(post2.comments, is: .optional, ofType: Comment2.self, associatedWith: Comment2.keys.postID),
       .field(post2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Post2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -981,17 +1082,22 @@ extension Comment2 {
     model.pluralName = \\"Comment2s\\"
     
     model.attributes(
-      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\")
+      .index(fields: [\\"postID\\", \\"content\\"], name: \\"byPost\\"),
+      .primaryKey(fields: [comment2.id])
     )
     
     model.fields(
-      .id(),
+      .field(comment2.id, is: .required, ofType: .string),
       .field(comment2.postID, is: .required, ofType: .string),
       .field(comment2.content, is: .required, ofType: .string),
       .field(comment2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Comment2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1059,8 +1165,12 @@ extension Project2 {
     
     model.pluralName = \\"Project2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [project2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(project2.id, is: .required, ofType: .string),
       .field(project2.name, is: .optional, ofType: .string),
       .field(project2.teamID, is: .optional, ofType: .string),
       .hasOne(project2.team, is: .optional, ofType: Team2.self, associatedWith: Team2.keys.id, targetName: \\"teamID\\"),
@@ -1068,6 +1178,10 @@ extension Project2 {
       .field(project2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Project2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1123,13 +1237,21 @@ extension Team2 {
     
     model.pluralName = \\"Team2s\\"
     
+    model.attributes(
+      .primaryKey(fields: [team2.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(team2.id, is: .required, ofType: .string),
       .field(team2.name, is: .required, ofType: .string),
       .field(team2.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team2.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Team2: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1191,14 +1313,22 @@ extension Post {
     
     model.pluralName = \\"Posts\\"
     
+    model.attributes(
+      .primaryKey(fields: [post.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
       .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.postCommentsId),
       .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1260,14 +1390,22 @@ extension Comment {
     
     model.pluralName = \\"Comments\\"
     
+    model.attributes(
+      .primaryKey(fields: [comment.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(comment.id, is: .required, ofType: .string),
       .field(comment.content, is: .required, ofType: .string),
       .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(comment.postCommentsId, is: .optional, ofType: .string)
     )
     }
+}
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1335,8 +1473,12 @@ extension Project {
     
     model.pluralName = \\"Projects\\"
     
+    model.attributes(
+      .primaryKey(fields: [project.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(project.id, is: .required, ofType: .string),
       .field(project.name, is: .optional, ofType: .string),
       .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.id, targetName: \\"projectTeamId\\"),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1344,6 +1486,10 @@ extension Project {
       .field(project.projectTeamId, is: .optional, ofType: .string)
     )
     }
+}
+extension Project: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1399,13 +1545,21 @@ extension Team {
     
     model.pluralName = \\"Teams\\"
     
+    model.attributes(
+      .primaryKey(fields: [team.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(team.id, is: .required, ofType: .string),
       .field(team.name, is: .required, ofType: .string),
       .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Team: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -1474,11 +1628,12 @@ extension Customer {
     model.pluralName = \\"Customers\\"
     
     model.attributes(
-      .index(fields: [\\"accountRepresentativeID\\"], name: \\"byRepresentative\\")
+      .index(fields: [\\"accountRepresentativeID\\"], name: \\"byRepresentative\\"),
+      .primaryKey(fields: [customer.id])
     )
     
     model.fields(
-      .id(),
+      .field(customer.id, is: .required, ofType: .string),
       .field(customer.name, is: .required, ofType: .string),
       .field(customer.phoneNumber, is: .optional, ofType: .string),
       .field(customer.accountRepresentativeID, is: .required, ofType: .string),
@@ -1486,5 +1641,9 @@ extension Customer {
       .field(customer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+extension Customer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias Identifier = DefaultModelIdentifier<Self>
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
+++ b/packages/appsync-modelgen-plugin/src/languages/swift-declaration-block.ts
@@ -121,6 +121,7 @@ export type VariableFlags = {
   listType?: ListType;
   variable?: boolean;
   isEnum?: boolean;
+  isTypeAlias?: boolean;
 };
 export type StructFlags = VariableFlags & { optional?: boolean; static?: boolean; isListNullable?: boolean, handleListNullabilityTransparently?: boolean };
 export type PropertyFlags = StructFlags;
@@ -364,7 +365,7 @@ export class SwiftDeclarationBlock {
     let resultArr: string[] = [
       prop.access === 'DEFAULT' ? '' : prop.access,
       prop.flags.static ? 'static' : '',
-      prop.flags.variable ? 'var' : 'let',
+      prop.flags.isTypeAlias ? 'typealias' : prop.flags.variable ? 'var' : 'let',
       `${escapeKeywords(prop.name)}${propertyType}`,
     ];
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -244,7 +244,7 @@ export class AppSyncSwiftVisitor<
           this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
 
         result.push(schemaDeclarations.string);
-
+        result.push('');
         result.push(this.generatePrimaryKeyExtensions(model));
       });
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -247,8 +247,10 @@ export class AppSyncSwiftVisitor<
           this.generateModelSchema(this.getModelName(model), model, schemaDeclarations);
 
         result.push(schemaDeclarations.string);
-        result.push('');
-        result.push(this.generatePrimaryKeyExtensions(model));
+        if (this.isCustomPKEnabled()) {
+          result.push('');
+          result.push(this.generatePrimaryKeyExtensions(model));  
+        }
       });
 
     Object.values(this.getSelectedNonModels()).forEach(model => {
@@ -491,7 +493,7 @@ export class AppSyncSwiftVisitor<
   }
 
   protected generatePrimaryKeyRules(model: CodeGenModel): string {
-    if (this.selectedTypeIsNonModel()) {
+    if (!this.isCustomPKEnabled() || this.selectedTypeIsNonModel()) {
       return '';
     }
     const primaryKeyField = model.fields.find(f => f.primaryKeyInfo)!;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -83,9 +83,12 @@ export class AppSyncSwiftVisitor<
         .withName(this.getModelName(obj))
         .access('public')
         .withProtocols(['Model']);
-      const primaryKeyField = this.getModelPrimaryKeyField(obj);
-      const { sortKeyFields } = primaryKeyField.primaryKeyInfo!;
-      const primaryKeyComponentFieldsName = [primaryKeyField, ...sortKeyFields].map(field => field.name);
+      let primaryKeyComponentFieldsName: string[] = ['id'];
+      if (this.config.respectPrimaryKeyAttributesOnConnectionField) {
+        const primaryKeyField = this.getModelPrimaryKeyField(obj);
+        const { sortKeyFields } = primaryKeyField.primaryKeyInfo!;
+        primaryKeyComponentFieldsName = [primaryKeyField, ...sortKeyFields].map(field => field.name);
+      }
       Object.entries(obj.fields).forEach(([fieldName, field]) => {
         const fieldType = this.getNativeType(field);
         const isVariable = !primaryKeyComponentFieldsName.includes(field.name);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -380,6 +380,9 @@ export class AppSyncSwiftVisitor<
   }
 
   private generateFieldSchema(field: CodeGenField, modelKeysName: string): string {
+    if (!this.isCustomPKEnabled() && field.type === 'ID' && field.name === 'id') {
+      return `.id()`;
+    }
     let ofType;
     let isReadOnly: string = '';
     const isEnumType = this.isEnumType(field);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -399,12 +399,18 @@ export class AppSyncSwiftVisitor<
           )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
         }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
+          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}])`
+          : `targetName: "${connectionInfo.targetName}"`;
         return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, targetName: "${connectionInfo.targetName}")`;
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
-        return `.belongsTo(${name}, is: ${isRequired}, ofType: ${typeName}, targetName: "${connectionInfo.targetName}")`;
+        const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
+          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}])`
+          : `targetName: "${connectionInfo.targetName}"`;
+        return `.belongsTo(${name}, is: ${isRequired}, ofType: ${typeName}, ${targetNameAttrStr})`;
       }
     }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -249,7 +249,7 @@ export class AppSyncSwiftVisitor<
         result.push(schemaDeclarations.string);
         if (this.isCustomPKEnabled()) {
           result.push('');
-          result.push(this.generatePrimaryKeyExtensions(model));  
+          result.push(this.generatePrimaryKeyExtensions(model));
         }
       });
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -83,9 +83,12 @@ export class AppSyncSwiftVisitor<
         .withName(this.getModelName(obj))
         .access('public')
         .withProtocols(['Model']);
+      const primaryKeyField = this.getModelPrimaryKeyField(obj);
+      const { sortKeyFields } = primaryKeyField.primaryKeyInfo!;
+      const primaryKeyComponentFieldsName = [primaryKeyField, ...sortKeyFields].map(field => field.name);
       Object.entries(obj.fields).forEach(([fieldName, field]) => {
         const fieldType = this.getNativeType(field);
-        const isVariable = field.name !== 'id';
+        const isVariable = !primaryKeyComponentFieldsName.includes(field.name);
         const listType: ListType = field.connectionInfo ? ListType.LIST : ListType.ARRAY;
         structBlock.addProperty(this.getFieldName(field), fieldType, undefined, 'public', {
           optional: !this.isFieldRequired(field),

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -399,7 +399,7 @@ export class AppSyncSwiftVisitor<
           )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
         }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
-        const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
+        const targetNameAttrStr = this.isCustomPKEnabled()
           ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
           : `targetName: "${connectionInfo.targetName}"`;
         return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
@@ -407,7 +407,7 @@ export class AppSyncSwiftVisitor<
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
-        const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
+        const targetNameAttrStr = this.isCustomPKEnabled()
           ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
           : `targetName: "${connectionInfo.targetName}"`;
         return `.belongsTo(${name}, is: ${isRequired}, ofType: ${typeName}, ${targetNameAttrStr})`;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -400,7 +400,7 @@ export class AppSyncSwiftVisitor<
         }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
         const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
-          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}])`
+          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
           : `targetName: "${connectionInfo.targetName}"`;
         return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
@@ -408,7 +408,7 @@ export class AppSyncSwiftVisitor<
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         const targetNameAttrStr = this.config.useFieldNameForPrimaryKeyConnectionField
-          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}])`
+          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
           : `targetName: "${connectionInfo.targetName}"`;
         return `.belongsTo(${name}, is: ${isRequired}, ofType: ${typeName}, ${targetNameAttrStr})`;
       }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -523,6 +523,7 @@ export class AppSyncModelVisitor<
       return acc;
     }, [] as CodeGenField[]);
   }
+
   /**
    * Check out if primary key field exists in the model and generate primary key info
    * @param model type defined with model directives
@@ -612,6 +613,7 @@ export class AppSyncModelVisitor<
     }
     return primaryKeyField;
   }
+
   protected ensureIdField(model: CodeGenModel) {
     const idField = model.fields.find(field => field.name === DEFAULT_HASH_KEY_FIELD);
     if (idField) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -523,7 +523,6 @@ export class AppSyncModelVisitor<
       return acc;
     }, [] as CodeGenField[]);
   }
-
   /**
    * Check out if primary key field exists in the model and generate primary key info
    * @param model type defined with model directives
@@ -613,7 +612,6 @@ export class AppSyncModelVisitor<
     }
     return primaryKeyField;
   }
-
   protected ensureIdField(model: CodeGenModel) {
     const idField = model.fields.find(field => field.name === DEFAULT_HASH_KEY_FIELD);
     if (idField) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Model schema:
- Added two extension `Identifiable` and `Identifier`
- Added `.primaryKey` attribute
- Removed `.id()`
- Replaced `targetName: string` with `targetNames:[string]` when feature flag `useFieldNameForPrimaryKeyConnectionField` is true

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Refer snapshots from #420
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.