### PR TITLE
fix(appsync-dart-visitor): generate correct model id filed name

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -157,7 +157,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
@@ -304,7 +304,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
     fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
@@ -497,7 +497,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
@@ -644,7 +644,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
     fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
@@ -1555,7 +1555,7 @@ class Person extends Model {
             mailingAddresses?.map((Address e) => e?.toJson())?.toList()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"person.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
   static final QueryField MAILINGADDRESSES =
@@ -1739,7 +1739,7 @@ class Person extends Model {
     'id': id, 'name': _name, 'phone': _phone?.toJson(), 'mailingAddresses': _mailingAddresses?.map((Address? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"person.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
   static final QueryField MAILINGADDRESSES = QueryField(fieldName: \\"mailingAddresses\\");
@@ -1966,7 +1966,7 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'status': enumToString(status)};
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -2239,7 +2239,7 @@ class TemporalTimeModel extends Model {
         'intList': intList
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"temporalTimeModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField DATE = QueryField(fieldName: \\"date\\");
   static final QueryField TIME = QueryField(fieldName: \\"time\\");
   static final QueryField DATETIME = QueryField(fieldName: \\"dateTime\\");
@@ -2519,7 +2519,7 @@ class TestEnumModel extends Model {
             nullableEnumNullableList?.map((e) => enumToString(e)).toList()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"testEnumModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField ENUMVAL = QueryField(fieldName: \\"enumVal\\");
   static final QueryField NULLABLEENUMVAL =
       QueryField(fieldName: \\"nullableEnumVal\\");
@@ -2767,7 +2767,7 @@ class TestModel extends Model {
         'nullableFloatNullableList': nullableFloatNullableList
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL =
       QueryField(fieldName: \\"floatNullableVal\\");
@@ -2951,7 +2951,7 @@ class Post extends Model {
         'tags': tags?.map((PostTags e) => e?.toJson())?.toList()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField TAGS = QueryField(
@@ -3067,7 +3067,7 @@ class Tag extends Model {
         'posts': posts?.map((PostTags e) => e?.toJson())?.toList()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"tag.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
       fieldName: \\"posts\\",
@@ -3172,7 +3172,7 @@ class PostTags extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'tag': tag?.toJson()};
 
-  static final QueryField ID = QueryField(fieldName: \\"postTags.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -3342,7 +3342,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField TAGS = QueryField(
@@ -3475,7 +3475,7 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"tag.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
     fieldName: \\"posts\\",
@@ -3610,7 +3610,7 @@ class PostTags extends Model {
     'id': id, 'post': _post?.toJson(), 'tag': _tag?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"postTags.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
     fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
@@ -3738,7 +3738,7 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -3860,7 +3860,7 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -3994,7 +3994,7 @@ class TodoWithAuth extends Model {
         'updatedAt': updatedAt?.format()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"todoWithAuth.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -4174,7 +4174,7 @@ class TodoWithAuth extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"todoWithAuth.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TodoWithAuth\\";
@@ -4332,7 +4332,7 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -4467,7 +4467,7 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"customClaim.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -4604,7 +4604,7 @@ class dynamicGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"dynamicGroups.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -4739,7 +4739,7 @@ class simpleOwnerAuth extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleOwnerAuth.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -4874,7 +4874,7 @@ class allowRead extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"allowRead.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -5008,7 +5008,7 @@ class privateType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"privateType.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -5139,7 +5139,7 @@ class publicType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"publicType.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -5270,7 +5270,7 @@ class staticGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryField ID = QueryField(fieldName: \\"staticGroups.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
   static var schema =
@@ -5410,7 +5410,7 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'author': author};
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
   static var schema =
@@ -5548,7 +5548,7 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'owner': owner};
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField OWNER = QueryField(fieldName: \\"owner\\");
   static var schema =
@@ -5698,7 +5698,7 @@ class Todo extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'tasks': tasks?.map((Task e) => e?.toJson())?.toList()};
 
-  static final QueryField ID = QueryField(fieldName: \\"todo.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TASKS = QueryField(
       fieldName: \\"tasks\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -5813,7 +5813,7 @@ class Task extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'todo': todo?.toJson()};
 
-  static final QueryField ID = QueryField(fieldName: \\"task.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TODO = QueryField(
       fieldName: \\"todo\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -5955,7 +5955,7 @@ class Blog extends Model {
         'test': test
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"blog.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
       fieldName: \\"posts\\",
@@ -6096,7 +6096,7 @@ class Comment extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'content': content};
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
       fieldType: ModelFieldType(ModelFieldTypeEnum.model,
@@ -6247,7 +6247,7 @@ class Post extends Model {
         'comments': comments?.map((Comment e) => e?.toJson())?.toList()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
       fieldName: \\"blog\\",
@@ -6420,7 +6420,7 @@ class authorBook extends Model {
         'book': book
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"authorBook.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField AUTHOR_ID = QueryField(fieldName: \\"author_id\\");
   static final QueryField BOOK_ID = QueryField(fieldName: \\"book_id\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
@@ -6549,7 +6549,7 @@ class TestModel extends Model {
     'id': id
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestModel\\";
     modelSchemaDefinition.pluralName = \\"TestModels\\";
@@ -6687,7 +6687,7 @@ class Blog extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"blog.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
     fieldName: \\"posts\\",
@@ -6839,7 +6839,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
     fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (Post).toString()));
@@ -7006,7 +7006,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
     fieldName: \\"blog\\",
@@ -7224,7 +7224,7 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
   static final QueryField FLOATLIST = QueryField(fieldName: \\"floatList\\");
@@ -7548,7 +7548,7 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList, 'intVal': _intVal, 'intNullableVal': _intNullableVal, 'intList': _intList, 'intNullableList': _intNullableList, 'nullableIntList': _nullableIntList, 'nullableIntNullableList': _nullableIntNullableList
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"testModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
   static final QueryField FLOATLIST = QueryField(fieldName: \\"floatList\\");
@@ -7760,7 +7760,7 @@ class SimpleModel extends Model {
         'updatedAt': updatedAt?.format()
       };
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
       Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -7907,7 +7907,7 @@ class SimpleModel extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"simpleModel.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SimpleModel\\";

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -119,7 +119,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
     fieldName: \\"comments\\",
@@ -271,7 +271,7 @@ class Comment extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -423,7 +423,7 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'project2TeamId': _project2TeamId
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"project2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
     fieldName: \\"team\\",
@@ -582,7 +582,7 @@ class Team2 extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"team2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
     fieldName: \\"project\\",
@@ -737,7 +737,7 @@ class Blog7V2 extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post7V2? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"blog7V2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
     fieldName: \\"posts\\",
@@ -904,7 +904,7 @@ class Post7V2 extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment7V2? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post7V2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
     fieldName: \\"blog\\",
@@ -1057,7 +1057,7 @@ class Comment7V2 extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment7V2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -1209,7 +1209,7 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"project.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
     fieldName: \\"team\\",
@@ -1368,7 +1368,7 @@ class Team extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"team.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
     fieldName: \\"project\\",
@@ -1533,7 +1533,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField TAGS = QueryField(
@@ -1695,7 +1695,7 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"tag.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
     fieldName: \\"posts\\",
@@ -1825,7 +1825,7 @@ class Todo extends Model {
     'id': id, 'content': _content
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"todo.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Todo\\";
@@ -1970,7 +1970,7 @@ class Post2 extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment2? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
     fieldName: \\"comments\\",
@@ -2128,7 +2128,7 @@ class Comment2 extends Model {
     'id': id, 'postID': _postID, 'content': _content
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POSTID = QueryField(fieldName: \\"postID\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -2277,7 +2277,7 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'teamID': _teamID, 'team': _team?.toJson()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"project2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAMID = QueryField(fieldName: \\"teamID\\");
   static final QueryField TEAM = QueryField(
@@ -2423,7 +2423,7 @@ class Team2 extends Model {
     'id': id, 'name': _name
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"team2.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Team2\\";
@@ -2568,7 +2568,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"post.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
     fieldName: \\"comments\\",
@@ -2717,7 +2717,7 @@ class Comment extends Model {
     'id': id, 'content': _content, 'postCommentsId': _postCommentsId
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"comment.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POSTCOMMENTSID = QueryField(fieldName: \\"postCommentsId\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -2866,7 +2866,7 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"project.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
     fieldName: \\"team\\",
@@ -3012,7 +3012,7 @@ class Team extends Model {
     'id': id, 'name': _name
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"team.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Team\\";
@@ -3170,7 +3170,7 @@ class Customer extends Model {
     'id': id, 'name': _name, 'phoneNumber': _phoneNumber, 'accountRepresentativeID': _accountRepresentativeID
   };
 
-  static final QueryField ID = QueryField(fieldName: \\"customer.id\\");
+  static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONENUMBER = QueryField(fieldName: \\"phoneNumber\\");
   static final QueryField ACCOUNTREPRESENTATIVEID = QueryField(fieldName: \\"accountRepresentativeID\\");

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -24,7 +24,6 @@ import {
 } from '../configs/dart-config';
 import dartStyle from 'dart-style';
 import { generateLicense } from '../utils/generateLicense';
-import { lowerCaseFirst } from 'lower-case-first';
 import { GraphQLSchema } from 'graphql';
 import { DART_SCALAR_MAP } from '../scalars';
 
@@ -748,8 +747,6 @@ export class AppSyncModelDartVisitor<
         indent(`fieldName: "${fieldName}",`),
         indent(`fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: (${modelName}).toString()))`),
       ].join('\n');
-    } else if (fieldName === 'id') {
-      value = `QueryField(fieldName: "${lowerCaseFirst(model.name)}.id")`;
     }
     declarationBlock.addClassMember(queryFieldName, 'QueryField', value, { static: true, final: true });
   }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Change Flutter model id field name from `<modelName>.id` to just `id`.

The original behavior should be redundant and inaccurate.

1. In the [iOS implementation of amplify-flutter](https://github.com/aws-amplify/amplify-flutter/blob/5c6d8eab63c1ea11e63d1ec8e82a975a4dffeb28/packages/amplify_datastore/ios/Classes/types/query/QueryPredicateBuilder.swift#L23-L29), it removes `<modelName>` elaborately when using the field name
2. The original name breaks query predicate functionality in amplify-flutter Android
    - base sync filter generated wrongly (see [this issue](https://github.com/aws-amplify/amplify-flutter/issues/1565))
    - `DataStore.query` was luckily working as amplify-android generated SQL commands somehow compatible with `<modelName>.id`

**NOTE:** this change won't be a breaking change, as amplify-flutter is backwards compatible with previously generated model. There is no frictions when customer upgrade either amplify-flutter library or amplify codegen.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-flutter/issues/1565

#### Description of how you validated changes

1. Unit tests in amplify-codegen
4. Integration tess in amplify-flutter

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.