### PR TITLE
feat: add support for sub::username identity claim

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-auth.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-auth.test.ts
@@ -1,4 +1,5 @@
 import {
+  createIdentityClaim,
   processAuthDirective,
   AuthRule,
   AuthStrategy,
@@ -165,6 +166,24 @@ describe('process auth directive', () => {
       expect(processedAuthDirective[0].arguments.rules[0]).toEqual({
         ...groupsAuthRule,
         operations: [AuthModelOperation.create, AuthModelOperation.update, AuthModelOperation.delete, AuthModelOperation.read],
+      });
+    });
+  });
+
+  describe('createIdentityClaim', () => {
+    it('returns passed in value', () => {
+      expect(createIdentityClaim('foo')).toEqual('foo');
+    });
+
+    describe('when identity claim is username', () => {
+      it('returns cognito:username', () => {
+        expect(createIdentityClaim('username')).toEqual('cognito:username');
+      });
+    });
+
+    describe('when identity claim is sub::username', () => {
+      it('returns cognito:username', () => {
+        expect(createIdentityClaim('sub::username')).toEqual('cognito:username');
       });
     });
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Related to changing the default identity claim here: https://github.com/aws-amplify/amplify-category-api/commit/fd2e4ff706ea3dccc609762a295bbeec3da20bd5. This change will take the `sub::username` identity claim and use `cognito:username` value from the token. This is primarily to account for the code generated through codegen. The libraries don't "know" how to handle a double identity claim yet (ie. sub + username), so the generated code will use the username identity claim.



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.