### PR TITLE
feat(appsync-dart-visitor): capability of creating query predicate wi…

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -157,7 +157,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -305,7 +304,6 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -503,7 +501,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -651,7 +648,6 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -1567,8 +1563,6 @@ class Person extends Model {
             mailingAddresses?.map((Address e) => e?.toJson())?.toList()
       };
 
-  static final QueryModelIdentifier<PersonModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PersonModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
@@ -1753,7 +1747,6 @@ class Person extends Model {
     'id': id, 'name': _name, 'phone': _phone?.toJson(), 'mailingAddresses': _mailingAddresses?.map((Address? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PersonModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PersonModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
@@ -1981,8 +1974,6 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'status': enumToString(status)};
 
-  static final QueryModelIdentifier<SimpleModelModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
   static var schema =
@@ -2256,9 +2247,6 @@ class TemporalTimeModel extends Model {
         'intList': intList
       };
 
-  static final QueryModelIdentifier<TemporalTimeModelModelIdentifier>
-      MODEL_IDENTIFIER =
-      QueryModelIdentifier<TemporalTimeModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField DATE = QueryField(fieldName: \\"date\\");
   static final QueryField TIME = QueryField(fieldName: \\"time\\");
@@ -2539,8 +2527,6 @@ class TestEnumModel extends Model {
             nullableEnumNullableList?.map((e) => enumToString(e)).toList()
       };
 
-  static final QueryModelIdentifier<TestEnumModelModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<TestEnumModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField ENUMVAL = QueryField(fieldName: \\"enumVal\\");
   static final QueryField NULLABLEENUMVAL =
@@ -2789,8 +2775,6 @@ class TestModel extends Model {
         'nullableFloatNullableList': nullableFloatNullableList
       };
 
-  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL =
@@ -2975,8 +2959,6 @@ class Post extends Model {
         'tags': tags?.map((PostTags e) => e?.toJson())?.toList()
       };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -3093,8 +3075,6 @@ class Tag extends Model {
         'posts': posts?.map((PostTags e) => e?.toJson())?.toList()
       };
 
-  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -3200,8 +3180,6 @@ class PostTags extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'tag': tag?.toJson()};
 
-  static final QueryModelIdentifier<PostTagsModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostTagsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
@@ -3377,7 +3355,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -3511,7 +3488,6 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -3647,7 +3623,6 @@ class PostTags extends Model {
     'id': id, 'post': _post?.toJson(), 'tag': _tag?.toJson()
   };
 
-  static final QueryModelIdentifier<PostTagsModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostTagsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -3781,8 +3756,6 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<SimpleModelModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -3905,8 +3878,6 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<SimpleModelModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4041,8 +4012,6 @@ class TodoWithAuth extends Model {
         'updatedAt': updatedAt?.format()
       };
 
-  static final QueryModelIdentifier<TodoWithAuthModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<TodoWithAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
@@ -4223,7 +4192,6 @@ class TodoWithAuth extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
-  static final QueryModelIdentifier<TodoWithAuthModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TodoWithAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -4382,8 +4350,6 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<customClaimModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<customClaimModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4519,8 +4485,6 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<customClaimModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<customClaimModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4658,8 +4622,6 @@ class dynamicGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<dynamicGroupsModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<dynamicGroupsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4795,8 +4757,6 @@ class simpleOwnerAuth extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<simpleOwnerAuthModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<simpleOwnerAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4932,8 +4892,6 @@ class allowRead extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<allowReadModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<allowReadModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5068,8 +5026,6 @@ class privateType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<privateTypeModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<privateTypeModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5201,8 +5157,6 @@ class publicType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<publicTypeModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<publicTypeModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5334,8 +5288,6 @@ class staticGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
-  static final QueryModelIdentifier<staticGroupsModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<staticGroupsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5476,8 +5428,6 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'author': author};
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
@@ -5616,8 +5566,6 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'owner': owner};
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField OWNER = QueryField(fieldName: \\"owner\\");
@@ -5768,8 +5716,6 @@ class Todo extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'tasks': tasks?.map((Task e) => e?.toJson())?.toList()};
 
-  static final QueryModelIdentifier<TodoModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<TodoModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TASKS = QueryField(
       fieldName: \\"tasks\\",
@@ -5885,8 +5831,6 @@ class Task extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'todo': todo?.toJson()};
 
-  static final QueryModelIdentifier<TaskModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<TaskModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TODO = QueryField(
       fieldName: \\"todo\\",
@@ -6029,8 +5973,6 @@ class Blog extends Model {
         'test': test
       };
 
-  static final QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<BlogModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -6172,8 +6114,6 @@ class Comment extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'content': content};
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
@@ -6329,8 +6269,6 @@ class Post extends Model {
         'comments': comments?.map((Comment e) => e?.toJson())?.toList()
       };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
-      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -6508,8 +6446,6 @@ class authorBook extends Model {
         'book': book
       };
 
-  static final QueryModelIdentifier<authorBookModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<authorBookModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField AUTHOR_ID = QueryField(fieldName: \\"author_id\\");
   static final QueryField BOOK_ID = QueryField(fieldName: \\"book_id\\");
@@ -6644,7 +6580,6 @@ class TestModel extends Model {
     'id': id
   };
 
-  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestModel\\";
@@ -6783,7 +6718,6 @@ class Blog extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<BlogModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -6936,7 +6870,6 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -7108,7 +7041,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -7331,7 +7263,6 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList
   };
 
-  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
@@ -7656,7 +7587,6 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList, 'intVal': _intVal, 'intNullableVal': _intNullableVal, 'intList': _intList, 'intNullableList': _intNullableList, 'nullableIntList': _nullableIntList, 'nullableIntNullableList': _nullableIntNullableList
   };
 
-  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
@@ -7869,8 +7799,6 @@ class SimpleModel extends Model {
         'updatedAt': updatedAt?.format()
       };
 
-  static final QueryModelIdentifier<SimpleModelModelIdentifier>
-      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
@@ -8018,7 +7946,6 @@ class SimpleModel extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
-  static final QueryModelIdentifier<SimpleModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -157,6 +157,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -304,6 +305,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -501,6 +503,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'status': enumToString(_status), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -648,6 +651,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -1563,6 +1567,8 @@ class Person extends Model {
             mailingAddresses?.map((Address e) => e?.toJson())?.toList()
       };
 
+  static final QueryModelIdentifier<PersonModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PersonModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
@@ -1747,6 +1753,7 @@ class Person extends Model {
     'id': id, 'name': _name, 'phone': _phone?.toJson(), 'mailingAddresses': _mailingAddresses?.map((Address? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PersonModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PersonModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONE = QueryField(fieldName: \\"phone\\");
@@ -1974,6 +1981,8 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'status': enumToString(status)};
 
+  static final QueryModelIdentifier<SimpleModelModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField STATUS = QueryField(fieldName: \\"status\\");
   static var schema =
@@ -2247,6 +2256,9 @@ class TemporalTimeModel extends Model {
         'intList': intList
       };
 
+  static final QueryModelIdentifier<TemporalTimeModelModelIdentifier>
+      MODEL_IDENTIFIER =
+      QueryModelIdentifier<TemporalTimeModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField DATE = QueryField(fieldName: \\"date\\");
   static final QueryField TIME = QueryField(fieldName: \\"time\\");
@@ -2527,6 +2539,8 @@ class TestEnumModel extends Model {
             nullableEnumNullableList?.map((e) => enumToString(e)).toList()
       };
 
+  static final QueryModelIdentifier<TestEnumModelModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<TestEnumModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField ENUMVAL = QueryField(fieldName: \\"enumVal\\");
   static final QueryField NULLABLEENUMVAL =
@@ -2775,6 +2789,8 @@ class TestModel extends Model {
         'nullableFloatNullableList': nullableFloatNullableList
       };
 
+  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL =
@@ -2959,6 +2975,8 @@ class Post extends Model {
         'tags': tags?.map((PostTags e) => e?.toJson())?.toList()
       };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -3075,6 +3093,8 @@ class Tag extends Model {
         'posts': posts?.map((PostTags e) => e?.toJson())?.toList()
       };
 
+  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -3180,6 +3200,8 @@ class PostTags extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'tag': tag?.toJson()};
 
+  static final QueryModelIdentifier<PostTagsModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PostTagsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
@@ -3355,6 +3377,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -3488,6 +3511,7 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -3623,6 +3647,7 @@ class PostTags extends Model {
     'id': id, 'post': _post?.toJson(), 'tag': _tag?.toJson()
   };
 
+  static final QueryModelIdentifier<PostTagsModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostTagsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -3756,6 +3781,8 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<SimpleModelModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -3878,6 +3905,8 @@ class SimpleModel extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<SimpleModelModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4012,6 +4041,8 @@ class TodoWithAuth extends Model {
         'updatedAt': updatedAt?.format()
       };
 
+  static final QueryModelIdentifier<TodoWithAuthModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<TodoWithAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
@@ -4192,6 +4223,7 @@ class TodoWithAuth extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<TodoWithAuthModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TodoWithAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -4350,6 +4382,8 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<customClaimModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<customClaimModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4485,6 +4519,8 @@ class customClaim extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<customClaimModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<customClaimModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4622,6 +4658,8 @@ class dynamicGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<dynamicGroupsModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<dynamicGroupsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4757,6 +4795,8 @@ class simpleOwnerAuth extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<simpleOwnerAuthModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<simpleOwnerAuthModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -4892,6 +4932,8 @@ class allowRead extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<allowReadModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<allowReadModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5026,6 +5068,8 @@ class privateType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<privateTypeModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<privateTypeModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5157,6 +5201,8 @@ class publicType extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<publicTypeModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<publicTypeModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5288,6 +5334,8 @@ class staticGroups extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'name': name, 'bar': bar};
 
+  static final QueryModelIdentifier<staticGroupsModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<staticGroupsModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BAR = QueryField(fieldName: \\"bar\\");
@@ -5428,6 +5476,8 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'author': author};
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField AUTHOR = QueryField(fieldName: \\"author\\");
@@ -5566,6 +5616,8 @@ class Post extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'title': title, 'owner': owner};
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField OWNER = QueryField(fieldName: \\"owner\\");
@@ -5716,6 +5768,8 @@ class Todo extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'tasks': tasks?.map((Task e) => e?.toJson())?.toList()};
 
+  static final QueryModelIdentifier<TodoModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<TodoModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TASKS = QueryField(
       fieldName: \\"tasks\\",
@@ -5831,6 +5885,8 @@ class Task extends Model {
 
   Map<String, dynamic> toJson() => {'id': id, 'todo': todo?.toJson()};
 
+  static final QueryModelIdentifier<TaskModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<TaskModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TODO = QueryField(
       fieldName: \\"todo\\",
@@ -5973,6 +6029,8 @@ class Blog extends Model {
         'test': test
       };
 
+  static final QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<BlogModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -6114,6 +6172,8 @@ class Comment extends Model {
   Map<String, dynamic> toJson() =>
       {'id': id, 'post': post?.toJson(), 'content': content};
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
       fieldName: \\"post\\",
@@ -6269,6 +6329,8 @@ class Post extends Model {
         'comments': comments?.map((Comment e) => e?.toJson())?.toList()
       };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER =
+      QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -6446,6 +6508,8 @@ class authorBook extends Model {
         'book': book
       };
 
+  static final QueryModelIdentifier<authorBookModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<authorBookModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField AUTHOR_ID = QueryField(fieldName: \\"author_id\\");
   static final QueryField BOOK_ID = QueryField(fieldName: \\"book_id\\");
@@ -6580,6 +6644,7 @@ class TestModel extends Model {
     'id': id
   };
 
+  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"TestModel\\";
@@ -6718,6 +6783,7 @@ class Blog extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<BlogModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<BlogModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -6870,6 +6936,7 @@ class Comment extends Model {
     'id': id, 'post': _post?.toJson(), 'content': _content
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POST = QueryField(
     fieldName: \\"post\\",
@@ -7041,6 +7108,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -7263,6 +7331,7 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList
   };
 
+  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
@@ -7587,6 +7656,7 @@ class TestModel extends Model {
     'id': id, 'floatVal': _floatVal, 'floatNullableVal': _floatNullableVal, 'floatList': _floatList, 'floatNullableList': _floatNullableList, 'nullableFloatList': _nullableFloatList, 'nullableFloatNullableList': _nullableFloatNullableList, 'intVal': _intVal, 'intNullableVal': _intNullableVal, 'intList': _intList, 'intNullableList': _intNullableList, 'nullableIntList': _nullableIntList, 'nullableIntNullableList': _nullableIntNullableList
   };
 
+  static final QueryModelIdentifier<TestModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TestModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField FLOATVAL = QueryField(fieldName: \\"floatVal\\");
   static final QueryField FLOATNULLABLEVAL = QueryField(fieldName: \\"floatNullableVal\\");
@@ -7799,6 +7869,8 @@ class SimpleModel extends Model {
         'updatedAt': updatedAt?.format()
       };
 
+  static final QueryModelIdentifier<SimpleModelModelIdentifier>
+      MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema =
@@ -7946,6 +8018,7 @@ class SimpleModel extends Model {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<SimpleModelModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<SimpleModelModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -8108,6 +8181,7 @@ class ModelWithImplicitID extends Model {
     'id': id, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithImplicitIDModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithImplicitIDModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -8314,6 +8388,7 @@ class ModelWithExplicitID extends Model {
     'id': id, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithExplicitIDModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithExplicitIDModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -8511,6 +8586,7 @@ class ModelWithExplicitIDAndSDI extends Model {
     'id': id, 'parentID': _parentID, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithExplicitIDAndSDIModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithExplicitIDAndSDIModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField PARENTID = QueryField(fieldName: \\"parentID\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -8751,6 +8827,7 @@ class ModelWithIDPlusSortKeys extends Model {
     'id': id, 'title': _title, 'rating': _rating, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithIDPlusSortKeysModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithIDPlusSortKeysModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -9003,6 +9080,7 @@ class ModelWithExplicitlyDefinedPK extends Model {
     'modelID': _modelID, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithExplicitlyDefinedPKModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithExplicitlyDefinedPKModelIdentifier>();
   static final QueryField MODELID = QueryField(fieldName: \\"modelID\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -9260,6 +9338,7 @@ class ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey extends Model {
     'modelID': _modelID, 'title': _title, 'rating': _rating, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKeyModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKeyModelIdentifier>();
   static final QueryField MODELID = QueryField(fieldName: \\"modelID\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField RATING = QueryField(fieldName: \\"rating\\");
@@ -9520,6 +9599,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -9778,6 +9858,7 @@ class Comment extends Model {
     'id': id, 'content': _content, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'postCommentsId': _postCommentsId, 'postCommentsTitle': _postCommentsTitle
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POSTCOMMENTSID = QueryField(fieldName: \\"postCommentsId\\");
@@ -10065,6 +10146,7 @@ class Project extends Model {
     'projectId': _projectId, 'name': _name, 'team': _team?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'projectTeamTeamId': _projectTeamTeamId, 'projectTeamName': _projectTeamName
   };
 
+  static final QueryModelIdentifier<ProjectModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ProjectModelIdentifier>();
   static final QueryField PROJECTID = QueryField(fieldName: \\"projectId\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -10347,6 +10429,7 @@ class Team extends Model {
     'teamId': _teamId, 'name': _name, 'project': _project?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<TeamModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TeamModelIdentifier>();
   static final QueryField TEAMID = QueryField(fieldName: \\"teamId\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
@@ -10621,6 +10704,7 @@ class CpkOneToOneBidirectionalParent extends Model {
     'id': id, 'name': _name, 'explicitChild': _explicitChild?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'cpkOneToOneBidirectionalParentExplicitChildId': _cpkOneToOneBidirectionalParentExplicitChildId, 'cpkOneToOneBidirectionalParentExplicitChildName': _cpkOneToOneBidirectionalParentExplicitChildName
   };
 
+  static final QueryModelIdentifier<CpkOneToOneBidirectionalParentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CpkOneToOneBidirectionalParentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField EXPLICITCHILD = QueryField(
@@ -10886,6 +10970,7 @@ class CpkOneToOneBidirectionalChildExplicit extends Model {
     'id': id, 'name': _name, 'belongsToParent': _belongsToParent?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
 
+  static final QueryModelIdentifier<CpkOneToOneBidirectionalChildExplicitModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CpkOneToOneBidirectionalChildExplicitModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField BELONGSTOPARENT = QueryField(

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -119,7 +119,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -272,7 +271,6 @@ class Comment extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
@@ -429,7 +427,6 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'project2TeamId': _project2TeamId
   };
 
-  static final QueryModelIdentifier<Project2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Project2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -589,7 +586,6 @@ class Team2 extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
-  static final QueryModelIdentifier<Team2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Team2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
@@ -745,7 +741,6 @@ class Blog7V2 extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post7V2? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<Blog7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Blog7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -913,7 +908,6 @@ class Post7V2 extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment7V2? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<Post7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Post7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -1067,7 +1061,6 @@ class Comment7V2 extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
-  static final QueryModelIdentifier<Comment7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Comment7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
@@ -1220,7 +1213,6 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
-  static final QueryModelIdentifier<ProjectModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ProjectModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -1380,7 +1372,6 @@ class Team extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
-  static final QueryModelIdentifier<TeamModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TeamModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
@@ -1546,7 +1537,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -1709,7 +1699,6 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -1840,7 +1829,6 @@ class Todo extends Model {
     'id': id, 'content': _content
   };
 
-  static final QueryModelIdentifier<TodoModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TodoModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -1986,7 +1974,6 @@ class Post2 extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment2? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<Post2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Post2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -2145,7 +2132,6 @@ class Comment2 extends Model {
     'id': id, 'postID': _postID, 'content': _content
   };
 
-  static final QueryModelIdentifier<Comment2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Comment2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POSTID = QueryField(fieldName: \\"postID\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -2299,7 +2285,6 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'teamID': _teamID, 'team': _team?.toJson()
   };
 
-  static final QueryModelIdentifier<Project2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Project2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAMID = QueryField(fieldName: \\"teamID\\");
@@ -2446,7 +2431,6 @@ class Team2 extends Model {
     'id': id, 'name': _name
   };
 
-  static final QueryModelIdentifier<Team2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Team2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -2592,7 +2576,6 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
-  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -2742,7 +2725,6 @@ class Comment extends Model {
     'id': id, 'content': _content, 'postCommentsId': _postCommentsId
   };
 
-  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POSTCOMMENTSID = QueryField(fieldName: \\"postCommentsId\\");
@@ -2892,7 +2874,6 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
-  static final QueryModelIdentifier<ProjectModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ProjectModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -3039,7 +3020,6 @@ class Team extends Model {
     'id': id, 'name': _name
   };
 
-  static final QueryModelIdentifier<TeamModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TeamModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -3198,7 +3178,6 @@ class Customer extends Model {
     'id': id, 'name': _name, 'phoneNumber': _phoneNumber, 'accountRepresentativeID': _accountRepresentativeID
   };
 
-  static final QueryModelIdentifier<CustomerModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CustomerModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONENUMBER = QueryField(fieldName: \\"phoneNumber\\");
@@ -3407,7 +3386,6 @@ class ModelWithPrimaryKey extends Model {
     'productID': _productID, 'name': _name, 'content': _content, 'albumID': _albumID, 'categoryID': _categoryID
   };
 
-  static final QueryModelIdentifier<ModelWithPrimaryKeyModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithPrimaryKeyModelIdentifier>();
   static final QueryField PRODUCTID = QueryField(fieldName: \\"productID\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -119,6 +119,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -271,6 +272,7 @@ class Comment extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
@@ -427,6 +429,7 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'project2TeamId': _project2TeamId
   };
 
+  static final QueryModelIdentifier<Project2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Project2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -586,6 +589,7 @@ class Team2 extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
+  static final QueryModelIdentifier<Team2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Team2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
@@ -741,6 +745,7 @@ class Blog7V2 extends Model {
     'id': id, 'name': _name, 'posts': _posts?.map((Post7V2? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<Blog7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Blog7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField POSTS = QueryField(
@@ -908,6 +913,7 @@ class Post7V2 extends Model {
     'id': id, 'title': _title, 'blog': _blog?.toJson(), 'comments': _comments?.map((Comment7V2? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<Post7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Post7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField BLOG = QueryField(
@@ -1061,6 +1067,7 @@ class Comment7V2 extends Model {
     'id': id, 'content': _content, 'post': _post?.toJson()
   };
 
+  static final QueryModelIdentifier<Comment7V2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Comment7V2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POST = QueryField(
@@ -1213,6 +1220,7 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
+  static final QueryModelIdentifier<ProjectModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ProjectModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -1372,6 +1380,7 @@ class Team extends Model {
     'id': id, 'name': _name, 'project': _project?.toJson()
   };
 
+  static final QueryModelIdentifier<TeamModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TeamModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PROJECT = QueryField(
@@ -1537,6 +1546,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'content': _content, 'tags': _tags?.map((PostTags? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -1699,6 +1709,7 @@ class Tag extends Model {
     'id': id, 'label': _label, 'posts': _posts?.map((PostTags? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<TagModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TagModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField LABEL = QueryField(fieldName: \\"label\\");
   static final QueryField POSTS = QueryField(
@@ -1829,6 +1840,7 @@ class Todo extends Model {
     'id': id, 'content': _content
   };
 
+  static final QueryModelIdentifier<TodoModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TodoModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -1974,6 +1986,7 @@ class Post2 extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment2? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<Post2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Post2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -2132,6 +2145,7 @@ class Comment2 extends Model {
     'id': id, 'postID': _postID, 'content': _content
   };
 
+  static final QueryModelIdentifier<Comment2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Comment2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField POSTID = QueryField(fieldName: \\"postID\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
@@ -2285,6 +2299,7 @@ class Project2 extends Model {
     'id': id, 'name': _name, 'teamID': _teamID, 'team': _team?.toJson()
   };
 
+  static final QueryModelIdentifier<Project2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Project2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAMID = QueryField(fieldName: \\"teamID\\");
@@ -2431,6 +2446,7 @@ class Team2 extends Model {
     'id': id, 'name': _name
   };
 
+  static final QueryModelIdentifier<Team2ModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<Team2ModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -2576,6 +2592,7 @@ class Post extends Model {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList()
   };
 
+  static final QueryModelIdentifier<PostModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<PostModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField TITLE = QueryField(fieldName: \\"title\\");
   static final QueryField COMMENTS = QueryField(
@@ -2725,6 +2742,7 @@ class Comment extends Model {
     'id': id, 'content': _content, 'postCommentsId': _postCommentsId
   };
 
+  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");
   static final QueryField POSTCOMMENTSID = QueryField(fieldName: \\"postCommentsId\\");
@@ -2874,6 +2892,7 @@ class Project extends Model {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
   };
 
+  static final QueryModelIdentifier<ProjectModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ProjectModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField TEAM = QueryField(
@@ -3020,6 +3039,7 @@ class Team extends Model {
     'id': id, 'name': _name
   };
 
+  static final QueryModelIdentifier<TeamModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<TeamModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
@@ -3178,6 +3198,7 @@ class Customer extends Model {
     'id': id, 'name': _name, 'phoneNumber': _phoneNumber, 'accountRepresentativeID': _accountRepresentativeID
   };
 
+  static final QueryModelIdentifier<CustomerModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CustomerModelIdentifier>();
   static final QueryField ID = QueryField(fieldName: \\"id\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField PHONENUMBER = QueryField(fieldName: \\"phoneNumber\\");
@@ -3386,6 +3407,7 @@ class ModelWithPrimaryKey extends Model {
     'productID': _productID, 'name': _name, 'content': _content, 'albumID': _albumID, 'categoryID': _categoryID
   };
 
+  static final QueryModelIdentifier<ModelWithPrimaryKeyModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<ModelWithPrimaryKeyModelIdentifier>();
   static final QueryField PRODUCTID = QueryField(fieldName: \\"productID\\");
   static final QueryField NAME = QueryField(fieldName: \\"name\\");
   static final QueryField CONTENT = QueryField(fieldName: \\"content\\");

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -874,7 +874,14 @@ export class AppSyncModelDartVisitor<
   }
 
   protected generateModelSchema(model: CodeGenModel, classDeclarationBlock: DartDeclarationBlock): void {
+    const modelName = model.name;
     const schemaDeclarationBlock = new DartDeclarationBlock();
+    schemaDeclarationBlock.addClassMember(
+      'MODEL_IDENTIFIER',
+      `QueryModelIdentifier<${modelName}ModelIdentifier>`,
+      `QueryModelIdentifier<${modelName}ModelIdentifier>()`,
+      { static: true, final: true },
+    );
     //QueryField
     this.getWritableFields(model).forEach(field => {
       this.generateQueryField(model, field, schemaDeclarationBlock);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -876,12 +876,17 @@ export class AppSyncModelDartVisitor<
   protected generateModelSchema(model: CodeGenModel, classDeclarationBlock: DartDeclarationBlock): void {
     const modelName = model.name;
     const schemaDeclarationBlock = new DartDeclarationBlock();
-    schemaDeclarationBlock.addClassMember(
-      'MODEL_IDENTIFIER',
-      `QueryModelIdentifier<${modelName}ModelIdentifier>`,
-      `QueryModelIdentifier<${modelName}ModelIdentifier>()`,
-      { static: true, final: true },
-    );
+
+    if (this.isCustomPKEnabled()) {
+      // QueryField that allows creating query predicate with custom PK
+      schemaDeclarationBlock.addClassMember(
+        'MODEL_IDENTIFIER',
+        `QueryModelIdentifier<${modelName}ModelIdentifier>`,
+        `QueryModelIdentifier<${modelName}ModelIdentifier>()`,
+        { static: true, final: true },
+      );
+    }
+
     //QueryField
     this.getWritableFields(model).forEach(field => {
       this.generateQueryField(model, field, schemaDeclarationBlock);


### PR DESCRIPTION
…th custom PK

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-flutter/issues/1426

#### Description of how you validated changes

Add a static query field `MODEL_IDENTIFIER` to allow creating query predicate with a  model identifier using custom primary key fields. e.g.

```dart
// query
final result = await Amplify.DataStore.query(
  CpkInventory.classType,
  where: CpkInventory.MODEL_IDENTIFIER.eq(
    CpkInventoryModelIdentifier(
      productId: '23ac8937-71b5-4782-9249-930cbd71d338',
      productName: 'test product',
      warehouseId: 'cd7c5225-43bb-47a7-9440-80e0a3e33b65',
    ),
  ),
);


// observe query
final testModel = CpkInventory(
  productId: UUID.getUUID(),
  productName: 'test product',
  warehouseId: UUID.getUUID(),
);

final observeStream = Amplify.DataStore.observeQuery(
  CpkInventory.classType,
  where: CpkInventory.MODEL_IDENTIFIER.eq(testModel.modelIdentifier),
)
```

amplify-flutter integration tests have been added to valid this change: https://github.com/aws-amplify/amplify-flutter/pull/1641

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.