### PR TITLE
chore: flip to use @aws-amplify namespace for private packages to avoid collision with improperly published packages

### DIFF
--- a/packages/amplify-codegen-e2e-core/package.json
+++ b/packages/amplify-codegen-e2e-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-codegen-e2e-core",
+  "name": "@aws-amplify/amplify-codegen-e2e-core",
   "version": "1.1.6",
   "description": "",
   "repository": {

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-codegen-e2e-tests",
+  "name": "@aws-amplify/amplify-codegen-e2e-tests",
   "version": "2.39.10",
   "description": "",
   "repository": {
@@ -22,7 +22,7 @@
     "clean-e2e-resources": "ts-node ./src/cleanup-e2e-resources.ts"
   },
   "dependencies": {
-    "amplify-codegen-e2e-core": "1.1.6",
+    "@aws-amplify/amplify-codegen-e2e-core": "1.1.6",
     "aws-amplify": "^3.0.8",
     "aws-appsync": "^4.0.3",
     "aws-sdk": "^2.845.0",

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/feature-flags.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/feature-flags.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { initJSProjectWithProfile, createNewProjectDir, deleteProject, deleteProjectDir } from 'amplify-codegen-e2e-core';
+import { initJSProjectWithProfile, createNewProjectDir, deleteProject, deleteProjectDir } from '@aws-amplify/amplify-codegen-e2e-core';
 import { pathManager } from 'amplify-cli-core';
 
 const codegenFeatureFlags = {

--- a/packages/amplify-codegen-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
+++ b/packages/amplify-codegen-e2e-tests/src/amplify-app-helpers/amplify-app-setup.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, KEY_DOWN_ARROW, isCI } from 'amplify-codegen-e2e-core';
+import { nspawn as spawn, KEY_DOWN_ARROW, isCI } from '@aws-amplify/amplify-codegen-e2e-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -5,7 +5,7 @@ import * as aws from 'aws-sdk';
 import _ from 'lodash';
 import fs from 'fs-extra';
 import path from 'path';
-import { deleteS3Bucket } from 'amplify-codegen-e2e-core';
+import { deleteS3Bucket } from '@aws-amplify/amplify-codegen-e2e-core';
 
 // Ensure to update scripts/split-e2e-tests.ts is also updated this gets updated
 const AWS_REGIONS_TO_RUN_TESTS = [

--- a/packages/amplify-codegen-e2e-tests/src/configure_tests.ts
+++ b/packages/amplify-codegen-e2e-tests/src/configure_tests.ts
@@ -1,4 +1,4 @@
-import { amplifyConfigure as configure, isCI } from 'amplify-codegen-e2e-core';
+import { amplifyConfigure as configure, isCI } from '@aws-amplify/amplify-codegen-e2e-core';
 
 async function setupAmplify() {
   if (isCI()) {

--- a/packages/amplify-codegen-e2e-tests/src/environment/env.ts
+++ b/packages/amplify-codegen-e2e-tests/src/environment/env.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath, getSocialProviders } from 'amplify-codegen-e2e-core';
+import { nspawn as spawn, getCLIPath, getSocialProviders } from '@aws-amplify/amplify-codegen-e2e-core';
 
 export function addEnvironment(cwd: string, settings: { envName: string; numLayers?: number }): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-codegen-e2e-tests/src/import-helpers/expects.ts
+++ b/packages/amplify-codegen-e2e-tests/src/import-helpers/expects.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { getProjectMeta, getBackendAmplifyMeta, getTeamProviderInfo, getBackendConfig } from 'amplify-codegen-e2e-core';
+import { getProjectMeta, getBackendAmplifyMeta, getTeamProviderInfo, getBackendConfig } from '@aws-amplify/amplify-codegen-e2e-core';
 import { AuthProjectDetails, DynamoDBProjectDetails, readRootStack, StorageProjectDetails } from '.';
 
 export const expectAuthProjectDetailsMatch = (projectDetails: AuthProjectDetails, ogProjectDetails: AuthProjectDetails) => {

--- a/packages/amplify-codegen-e2e-tests/src/import-helpers/settings.ts
+++ b/packages/amplify-codegen-e2e-tests/src/import-helpers/settings.ts
@@ -4,7 +4,7 @@ import {
   AddAuthIdentityPoolAndUserPoolWithOAuthSettings,
   AddStorageSettings,
   AddDynamoDBSettings,
-} from 'amplify-codegen-e2e-core';
+} from '@aws-amplify/amplify-codegen-e2e-core';
 
 export const createNoOAuthSettings = (projectPrefix: string, shortId: string): AddAuthUserPoolOnlyNoOAuthSettings => {
   return {

--- a/packages/amplify-codegen-e2e-tests/src/import-helpers/utilities.ts
+++ b/packages/amplify-codegen-e2e-tests/src/import-helpers/utilities.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { $TSObject, JSONUtilities } from 'amplify-cli-core';
 import { AppClientSettings, DynamoDBProjectDetails } from './types';
 import { AuthProjectDetails, StorageProjectDetails } from '.';
-import { getBackendAmplifyMeta, getProjectMeta, getTeamProviderInfo } from 'amplify-codegen-e2e-core';
+import { getBackendAmplifyMeta, getProjectMeta, getTeamProviderInfo } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';

--- a/packages/amplify-codegen-e2e-tests/src/import-helpers/walkthroughs.ts
+++ b/packages/amplify-codegen-e2e-tests/src/import-helpers/walkthroughs.ts
@@ -1,4 +1,4 @@
-import { getCLIPath, nspawn as spawn } from 'amplify-codegen-e2e-core';
+import { getCLIPath, nspawn as spawn } from '@aws-amplify/amplify-codegen-e2e-core';
 
 export const importUserPoolOnly = (cwd: string, autoCompletePrefix: string, clientNames?: { web?: string; native?: string }) => {
   return new Promise((resolve, reject) => {

--- a/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions, addCircleCITags, KEY_DOWN_ARROW } from 'amplify-codegen-e2e-core';
+import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions, addCircleCITags, KEY_DOWN_ARROW } from '@aws-amplify/amplify-codegen-e2e-core';
 import fs from 'fs-extra';
 import os from 'os';
 

--- a/packages/amplify-codegen-e2e-tests/src/plugin/index.ts
+++ b/packages/amplify-codegen-e2e-tests/src/plugin/index.ts
@@ -1,7 +1,7 @@
 export * from './new-plugin';
 export * from './verifyPluginStructure';
 
-import { nspawn as spawn, getCLIPath } from 'amplify-codegen-e2e-core';
+import { nspawn as spawn, getCLIPath } from '@aws-amplify/amplify-codegen-e2e-core';
 export function help(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['plugin', 'help'], { cwd, stripColors: true })

--- a/packages/amplify-codegen-e2e-tests/src/plugin/new-plugin.ts
+++ b/packages/amplify-codegen-e2e-tests/src/plugin/new-plugin.ts
@@ -1,4 +1,4 @@
-import { nspawn as spawn, getCLIPath } from 'amplify-codegen-e2e-core';
+import { nspawn as spawn, getCLIPath } from '@aws-amplify/amplify-codegen-e2e-core';
 
 export async function newPlugin(cwd: string): Promise<string> {
   const pluginPackageDirName = 'newpluginpackage';

--- a/packages/amplify-codegen-e2e-tests/src/plugin/verifyPluginStructure.ts
+++ b/packages/amplify-codegen-e2e-tests/src/plugin/verifyPluginStructure.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { readJsonFile } from 'amplify-codegen-e2e-core';
+import { readJsonFile } from '@aws-amplify/amplify-codegen-e2e-core';
 
 export function verifyPlugin(pluginDirPath: string): boolean {
   if (fs.existsSync(pluginDirPath) && fs.statSync(pluginDirPath).isDirectory()) {

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/authHelper.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/authHelper.ts
@@ -1,5 +1,5 @@
 import { CognitoIdentityServiceProvider } from 'aws-sdk';
-import { getProjectMeta, getBackendAmplifyMeta } from 'amplify-codegen-e2e-core';
+import { getProjectMeta, getBackendAmplifyMeta } from '@aws-amplify/amplify-codegen-e2e-core';
 import Amplify, { Auth } from 'aws-amplify';
 import { AuthenticationDetails } from 'amazon-cognito-identity-js';
 import fs from 'fs-extra';

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/common.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/common.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import _ from 'lodash';
 import gql from 'graphql-tag';
-import { addApi, amplifyPush, updateAuthAddUserGroups } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush, updateAuthAddUserGroups } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import {
   setupUser,

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/functionTester.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/functionTester.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import uuid from 'uuid';
 import fs from 'fs-extra';
-import { amplifyPush, addFunction, addApi } from 'amplify-codegen-e2e-core';
+import { amplifyPush, addFunction, addApi } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { configureAmplify, getApiKey, getConfiguredAppsyncClientAPIKeyAuth } from './authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-customClaims.ts
@@ -5,7 +5,7 @@ import {
   addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
   updateAuthAddUserGroups,
   amplifyPush,
-} from 'amplify-codegen-e2e-core';
+} from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getUserPoolId, configureAmplify, setupUser, signInUser, getConfiguredAppsyncClientCognitoAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-private2.ts
@@ -1,4 +1,4 @@
-import { addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { configureAmplify, getConfiguredAppsyncClientIAMAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-public1.ts
@@ -1,4 +1,4 @@
-import { addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-public2.ts
@@ -1,4 +1,4 @@
-import { addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { configureAmplify, getConfiguredAppsyncClientIAMAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/auth-usingOidc.ts
@@ -1,4 +1,4 @@
-import { addAuthWithDefault, amplifyPushWithoutCodegen, addApi, updateAuthAddUserGroups, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addAuthWithDefault, amplifyPushWithoutCodegen, addApi, updateAuthAddUserGroups, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import {
   getAppClientIDWeb,

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-chaining.ts
@@ -1,4 +1,4 @@
-import { addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-differentRegion.ts
@@ -11,7 +11,7 @@ import {
   amplifyPushWithoutCodegen,
   addFunction,
   initProjectWithAccessKey,
-} from 'amplify-codegen-e2e-core';
+} from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-example2.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/function-example2.ts
@@ -7,7 +7,7 @@ import {
   addApiWithCognitoUserPoolAuthTypeWhenAuthExists,
   updateAuthAddUserGroups,
   addAuthWithDefault,
-} from 'amplify-codegen-e2e-core';
+} from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { updateFunctionNameInSchema } from '../functionTester';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/key-howTo4.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { addApiWithBlankSchemaAndConflictDetection, updateApiSchema, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApiWithBlankSchemaAndConflictDetection, updateApiSchema, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 import { testQueries, testMutations } from '../common';
 

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/predictions-usage.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import aws from 'aws-sdk';
 import gql from 'graphql-tag';
-import { addAuthWithDefault, addS3Storage, getBackendAmplifyMeta, addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addAuthWithDefault, addS3Storage, getBackendAmplifyMeta, addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 import { updateSchemaInTestProject } from '../common';

--- a/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
+++ b/packages/amplify-codegen-e2e-tests/src/schema-api-directives/tests/searchable-usage.ts
@@ -1,4 +1,4 @@
-import { addApi, amplifyPush } from 'amplify-codegen-e2e-core';
+import { addApi, amplifyPush } from '@aws-amplify/amplify-codegen-e2e-core';
 
 import { getApiKey, configureAmplify, getConfiguredAppsyncClientAPIKeyAuth } from '../authHelper';
 


### PR DESCRIPTION
#### Description of changes
Somebody was squatting on the non-namespaced versions of our test core package, resulting in a security alert. This is a private package and should not be published. Flipping to use the secured `@aws-amplify` npm namespace to avoid issues like this in the future.

#### Issue #, if available
N/A

#### Description of how you validated changes
Built and tested the repo.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.