### PR TITLE
fix: use cli internal for e2e

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -1,25 +1,28 @@
 version: 2.1
+orbs:
+  aws-ecr: circleci/aws-ecr@6.15.3
 machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 executors:
-  linux_node12: &linux_node12
-    docker:
-      - image: circleci/node:12
-    resource_class: large
-  linux_node15: &linux_node15
-    docker:
-      - image: circleci/node:15
-    resource_class: large
-  windows_node12: &windows_node12
+  w: &windows-e2e-executor
     machine:
-      image: 'windows-server-2019-vs2019:stable'
-      resource_class: windows.large
+      image: "windows-server-2019-vs2019:stable"
+      resource_class: "windows.medium"
       shell: bash.exe
-  macos_node12: &macos_node12
-    macos:
-      xcode: 13.2.1
-      resource_class: large
+    working_directory: ~/repo
+    environment:
+      AMPLIFY_DIR: C:/home/circleci/repo/out
+      AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
+
+  l: &linux-e2e-executor
+    docker:
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
+    working_directory: ~/repo
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
 
 defaults: &defaults
   working_directory: ~/repo
@@ -76,8 +79,7 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ *macos_node12, << parameters.os >> ]
-              - equal: [ *windows_node12, << parameters.os >> ]
+              - equal: [ *windows-e2e-executor, << parameters.os >> ]
           steps:
             - checkout
             - run: nvm install 12.22.7
@@ -88,8 +90,7 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ *linux_node12, << parameters.os >> ]
-              - equal: [ *linux_node15, << parameters.os >> ]
+              - equal: [ *linux-e2e-executor, << parameters.os >> ]
           steps:
             - attach_workspace:
                 at: ./
@@ -204,27 +205,27 @@ workflows:
                 - e2e-testing
     jobs:
       - build:
-          os: linux_node12
+          os: l
       - cleanup_resources:
           context:
             - cleanup-resources
-          os: linux_node12
+          os: l
           requires:
             - build
 
   build_test_deploy:
     jobs:
       - build:
-          os: linux_node12
+          os: l
       - test:
           name: test-<< matrix.os >>
           matrix:
             parameters:
-              os: [linux_node15, linux_node12, windows_node12, macos_node12]
+              os: [l, w]
           requires:
             - build
       - publish_to_local_registry:
-          os: linux_node12
+          os: l
           requires:
             - build
           filters:
@@ -236,7 +237,7 @@ workflows:
       - e2e-test:
           context:
             - cleanup-resources
-          os: linux_node15
+          os: l
           requires:
             - publish_to_local_registry
           post-steps:
@@ -248,7 +249,7 @@ workflows:
                 - e2e-testing
                 - /tagged-release\/.*/
       - deploy:
-          os: linux_node12
+          os: l
           requires:
             - build
             - test
@@ -261,6 +262,6 @@ workflows:
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
       - done_with_node_e2e_tests:
-          os: linux_node12
+          os: l
           requires:
             - e2e-test

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -33,7 +33,7 @@ install_cli_with_local_codegen: &install_cli
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
-    sudo npm install -g @aws-amplify/cli@amplify-codegen-e2e-tests
+    sudo npm install -g @aws-amplify/cli-internal
     sudo npm install -g amplify-app
     amplify -v
     amplify-app --version

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -236,7 +236,7 @@ workflows:
       - e2e-test:
           context:
             - cleanup-resources
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ workflows:
       - push-codegen-ios-e2e-test:
           context: &ref_8
             - cleanup-resources
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: &ref_9
@@ -472,147 +472,147 @@ workflows:
                 - /tagged-release\/.*/
       - add-codegen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - remove-codegen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - graphql-codegen-ios-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - push-codegen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - datastore-modelgen-flutter-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - feature-flags-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - push-codegen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - datastore-modelgen-ios-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - configure-codegen-ios-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - pull-codegen-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - datastore-modelgen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - configure-codegen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - env-codegen-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - datastore-modelgen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - configure-codegen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - add-codegen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - remove-codegen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - graphql-codegen-android-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - add-codegen-ios-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - remove-codegen-ios-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9
           filters: *ref_10
       - graphql-codegen-js-e2e-test:
           context: *ref_8
-          os: linux_node12
+          os: linux_node15
           requires:
             - publish_to_local_registry
           post-steps: *ref_9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ install_cli_with_local_codegen: &ref_5
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
-    sudo npm install -g @aws-amplify/cli@amplify-codegen-e2e-tests
+    sudo npm install -g @aws-amplify/cli-internal
     sudo npm install -g amplify-app
     amplify -v
     amplify-app --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,34 @@
 # auto generated file. Edit config.base.yaml if you want to change
 version: 2.1
+orbs:
+  aws-ecr: circleci/aws-ecr@6.15.3
 machine:
   environment:
     PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
 executors:
-  linux_node12: &ref_3
-    docker:
-      - image: 'circleci/node:12'
-    resource_class: large
-  linux_node15: &ref_4
-    docker:
-      - image: 'circleci/node:15'
-    resource_class: large
-  windows_node12: &ref_2
+  w: &ref_1
     machine:
       image: 'windows-server-2019-vs2019:stable'
-      resource_class: windows.large
+      resource_class: windows.medium
       shell: bash.exe
-  macos_node12: &ref_1
-    macos:
-      xcode: 13.2.1
-      resource_class: large
+    working_directory: ~/repo
+    environment:
+      AMPLIFY_DIR: 'C:/home/circleci/repo/out'
+      AMPLIFY_PATH: 'C:/home/circleci/repo/out/amplify.exe'
+  l: &ref_2
+    docker:
+      - image: 'public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest'
+    working_directory: ~/repo
+    resource_class: large
+    environment:
+      AMPLIFY_DIR: /home/circleci/repo/out
+      AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
 defaults:
   working_directory: ~/repo
   parameters: &ref_0
     os:
       type: executor
-install_cli_with_local_codegen: &ref_5
+install_cli_with_local_codegen: &ref_3
   name: install Amplify CLI and amplify-app with local Amplify Codegen
   command: |
     source .circleci/local_publish_helpers.sh
@@ -38,7 +40,7 @@ install_cli_with_local_codegen: &ref_5
     amplify-app --version
     unsetNpmRegistryUrl
   working_directory: ~/repo
-clean_up_e2e_resources: &ref_7
+clean_up_e2e_resources: &ref_5
   name: Clean up e2e resources
   command: |
     cd packages/amplify-codegen-e2e-tests
@@ -77,9 +79,6 @@ jobs:
               - equal:
                   - *ref_1
                   - << parameters.os >>
-              - equal:
-                  - *ref_2
-                  - << parameters.os >>
           steps:
             - checkout
             - run: nvm install 12.22.7
@@ -91,10 +90,7 @@ jobs:
           condition:
             or:
               - equal:
-                  - *ref_3
-                  - << parameters.os >>
-              - equal:
-                  - *ref_4
+                  - *ref_2
                   - << parameters.os >>
           steps:
             - attach_workspace:
@@ -158,12 +154,12 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: &ref_6
+    steps: &ref_4
       - attach_workspace:
           at: ./
       - restore_cache:
           key: 'amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}'
-      - run: *ref_5
+      - run: *ref_3
       - run:
           name: Run e2e tests
           command: |
@@ -201,7 +197,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/push-codegen-ios.test.ts
       CLI_REGION: us-east-2
@@ -209,7 +205,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/push-codegen-android.test.ts
       CLI_REGION: us-west-1
@@ -217,7 +213,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/push-codegen-js.test.ts
       CLI_REGION: eu-west-2
@@ -225,7 +221,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/pull-codegen.test.ts
       CLI_REGION: eu-central-1
@@ -233,7 +229,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/env-codegen.test.ts
       CLI_REGION: ap-northeast-1
@@ -241,7 +237,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/add-codegen-js.test.ts
       CLI_REGION: ap-southeast-1
@@ -249,7 +245,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/add-codegen-ios.test.ts
       CLI_REGION: ap-southeast-2
@@ -257,7 +253,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/add-codegen-android.test.ts
       CLI_REGION: us-east-2
@@ -265,7 +261,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-flutter.test.ts
       CLI_REGION: us-west-1
@@ -273,7 +269,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-ios.test.ts
       CLI_REGION: eu-west-2
@@ -281,7 +277,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-android.test.ts
       CLI_REGION: eu-central-1
@@ -289,7 +285,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-js.test.ts
       CLI_REGION: ap-northeast-1
@@ -297,7 +293,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
       CLI_REGION: ap-southeast-1
@@ -305,7 +301,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
       CLI_REGION: ap-southeast-2
@@ -313,7 +309,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
       CLI_REGION: us-east-2
@@ -321,7 +317,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
       CLI_REGION: us-west-1
@@ -329,7 +325,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-ios.test.ts
       CLI_REGION: eu-west-2
@@ -337,7 +333,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-android.test.ts
       CLI_REGION: eu-central-1
@@ -345,7 +341,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-js.test.ts
       CLI_REGION: ap-northeast-1
@@ -353,7 +349,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
       CLI_REGION: ap-southeast-1
@@ -361,7 +357,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
       CLI_REGION: ap-southeast-2
@@ -369,7 +365,7 @@ jobs:
     working_directory: ~/repo
     parameters: *ref_0
     executor: << parameters.os >>
-    steps: *ref_6
+    steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
       CLI_REGION: us-east-2
@@ -386,30 +382,28 @@ workflows:
                 - e2e-testing
     jobs:
       - build:
-          os: linux_node12
+          os: l
       - cleanup_resources:
           context:
             - cleanup-resources
-          os: linux_node12
+          os: l
           requires:
             - build
   build_test_deploy:
     jobs:
       - build:
-          os: linux_node12
+          os: l
       - test:
           name: test-<< matrix.os >>
           matrix:
             parameters:
               os:
-                - linux_node15
-                - linux_node12
-                - windows_node12
-                - macos_node12
+                - l
+                - w
           requires:
             - build
       - publish_to_local_registry:
-          os: linux_node12
+          os: l
           requires:
             - build
           filters:
@@ -419,7 +413,7 @@ workflows:
                 - e2e-testing
                 - /tagged-release\/.*/
       - deploy:
-          os: linux_node12
+          os: l
           requires:
             - build
             - test
@@ -432,7 +426,7 @@ workflows:
                 - /tagged-release\/.*/
                 - /tagged-release-without-e2e-tests\/.*/
       - done_with_node_e2e_tests:
-          os: linux_node12
+          os: l
           requires:
             - push-codegen-ios-e2e-test
             - add-codegen-android-e2e-test
@@ -457,163 +451,163 @@ workflows:
             - remove-codegen-ios-e2e-test
             - graphql-codegen-js-e2e-test
       - push-codegen-ios-e2e-test:
-          context: &ref_8
+          context: &ref_6
             - cleanup-resources
-          os: linux_node15
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: &ref_9
-            - run: *ref_7
-          filters: &ref_10
+          post-steps: &ref_7
+            - run: *ref_5
+          filters: &ref_8
             branches:
               only:
                 - master
                 - e2e-testing
                 - /tagged-release\/.*/
       - add-codegen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - remove-codegen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - graphql-codegen-ios-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - push-codegen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - datastore-modelgen-flutter-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - feature-flags-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - push-codegen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - datastore-modelgen-ios-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - configure-codegen-ios-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - pull-codegen-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - datastore-modelgen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - configure-codegen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - env-codegen-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - datastore-modelgen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - configure-codegen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - add-codegen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - remove-codegen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - graphql-codegen-android-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - add-codegen-ios-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - remove-codegen-ios-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8
       - graphql-codegen-js-e2e-test:
-          context: *ref_8
-          os: linux_node15
+          context: *ref_6
+          os: l
           requires:
             - publish_to_local_registry
-          post-steps: *ref_9
-          filters: *ref_10
+          post-steps: *ref_7
+          filters: *ref_8

--- a/packages/amplify-codegen-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-codegen-e2e-core/src/init/initProjectHelper.ts
@@ -72,7 +72,11 @@ export function initJSProjectWithProfile(cwd: string, settings: Object = {}): Pr
           .sendLine(s.profileName);
       }
 
-      chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
+      chain
+      .wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
+      .sendConfirmYes()
+      .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+      .run((err: Error) => {
         if (err) {
           reject(err);
         } else {
@@ -112,6 +116,8 @@ export function initAndroidProjectWithProfile(cwd: string, settings: Object): Pr
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
+      .wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
+      .sendConfirmYes()
       .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
@@ -153,6 +159,8 @@ export function initIosProjectWithProfile(cwd: string, settings: Object): Promis
       .sendCarriageReturn()
       .wait('Please choose the profile you want to use')
       .sendLine(s.profileName)
+      .wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
+      .sendConfirmYes()
       .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
       .run((err: Error) => {
         if (!err) {
@@ -194,7 +202,11 @@ export function initFlutterProjectWithProfile(cwd: string, settings: Object): Pr
 
     singleSelect(chain, s.region, amplifyRegions);
 
-    chain.wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything').run((err: Error) => {
+    chain
+    .wait('Help improve Amplify CLI by sharing non sensitive configurations on failures')
+    .sendConfirmYes()
+    .wait('Try "amplify add api" to create a backend API and then "amplify push" to deploy everything')
+    .run((err: Error) => {
       if (!err) {
         resolve();
       } else {

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -48,8 +48,8 @@
   "jest": {
     "verbose": false,
     "preset": "ts-jest",
-    "testRunner": "amplify-codegen-e2e-core/runner",
-    "testEnvironment": "amplify-codegen-e2e-core/environment",
+    "testRunner": "@aws-amplify/amplify-codegen-e2e-core/runner",
+    "testEnvironment": "@aws-amplify/amplify-codegen-e2e-core/environment",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -70,7 +70,7 @@
       "default",
       "jest-junit",
       [
-        "amplify-codegen-e2e-core/reporter",
+        "@aws-amplify/amplify-codegen-e2e-core/reporter",
         {
           "publicPath": "./amplify-e2e-reports",
           "filename": "index.html",

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-android.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testAddCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-ios.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testAddCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
@@ -6,7 +6,7 @@ import {
     createRandomName,
     addApiWithoutSchema,
     updateApiSchema
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-android.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testConfigureCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-ios.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testConfigureCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/configure-codegen-js.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_JS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_JS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testConfigureCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_JS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_JS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/env-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/env-codegen.test.ts
@@ -7,7 +7,7 @@ import {
   generateModels,
   addApiWithoutSchema,
   updateApiSchema
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { addEnvironment, checkoutEnvironment } from "../environment/env";
 const schema = 'simple_model.graphql';
 const schemaWithError = 'modelgen/model_gen_schema_with_errors.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-android.test.ts
@@ -1,7 +1,7 @@
 import { 
     createNewProjectDir,
     DEFAULT_ANDROID_CONFIG,
-  } from "amplify-codegen-e2e-core";
+  } from "@aws-amplify/amplify-codegen-e2e-core";
   import { deleteAmplifyProject, testGraphQLCodegen } from '../codegen-tests-base';
   
   const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-ios.test.ts
@@ -1,7 +1,7 @@
 import { 
     createNewProjectDir,
     DEFAULT_IOS_CONFIG,
-  } from "amplify-codegen-e2e-core";
+  } from "@aws-amplify/amplify-codegen-e2e-core";
   import { deleteAmplifyProject, testGraphQLCodegen } from '../codegen-tests-base';
   
   const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/graphql-codegen-js.test.ts
@@ -1,7 +1,7 @@
 import { 
     createNewProjectDir,
     DEFAULT_JS_CONFIG,
-  } from "amplify-codegen-e2e-core";
+  } from "@aws-amplify/amplify-codegen-e2e-core";
   import { deleteAmplifyProject, testGraphQLCodegen } from '../codegen-tests-base';
   
   const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
@@ -17,7 +17,7 @@ import {
   getAdminApp,
   amplifyPullSandbox,
   getProjectSchema
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-android.test.ts
@@ -1,7 +1,7 @@
 import { 
     createNewProjectDir,
     DEFAULT_ANDROID_CONFIG
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testPushCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-ios.test.ts
@@ -1,7 +1,7 @@
 import { 
     createNewProjectDir,
     DEFAULT_IOS_CONFIG
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testPushCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-js.test.ts
@@ -1,7 +1,7 @@
 import { 
   createNewProjectDir,
   DEFAULT_JS_CONFIG
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testPushCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-android.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testRemoveCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-ios.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testRemoveCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/remove-codegen-js.test.ts
@@ -6,7 +6,7 @@ import {
     addApiWithoutSchema,
     updateApiSchema,
     createRandomName
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { deleteAmplifyProject, testRemoveCodegen } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/add-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/add-codegen.ts
@@ -5,7 +5,7 @@ import {
     addCodegen,
     AmplifyFrontendConfig,
     createRandomName
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/configure-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/configure-codegen.ts
@@ -6,7 +6,7 @@ import {
     configureCodegen,
     AmplifyFrontendConfig,
     createRandomName
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync, readFileSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -5,7 +5,7 @@ import {
     createRandomName,
     generateModels,
     AmplifyFrontendConfig
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/graphql-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/graphql-codegen.ts
@@ -6,7 +6,7 @@ import {
     AmplifyFrontendConfig,
     generateStatementsAndTypes,
     createRandomName
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
@@ -7,7 +7,7 @@ import {
     AmplifyFrontendConfig,
     amplifyPushWithCodegenUpdate,
     updateAPIWithResolutionStrategyWithModels
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/remove-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/remove-codegen.ts
@@ -6,7 +6,7 @@ import {
     addCodegen,
     removeCodegen,
     AmplifyFrontendConfig
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync, readFileSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/test-setup.ts
@@ -4,7 +4,7 @@ import {
     AmplifyFrontendConfig,
     getAdminApp,
     constructGraphQLConfig
-} from "amplify-codegen-e2e-core";
+} from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync, readFileSync } from "fs";
 import path from 'path';
 import { generateSourceCode } from '../utils';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Update the e2e tests to use cli internal package
- Use aws ecr docker of amplify cli as executor to avoid node engine error during build time
- Fixed the import for `@aws-amplify/amplify-codegen-e2e-core`

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/master/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.