### PR TITLE
chore: remove unused dependencies based on depcheck report

### DIFF
--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -32,8 +32,6 @@
     "fs-extra": "^8.1.0",
     "graphql-tag": "^2.10.1",
     "lodash": "^4.17.19",
-    "promise-sequential": "^1.1.1",
-    "rimraf": "^3.0.0",
     "uuid": "^3.4.0",
     "yargs": "^15.1.0"
   },

--- a/packages/graphql-docs-generator/package.json
+++ b/packages/graphql-docs-generator/package.json
@@ -32,7 +32,6 @@
     "clean": "rimraf ./lib"
   },
   "dependencies": {
-    "change-case": "^4.1.1",
     "graphql": "^14.5.8",
     "handlebars": "4.7.7",
     "prettier": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12961,11 +12961,6 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-promise-sequential@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/promise-sequential/-/promise-sequential-1.1.1.tgz#f79e8950ef86e7a7a85bf320452643592f6d2fb2"
-  integrity sha512-gpziThEJPnPEeaHNqjy9f4PE1JwXb07fX3dz+41nhALpIAaEI9VZU8Q89eyBBAa2xAhnz0KgUTDtCA7FZYbZQQ==
-
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
#### Description of changes
remove unused dependencies based on depcheck report. Generated per-package by installing depcheck via `npm i -g depcheck` and executing `lerna exec --no-bail -- depcheck --json \>\> ./depcheck.json` to generate a report, then investigating the packages in `dependencies`, and `dev-dependencies`. There were some false positives, we identified a few packages that could be cleaned up.

Codegen PR: https://github.com/aws-amplify/amplify-codegen/pull/450
API Category PR: https://github.com/aws-amplify/amplify-category-api/pull/610
CLI PR: https://github.com/aws-amplify/amplify-cli/pull/10666

#### Issue #, if available
N/A

#### Description of how you validated changes
Built and ran unit tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.