### PR TITLE
fix: change pk naming in manyToMany models

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -922,12 +922,12 @@ describe('AppSyncModelVisitor', () => {
   describe('manyToMany with sort key testing', () => {
     const schema = /* GraphQL */ `
       type ModelA @model {
-        id: ID! @primaryKey(sortKeyFields: ["sortId"])
+        customId: ID! @primaryKey(sortKeyFields: ["sortId"])
         sortId: ID!
         models: [ModelB] @manyToMany(relationName: "ModelAModelB")
       }
       type ModelB @model {
-        id: ID! @primaryKey(sortKeyFields: ["sortId"])
+        customId: ID! @primaryKey(sortKeyFields: ["sortId"])
         sortId: ID!
         models: [ModelA] @manyToMany(relationName: "ModelAModelB")
       }
@@ -948,28 +948,28 @@ describe('AppSyncModelVisitor', () => {
       expect(modelBSortKeyField.isNullable).toBe(false);
       const modelAIndexDirective = ModelAModelB.directives.find(d => d.name === 'key' && d.arguments.name === 'byModelA');
       expect(modelAIndexDirective).toBeDefined();
-      expect(modelAIndexDirective.arguments.fields).toEqual(['modelAID', 'modelAsortId']);
+      expect(modelAIndexDirective.arguments.fields).toEqual(['modelACustomId', 'modelAsortId']);
       const modelBIndexDirective = ModelAModelB.directives.find(d => d.name === 'key' && d.arguments.name === 'byModelB');
       expect(modelBIndexDirective).toBeDefined();
-      expect(modelBIndexDirective.arguments.fields).toEqual(['modelBID', 'modelBsortId']);
+      expect(modelBIndexDirective.arguments.fields).toEqual(['modelBCustomId', 'modelBsortId']);
       const modelABelongsToDirective = ModelAModelB.fields.find(f => f.name === 'modelA')!.directives.find(d => d.name === 'belongsTo');
       expect(modelABelongsToDirective).toBeDefined();
-      expect(modelABelongsToDirective.arguments.fields).toEqual(['modelAID', 'modelAsortId']);
+      expect(modelABelongsToDirective.arguments.fields).toEqual(['modelACustomId', 'modelAsortId']);
       const modelBBelongsToDirective = ModelAModelB.fields.find(f => f.name === 'modelB')!.directives.find(d => d.name === 'belongsTo');
       expect(modelBBelongsToDirective).toBeDefined();
-      expect(modelBBelongsToDirective.arguments.fields).toEqual(['modelBID', 'modelBsortId']);
+      expect(modelBBelongsToDirective.arguments.fields).toEqual(['modelBCustomId', 'modelBsortId']);
     });
     it('should generate correct hasMany fields for original models', () => {
       expect(ModelA).toBeDefined();
       const modelAHasManyDirective = ModelA.fields.find(f => f.name === 'models')!.directives.find(d => d.name === 'hasMany');
       expect(modelAHasManyDirective).toBeDefined();
       expect(modelAHasManyDirective.arguments.indexName).toEqual('byModelA');
-      expect(modelAHasManyDirective.arguments.fields).toEqual(['id', 'sortId']);
+      expect(modelAHasManyDirective.arguments.fields).toEqual(['customId', 'sortId']);
       expect(ModelB).toBeDefined();
       const modelBHasManyDirective = ModelB.fields.find(f => f.name === 'models')!.directives.find(d => d.name === 'hasMany');
       expect(modelBHasManyDirective).toBeDefined();
       expect(modelBHasManyDirective.arguments.indexName).toEqual('byModelB');
-      expect(modelBHasManyDirective.arguments.fields).toEqual(['id', 'sortId']);
+      expect(modelBHasManyDirective.arguments.fields).toEqual(['customId', 'sortId']);
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Change the naming for model PK in manyToMany models:
- from `${model_name}ID` to `${model_name}${model_primary_key_field_name}` in camelCase

This change is behind the feature flag `respectPrimaryKeyAttributesOnConnectionField`
#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
CLI PR: https://github.com/aws-amplify/amplify-category-api/pull/660


#### Description of how you validated changes
`yarn test`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.