### PR TITLE
fix(modelgen-js): use optional fields for FK in manyToMany

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -114,3 +114,58 @@ export declare class Team {
   static copyOf(source: Team, mutator: (draft: MutableModel<Team>) => MutableModel<Team> | void): Team;
 }"
 `;
+
+exports[`Javascript visitor with connected models of custom pk manyToMany relation should generate correct declaration for manyToMany model when custom pk is enabled 1`] = `
+"import { ModelInit, MutableModel, __modelMeta__, CompositeIdentifier, ManagedIdentifier } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+export declare class Post {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Post, ['customPostId', 'title']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly customPostId: string;
+  readonly title: string;
+  readonly content?: string | null;
+  readonly tags?: (PostTags | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  constructor(init: ModelInit<Post>);
+  static copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+}
+
+export declare class Tag {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Tag, ['customTagId', 'label']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly customTagId: string;
+  readonly label: string;
+  readonly posts?: (PostTags | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  constructor(init: ModelInit<Tag>);
+  static copyOf(source: Tag, mutator: (draft: MutableModel<Tag>) => MutableModel<Tag> | void): Tag;
+}
+
+export declare class PostTags {
+  readonly [__modelMeta__]: {
+    identifier: ManagedIdentifier<PostTags, 'id'>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly postCustomPostId?: string | null;
+  readonly posttitle?: string | null;
+  readonly tagCustomTagId?: string | null;
+  readonly taglabel?: string | null;
+  readonly post: Post;
+  readonly tag: Tag;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  constructor(init: ModelInit<PostTags>);
+  static copyOf(source: PostTags, mutator: (draft: MutableModel<PostTags>) => MutableModel<PostTags> | void): PostTags;
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -885,4 +885,30 @@ describe('Javascript visitor with connected models of custom pk', () => {
       expect(declarations).toMatchSnapshot();
     });
   });
+  describe('manyToMany relation', () => {
+    it('should generate correct declaration for manyToMany model when custom pk is enabled', () => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          customPostId: ID! @primaryKey(sortKeyFields: ["title"])
+          title: String!
+          content: String
+          tags: [Tag] @manyToMany(relationName: "PostTags")
+        }
+        type Tag @model {
+          customTagId: ID! @primaryKey(sortKeyFields: ["label"])
+          label: String!
+          posts: [Post] @manyToMany(relationName: "PostTags")
+        }
+      `;
+      const visitor = getVisitor(schema, {
+        isDeclaration: true,
+        isTimestampFieldsAdded: true,
+        respectPrimaryKeyAttributesOnConnectionField: true,
+        transformerVersion: 2,
+      });
+      const declarations = visitor.generate();
+      validateTs(declarations);
+      expect(declarations).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -953,11 +953,11 @@ describe('AppSyncModelVisitor', () => {
       const modelASortKeyField = ModelAModelB.fields.find(f => f.name === 'modelAsortId')!;
       expect(modelASortKeyField).toBeDefined();
       expect(modelASortKeyField.type).toEqual('ID');
-      expect(modelASortKeyField.isNullable).toBe(false);
+      expect(modelASortKeyField.isNullable).toBe(true);
       const modelBSortKeyField = ModelAModelB.fields.find(f => f.name === 'modelBsortId')!;
       expect(modelBSortKeyField).toBeDefined();
       expect(modelBSortKeyField.type).toEqual('ID');
-      expect(modelBSortKeyField.isNullable).toBe(false);
+      expect(modelBSortKeyField.isNullable).toBe(true);
       const modelAIndexDirective = ModelAModelB.directives.find(d => d.name === 'key' && d.arguments.name === 'byModelA')!;
       expect(modelAIndexDirective).toBeDefined();
       expect(modelAIndexDirective.arguments.fields).toEqual(['modelACustomId', 'modelAsortId']);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -682,7 +682,7 @@ export class AppSyncModelVisitor<
         },
         {
           type: 'ID',
-          isNullable: false,
+          isNullable: true,
           isList: false,
           name: firstModelKeyFieldName,
           directives: [
@@ -698,7 +698,7 @@ export class AppSyncModelVisitor<
         ...firstModelSortKeyFields.map(field => {
           return {
             type: field.type,
-            isNullable: false,
+            isNullable: true,
             isList: field.isList,
             name: this.generateIntermediateModelSortKeyFieldName(firstModel, field),
             directives: [],
@@ -706,7 +706,7 @@ export class AppSyncModelVisitor<
         }),
         {
           type: 'ID',
-          isNullable: false,
+          isNullable: true,
           isList: false,
           name: secondModelKeyFieldName,
           directives: [
@@ -722,7 +722,7 @@ export class AppSyncModelVisitor<
         ...secondModelSortKeyFields.map(field => {
           return {
             type: field.type,
-            isNullable: false,
+            isNullable: true,
             isList: field.isList,
             name: this.generateIntermediateModelSortKeyFieldName(secondModel, field),
             directives: [],


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use optional fields for manyToMany foreign key fields. This only has impact on the JS modelgen since in native platforms FK fields are always removed.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.