### PR TITLE
fix(amplify-codegen): iOS use default when PK.OptionallyManagedId

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -417,14 +417,8 @@ extension ModelExplicitDefaultPk {
 }
 
 extension ModelExplicitDefaultPk: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
-}
-
-extension ModelExplicitDefaultPk.IdentifierProtocol {
-  public static func identifier(id: String) -> Self {
-    .make(fields:[(name: \\"id\\", value: id)])
-  }
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }"
 `;
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -320,7 +320,8 @@ export class AppSyncSwiftVisitor<
     let result: string[] = [];
     const primaryKeyField = model.fields.find(field => field.primaryKeyInfo)!;
     const { primaryKeyType, sortKeyFields } = primaryKeyField.primaryKeyInfo!;
-    const useDefaultExplicitID = primaryKeyType === CodeGenPrimaryKeyType.ManagedId;
+    const useDefaultExplicitID =
+      primaryKeyType === CodeGenPrimaryKeyType.ManagedId || primaryKeyType === CodeGenPrimaryKeyType.OptionallyManagedId;
 
     const identifiableExtension = new SwiftDeclarationBlock()
       .asKind('extension')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

For the schema:
```
type ModelExplicitDefaultPk @model {
   id: ID! @primaryKey
   name: String
 }
```
Improve the DX by using the default IdentifierFormat and IdentifierProtocol for when the identifier is explicitly declared as the primary key that's simply named "id". 

The DX before this change:

```swift
Amplify.DataStore.query(ModelExplicitDefaultPk.self,
                                byIdentifier: .identifier(id: model.id)) { result in

Amplify.DataStore.delete(ModelExplicitDefaultPk.self,
                                 withIdentifier: .identifier(id: model.id)) { result in 
```

DX after this change:
```swift
Amplify.DataStore.query(ModelExplicitDefaultPk.self,
                                byIdentifier: model.id) { result in

Amplify.DataStore.delete(ModelExplicitDefaultPk.self,
                                 withIdentifier: model.id) { result in 
```

#### Description of how you validated changes
`yarn test` and `yarn setup-dev` and then `amplify-dev codegen models` in my sample app. Verifed that my models that have `id` as the primary key also have the Default IdentifierFormat/Protocol. 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.