### PR TITLE
Release Amplify Codegen v3.0.5

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -417,14 +417,8 @@ extension ModelExplicitDefaultPk {
 }
 
 extension ModelExplicitDefaultPk: ModelIdentifiable {
-  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
-}
-
-extension ModelExplicitDefaultPk.IdentifierProtocol {
-  public static func identifier(id: String) -> Self {
-    .make(fields:[(name: \\"id\\", value: id)])
-  }
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }"
 `;
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -82,10 +82,10 @@ extension Post {
 
 extension Post: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension Post.Identifier {
+extension Post.IdentifierProtocol {
   public static func identifier(id: String,
       title: String) -> Self {
     .make(fields:[(name: \\"id\\", value: id), (name: \\"title\\", value: title)])
@@ -175,10 +175,10 @@ extension Comment {
 
 extension Comment: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension Comment.Identifier {
+extension Comment.IdentifierProtocol {
   public static func identifier(id: String,
       content: String) -> Self {
     .make(fields:[(name: \\"id\\", value: id), (name: \\"content\\", value: content)])
@@ -261,10 +261,10 @@ extension ModelCompositePk {
 
 extension ModelCompositePk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelCompositePk.Identifier {
+extension ModelCompositePk.IdentifierProtocol {
   public static func identifier(id: String,
       dob: Temporal.DateTime) -> Self {
     .make(fields:[(name: \\"id\\", value: id), (name: \\"dob\\", value: dob)])
@@ -340,10 +340,10 @@ extension ModelExplicitCustomPk {
 
 extension ModelExplicitCustomPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelExplicitCustomPk.Identifier {
+extension ModelExplicitCustomPk.IdentifierProtocol {
   public static func identifier(userId: String) -> Self {
     .make(fields:[(name: \\"userId\\", value: userId)])
   }
@@ -418,10 +418,10 @@ extension ModelExplicitDefaultPk {
 
 extension ModelExplicitDefaultPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension ModelExplicitDefaultPk.Identifier {
+extension ModelExplicitDefaultPk.IdentifierProtocol {
   public static func identifier(id: String) -> Self {
     .make(fields:[(name: \\"id\\", value: id)])
   }
@@ -495,7 +495,7 @@ extension ModelImplicitDefaultPk {
 
 extension ModelImplicitDefaultPk: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Default
-  public typealias Identifier = DefaultModelIdentifier<Self>
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }"
 `;
 
@@ -588,10 +588,10 @@ extension Project {
 
 extension Project: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension Project.Identifier {
+extension Project.IdentifierProtocol {
   public static func identifier(projectId: String,
       name: String) -> Self {
     .make(fields:[(name: \\"projectId\\", value: projectId), (name: \\"name\\", value: name)])
@@ -674,10 +674,10 @@ extension Team {
 
 extension Team: ModelIdentifiable {
   public typealias IdentifierFormat = ModelIdentifierFormat.Custom
-  public typealias Identifier = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
 }
 
-extension Team.Identifier {
+extension Team.IdentifierProtocol {
   public static func identifier(teamId: String,
       name: String) -> Self {
     .make(fields:[(name: \\"teamId\\", value: teamId), (name: \\"name\\", value: name)])

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -320,7 +320,8 @@ export class AppSyncSwiftVisitor<
     let result: string[] = [];
     const primaryKeyField = model.fields.find(field => field.primaryKeyInfo)!;
     const { primaryKeyType, sortKeyFields } = primaryKeyField.primaryKeyInfo!;
-    const useDefaultExplicitID = primaryKeyType === CodeGenPrimaryKeyType.ManagedId;
+    const useDefaultExplicitID =
+      primaryKeyType === CodeGenPrimaryKeyType.ManagedId || primaryKeyType === CodeGenPrimaryKeyType.OptionallyManagedId;
 
     const identifiableExtension = new SwiftDeclarationBlock()
       .asKind('extension')

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -292,7 +292,7 @@ export class AppSyncSwiftVisitor<
     const authRules = this.generateAuthRules(model);
     const keyDirectives = this.config.generateIndexRules ? this.generateKeyRules(model) : [];
     const priamryKeyRules = this.generatePrimaryKeyRules(model);
-    const attributes = [ ...keyDirectives, priamryKeyRules ].filter(f => f);
+    const attributes = [...keyDirectives, priamryKeyRules].filter(f => f);
     const closure = [
       '{ model in',
       `let ${keysName} = ${this.getModelName(model)}.keys`,
@@ -322,20 +322,31 @@ export class AppSyncSwiftVisitor<
     const { primaryKeyType, sortKeyFields } = primaryKeyField.primaryKeyInfo!;
     const useDefaultExplicitID = primaryKeyType === CodeGenPrimaryKeyType.ManagedId;
 
-    const identifiableExtension = new SwiftDeclarationBlock().asKind('extension').withName(`${this.getModelName(model)}: ModelIdentifiable`);
+    const identifiableExtension = new SwiftDeclarationBlock()
+      .asKind('extension')
+      .withName(`${this.getModelName(model)}: ModelIdentifiable`);
     // identifier format
     const identifierFormatValue = `ModelIdentifierFormat.${useDefaultExplicitID ? 'Default' : 'Custom'}`;
     identifiableExtension.addProperty('IdentifierFormat', '', identifierFormatValue, 'public', { isTypeAlias: true });
     // identifier
     const identifierValue = useDefaultExplicitID ? 'DefaultModelIdentifier<Self>' : 'ModelIdentifier<Self, ModelIdentifierFormat.Custom>';
-    identifiableExtension.addProperty('Identifier', '', identifierValue, 'public', { isTypeAlias: true });
+    identifiableExtension.addProperty('IdentifierProtocol', '', identifierValue, 'public', { isTypeAlias: true });
     result.push(identifiableExtension.string);
 
     if (!useDefaultExplicitID) {
-      const identifierExtension = new SwiftDeclarationBlock().asKind('extension').withName(`${this.getModelName(model)}.Identifier`);
-      const primaryKeyComponentFields = [ primaryKeyField, ...sortKeyFields ];
-      const identifierArgs = primaryKeyComponentFields.map(field => ({name: this.getFieldName(field), type: this.getNativeType(field), flags: {}, value: undefined}));
-      const identifierBody = `.make(fields:[${primaryKeyComponentFields.map(field => `(name: "${this.getFieldName(field)}", value: ${this.getFieldName(field)})`).join(', ')}])`;
+      const identifierExtension = new SwiftDeclarationBlock()
+        .asKind('extension')
+        .withName(`${this.getModelName(model)}.IdentifierProtocol`);
+      const primaryKeyComponentFields = [primaryKeyField, ...sortKeyFields];
+      const identifierArgs = primaryKeyComponentFields.map(field => ({
+        name: this.getFieldName(field),
+        type: this.getNativeType(field),
+        flags: {},
+        value: undefined,
+      }));
+      const identifierBody = `.make(fields:[${primaryKeyComponentFields
+        .map(field => `(name: "${this.getFieldName(field)}", value: ${this.getFieldName(field)})`)
+        .join(', ')}])`;
       identifierExtension.addClassMethod('identifier', 'Self', identifierBody, identifierArgs, 'public', { static: true });
       result.push(identifierExtension.string);
     }
@@ -404,8 +415,8 @@ export class AppSyncSwiftVisitor<
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
         return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-          )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
-        }
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+      }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
         const targetNameAttrStr = this.isCustomPKEnabled()
           ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
@@ -505,7 +516,9 @@ export class AppSyncSwiftVisitor<
     const primaryKeyField = model.fields.find(f => f.primaryKeyInfo)!;
     const { sortKeyFields } = primaryKeyField.primaryKeyInfo!;
     const modelName = lowerCaseFirst(this.getModelName(model));
-    return `.primaryKey(fields: [${[primaryKeyField, ...sortKeyFields].map(field => `${modelName}.${this.getFieldName(field)}`).join(', ')}])`
+    return `.primaryKey(fields: [${[primaryKeyField, ...sortKeyFields]
+      .map(field => `${modelName}.${this.getFieldName(field)}`)
+      .join(', ')}])`;
   }
 
   protected isHasManyConnectionField(field: CodeGenField): boolean {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Patch for iOS modelgen of CPK feature:

- Renamed `ModelIdentifiable.Identifier` to `IdentifierProtocol`
- iOS now treats `id: ID @primaryKey` as the default managed ID

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.