### PR TITLE
feat: wip implementation of model introspection schema generator

### DIFF
--- a/packages/amplify-codegen/amplify-plugin.json
+++ b/packages/amplify-codegen/amplify-plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codegen",
   "type": "util",
-  "commands": ["add", "codegen", "configure", "remove", "statements", "types", "models"],
+  "commands": ["add", "codegen", "configure", "remove", "statements", "types", "models", "introspection"],
   "commandAliases": {
     "update": "configure",
     "statement": "statements",

--- a/packages/amplify-codegen/commands/codegen/introspection.js
+++ b/packages/amplify-codegen/commands/codegen/introspection.js
@@ -1,0 +1,24 @@
+const codeGen = require('../../src');
+const { exitOnNextTick } = require('amplify-cli-core');
+var path = require('path');
+
+module.exports = {
+  name: 'introspection',
+  run: async context => {
+    try {
+      // Verify override path flag is provided
+      const outputFileParam = context.input.options ? context.input.options['output-file'] : null;
+      if (!outputFileParam) {
+        throw new Error('Expected --output-file flag to be set for introspection command.');
+      }
+
+      const outputFilePath = path.isAbsolute(outputFileParam) ? outputFileParam : path.join(context.amplify.getEnvInfo().projectPath, outputFileParam);
+      await codeGen.generateModels(context, { generateIntrospectionSchema: true, outputFilePath });
+    } catch (ex) {
+      context.print.info(ex.message);
+      console.log(ex.stack);
+      await context.usageData.emitError(ex);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -44,7 +44,12 @@ const readNumericFeatureFlag = key => {
   }
 };
 
-async function generateModels(context) {
+const defaultGenerateOptions = {
+  generateIntrospectionSchema: false,
+  outputFilePath: null,
+};
+
+async function generateModels(context, generateOptions = defaultGenerateOptions) {
   // steps:
   // 1. Load the schema and validate using transformer
   // 2. get all the directives supported by transformer
@@ -116,7 +121,7 @@ async function generateModels(context) {
     baseOutputDir: outputPath,
     schema,
     config: {
-      target: platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend,
+      target: generateOptions.generateIntrospectionSchema ? 'model-introspection' : platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend,
       directives: directiveDefinitions,
       isTimestampFieldsAdded,
       emitAuthProvider,
@@ -128,6 +133,7 @@ async function generateModels(context) {
       transformerVersion,
       dartUpdateAmplifyCoreDependency,
       respectPrimaryKeyAttributesOnConnectionField,
+      outputFilePath: generateOptions.outputFilePath,
     },
   });
 

--- a/packages/appsync-modelgen-plugin/resources/ModelIntrospection.schema.json
+++ b/packages/appsync-modelgen-plugin/resources/ModelIntrospection.schema.json
@@ -1,0 +1,1058 @@
+{
+  "type": "object",
+  "properties": {
+    "models": {
+      "type": "object",
+      "properties": {
+        "Blog": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "fields": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "author": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "title": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "posts": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "object",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "model"
+                      ]
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isArrayNullable": {
+                      "type": "boolean"
+                    },
+                    "association": {
+                      "type": "object",
+                      "properties": {
+                        "connectionType": {
+                          "type": "string"
+                        },
+                        "associatedWith": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "connectionType",
+                        "associatedWith"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isArrayNullable",
+                    "association"
+                  ]
+                },
+                "createdAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                },
+                "updatedAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "author",
+                "title",
+                "posts",
+                "createdAt",
+                "updatedAt"
+              ]
+            },
+            "syncable": {
+              "type": "boolean"
+            },
+            "pluralName": {
+              "type": "string"
+            },
+            "attributes": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "rules"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "fields",
+            "syncable",
+            "pluralName",
+            "attributes"
+          ]
+        },
+        "Post": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "fields": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "title": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "content": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "createdAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                },
+                "updatedAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                },
+                "blogPostsId": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "title",
+                "content",
+                "createdAt",
+                "updatedAt",
+                "blogPostsId"
+              ]
+            },
+            "syncable": {
+              "type": "boolean"
+            },
+            "pluralName": {
+              "type": "string"
+            },
+            "attributes": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "rules"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "fields",
+            "syncable",
+            "pluralName",
+            "attributes"
+          ]
+        },
+        "Todo": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "fields": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "content": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes"
+                  ]
+                },
+                "createdAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                },
+                "updatedAt": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "isArray": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "isRequired": {
+                      "type": "boolean"
+                    },
+                    "attributes": {
+                      "type": "array",
+                      "items": {}
+                    },
+                    "isReadOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "isArray",
+                    "type",
+                    "isRequired",
+                    "attributes",
+                    "isReadOnly"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "content",
+                "createdAt",
+                "updatedAt"
+              ]
+            },
+            "syncable": {
+              "type": "boolean"
+            },
+            "pluralName": {
+              "type": "string"
+            },
+            "attributes": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "allow": {
+                                  "type": "string"
+                                },
+                                "operations": {
+                                  "type": "array",
+                                  "items": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "provider",
+                                "allow",
+                                "operations"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "rules"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "properties"
+                  ]
+                }
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "fields",
+            "syncable",
+            "pluralName",
+            "attributes"
+          ]
+        }
+      },
+      "required": [
+        "Blog",
+        "Post",
+        "Todo"
+      ]
+    },
+    "enums": {
+      "type": "object"
+    },
+    "nonModels": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "models",
+    "enums",
+    "nonModels"
+  ]
+}

--- a/packages/appsync-modelgen-plugin/src/plugin.ts
+++ b/packages/appsync-modelgen-plugin/src/plugin.ts
@@ -8,6 +8,8 @@ import { AppSyncModelJavaVisitor } from './visitors/appsync-java-visitor';
 import { AppSyncModelTypeScriptVisitor } from './visitors/appsync-typescript-visitor';
 import { AppSyncModelJavascriptVisitor } from './visitors/appsync-javascript-visitor';
 import { AppSyncModelDartVisitor } from './visitors/appsync-dart-visitor';
+import { AppSyncModelIntrospectionVisitor } from './visitors/appsync-model-introspection-visitor';
+
 export const plugin: PluginFunction<RawAppSyncModelConfig> = (
   schema: GraphQLSchema,
   rawDocuments: Types.DocumentFile[],
@@ -35,6 +37,9 @@ export const plugin: PluginFunction<RawAppSyncModelConfig> = (
       break;
     case 'javascript':
       visitor = new AppSyncModelJavascriptVisitor(schema, config, {});
+      break;
+    case 'model-introspection':
+      visitor = new AppSyncModelIntrospectionVisitor(schema, config, {});
       break;
     case 'dart':
       visitor = new AppSyncModelDartVisitor(schema, config, {

--- a/packages/appsync-modelgen-plugin/src/preset.ts
+++ b/packages/appsync-modelgen-plugin/src/preset.ts
@@ -188,6 +188,24 @@ const generateJavasScriptPreset = (
   return config;
 };
 
+const generateModelIntrospectionPreset = (
+  options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): Types.GenerateOptions[] => {
+  const config: Types.GenerateOptions[] = [];
+  const defaultOutputPath = join(options.baseOutputDir, 'models', 'model-introspection.json');
+  config.push({
+    ...options,
+    filename: options.config.outputFilePath ? options.config.outputFilePath : defaultOutputPath,
+    config: {
+      ...options.config,
+      scalars: { ...TYPESCRIPT_SCALAR_MAP, ...options.config.scalars },
+      target: 'model-introspection',
+    },
+  });
+  return config;
+};
+
 const generateDartPreset = (
   options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
   models: TypeDefinitionNode[],
@@ -270,6 +288,8 @@ export const preset: Types.OutputPreset<AppSyncModelCodeGenPresetConfig> = {
         return generateJavasScriptPreset(options, models);
       case 'typescript':
         return generateTypeScriptPreset(options, models);
+      case 'model-introspection':
+        return generateModelIntrospectionPreset(options, models);
       case 'dart':
         return generateDartPreset(options, models);
       default:

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -1,0 +1,253 @@
+import { DEFAULT_SCALARS, NormalizedScalarsMap } from '@graphql-codegen/visitor-plugin-common';
+import { GraphQLSchema } from 'graphql';
+import { CodeGenConnectionType } from '../utils/process-connections';
+import {
+  AppSyncModelVisitor,
+  CodeGenField,
+  CodeGenModel,
+  ParsedAppSyncModelConfig,
+  RawAppSyncModelConfig,
+  CodeGenEnum,
+} from './appsync-visitor';
+import { METADATA_SCALAR_MAP } from '../scalars';
+import Ajv from 'ajv';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export type JSONSchema = {
+  models: JSONSchemaModels;
+  enums: JSONSchemaEnums;
+  nonModels: JSONSchemaTypes;
+  version: string;
+};
+
+export type JSONSchemaModels = Record<string, JSONSchemaModel>;
+
+export type JSONSchemaTypes = Record<string, JSONSchemaNonModel>;
+
+export type JSONSchemaNonModel = {
+  name: string;
+  fields: JSONModelFields;
+};
+
+type JSONSchemaModel = {
+  name: string;
+  attributes?: JSONModelAttributes;
+  fields: JSONModelFields;
+  pluralName: String;
+  syncable?: boolean;
+};
+
+type JSONSchemaEnums = Record<string, JSONSchemaEnum>;
+
+type JSONSchemaEnum = {
+  name: string;
+  values: string[];
+};
+
+type JSONModelAttributes = JSONModelAttribute[];
+
+type JSONModelAttribute = { type: string; properties?: Record<string, any> };
+
+type JSONModelFields = Record<string, JSONModelField>;
+
+type AssociationBaseType = {
+  connectionType: CodeGenConnectionType;
+};
+
+export type AssociationHasMany = AssociationBaseType & {
+  connectionType: CodeGenConnectionType.HAS_MANY;
+  associatedWith: string;
+};
+
+type AssociationHasOne = AssociationHasMany & {
+  connectionType: CodeGenConnectionType.HAS_ONE;
+  targetName: string;
+};
+
+type AssociationBelongsTo = AssociationBaseType & {
+  targetName: string;
+};
+
+type AssociationType = AssociationHasMany | AssociationHasOne | AssociationBelongsTo;
+
+type JSONModelFieldType = keyof typeof METADATA_SCALAR_MAP | { model: string } | { enum: string } | { nonModel: string };
+
+type JSONModelField = {
+  name: string;
+  type: JSONModelFieldType;
+  isArray: boolean;
+  isRequired?: boolean;
+  isArrayNullable?: boolean;
+  isReadOnly?: boolean;
+  attributes?: JSONModelFieldAttributes;
+  association?: AssociationType;
+};
+
+type JSONModelFieldAttributes = JSONModelFieldAttribute[];
+
+type JSONModelFieldAttribute = JSONModelAttribute;
+
+export interface RawAppSyncModelMetadataConfig extends RawAppSyncModelConfig {}
+
+export interface ParsedAppSyncModelMetadataConfig extends ParsedAppSyncModelConfig {
+  metadataTarget: string;
+}
+
+export class AppSyncModelIntrospectionVisitor<
+  TRawConfig extends RawAppSyncModelMetadataConfig = RawAppSyncModelMetadataConfig,
+  TPluginConfig extends ParsedAppSyncModelMetadataConfig = ParsedAppSyncModelMetadataConfig
+> extends AppSyncModelVisitor<TRawConfig, TPluginConfig> {
+  schemaValidator: Ajv.ValidateFunction;
+
+  constructor(
+    schema: GraphQLSchema,
+    rawConfig: TRawConfig,
+    additionalConfig: Partial<TPluginConfig>,
+    defaultScalars: NormalizedScalarsMap = DEFAULT_SCALARS,
+  ) {
+    super(schema, rawConfig, additionalConfig, defaultScalars);
+
+    const modelIntrospectionSchemaText = fs.readFileSync(path.join(__dirname, '..', '..', 'resources', 'ModelIntrospection.schema.json'), 'utf8');
+    const modelIntrospectionSchema = JSON.parse(modelIntrospectionSchemaText);
+    this.schemaValidator = new Ajv().compile(modelIntrospectionSchema); // options can be passed, e.g. {allErrors: true}
+  }
+
+  generate(): string {
+    // TODO: Remove us, leaving in to be explicit on why this flag is here.
+    const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
+    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    const modelIntrospectionSchema = this.generateModelIntrospection();
+
+    // Validate
+    const valid = this.schemaValidator(modelIntrospectionSchema)
+    if (!valid) {
+      console.log(this.schemaValidator.errors);
+    }
+
+    // Return
+    return JSON.stringify(modelIntrospectionSchema, null, 4);
+  }
+
+  protected generateModelIntrospection(): JSONSchema {
+    const result: JSONSchema = {
+      models: {},
+      enums: {},
+      nonModels: {},
+      version: this.computeVersion(),
+    };
+
+    const models = Object.values(this.getSelectedModels()).reduce((acc, model: CodeGenModel) => {
+      return { ...acc, [model.name]: this.generateModelMetadata(model) };
+    }, {});
+
+    const nonModels = Object.values(this.getSelectedNonModels()).reduce((acc, nonModel: CodeGenModel) => {
+      return { ...acc, [nonModel.name]: this.generateNonModelMetadata(nonModel) };
+    }, {});
+
+    const enums = Object.values(this.enumMap).reduce((acc, enumObj) => {
+      const enumV = this.generateEnumMetadata(enumObj);
+      return { ...acc, [this.getEnumName(enumObj)]: enumV };
+    }, {});
+    return { ...result, models, nonModels: nonModels, enums }
+  }
+
+  private getFieldAssociation(field: CodeGenField): AssociationType | void {
+    if (field.connectionInfo) {
+      const { connectionInfo } = field;
+      const connectionAttribute: any = { connectionType: connectionInfo.kind };
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
+        if (this.isCustomPKEnabled()) {
+          connectionAttribute.associatedWith = connectionInfo.associatedWithFields.map(f => this.getFieldName(f));
+        } else {
+          connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+        }
+      } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        if (this.isCustomPKEnabled()) {
+          connectionAttribute.associatedWith = connectionInfo.associatedWithFields.map(f => this.getFieldName(f));
+          connectionAttribute.targetNames = connectionInfo.targetNames;
+        } else {
+          connectionAttribute.associatedWith = this.getFieldName(connectionInfo.associatedWith);
+          connectionAttribute.targetName = connectionInfo.targetName;
+        }
+      } else {
+        if (this.isCustomPKEnabled()) {
+          connectionAttribute.targetNames = connectionInfo.targetNames;
+        } else {
+          connectionAttribute.targetName = connectionInfo.targetName;
+        }
+      }
+      return connectionAttribute;
+    }
+  }
+
+  private generateModelAttributes(model: CodeGenModel): JSONModelAttributes {
+    return model.directives.map(d => ({
+      type: d.name,
+      properties: d.arguments,
+    }));
+  }
+
+  private generateModelMetadata(model: CodeGenModel): JSONSchemaModel {
+    return {
+      ...this.generateNonModelMetadata(model),
+      syncable: true,
+      pluralName: this.pluralizeModelName(model),
+      attributes: this.generateModelAttributes(model),
+    };
+  }
+
+  private generateNonModelMetadata(nonModel: CodeGenModel): JSONSchemaNonModel {
+    return {
+      name: this.getModelName(nonModel),
+      fields: nonModel.fields.reduce((acc: JSONModelFields, field: CodeGenField) => {
+        const fieldMeta: JSONModelField = {
+          name: this.getFieldName(field),
+          isArray: field.isList,
+          type: this.getType(field.type),
+          isRequired: !field.isNullable,
+          attributes: [],
+        };
+
+        if (field.isListNullable !== undefined) {
+          fieldMeta.isArrayNullable = field.isListNullable;
+        }
+
+        if (field.isReadOnly !== undefined) {
+          fieldMeta.isReadOnly = field.isReadOnly;
+        }
+
+        const association: AssociationType | void = this.getFieldAssociation(field);
+        if (association) {
+          fieldMeta.association = association;
+        }
+        acc[fieldMeta.name] = fieldMeta;
+        return acc;
+      }, {}),
+    };
+  }
+
+  private generateEnumMetadata(enumObj: CodeGenEnum): JSONSchemaEnum {
+    return {
+      name: enumObj.name,
+      values: Object.values(enumObj.values),
+    };
+  }
+
+  private getType(gqlType: string): JSONModelFieldType {
+    // Todo: Handle unlisted scalars
+    if (gqlType in METADATA_SCALAR_MAP) {
+      return METADATA_SCALAR_MAP[gqlType as keyof typeof METADATA_SCALAR_MAP];
+    }
+    if (gqlType in this.enumMap) {
+      return { enum: this.enumMap[gqlType].name };
+    }
+    if (gqlType in this.nonModelMap) {
+      return { nonModel: gqlType };
+    }
+    if (gqlType in this.modelMap) {
+      return { model: gqlType };
+    }
+    throw new Error(`Unknown type ${gqlType}`);
+  }
+}

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -53,7 +53,7 @@ export interface RawAppSyncModelConfig extends RawConfig {
    *  plugins:
    *    - amplify-codegen-appsync-model-plugin
    * ```
-   * target: 'swift'| 'javascript'| 'typescript' | 'java' | 'metadata' | 'dart'
+   * target: 'swift'| 'javascript'| 'typescript' | 'java' | 'metadata' | 'dart' | 'introspection'
    */
   target: string;
 


### PR DESCRIPTION
#### Description of changes
Verifying that we can make a minimal set of changes supporting a new metadata output for data model introspection use-cases. This is draft, and needs both refactor and tests before it'd be consider 'ready to go'. We also need an API review for the CLI shape changes, and to confirm the output changes.

Outstanding Changes
* Update json schema file to be correct.
* Update output shape to be correct.
* Add unit tests for visitor.
* Add snapshot tests for output.
* Add e2e tests for failing case, relative path, local path.

#### Issue #, if available
N/A

#### Description of how you validated changes
Currently just testing manually w/ `amplify-dev codegen introspection --output-file ./relativeModelIntrospectionSchema.json` and the same w/ an absolute path. Verified that the model introspection will throw failure if I change it.

#### Checklist
- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.