### PR TITLE
feat(amplify-codegen): new codegen command of  model intropection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,14 @@ jobs:
     environment:
       TEST_SUITE: src/__tests__/add-codegen-js.test.ts
       CLI_REGION: ap-southeast-1
+  model-introspection-codegen-e2e-test:
+    working_directory: ~/repo
+    parameters: *ref_0
+    executor: << parameters.os >>
+    steps: *ref_4
+    environment:
+      TEST_SUITE: src/__tests__/model-introspection-codegen.test.ts
+      CLI_REGION: ap-southeast-2
   add-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -248,7 +256,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/add-codegen-ios.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   add-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -256,7 +264,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/add-codegen-android.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-1
   datastore-modelgen-flutter-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -264,7 +272,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-flutter.test.ts
-      CLI_REGION: us-west-1
+      CLI_REGION: eu-west-2
   datastore-modelgen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -272,7 +280,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-ios.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   datastore-modelgen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -280,7 +288,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-android.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   datastore-modelgen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -288,7 +296,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/datastore-modelgen-js.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   remove-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -296,7 +304,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-android.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   remove-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -304,7 +312,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-ios.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   remove-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -312,7 +320,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/remove-codegen-js.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-1
   feature-flags-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -320,7 +328,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/feature-flags.test.ts
-      CLI_REGION: us-west-1
+      CLI_REGION: eu-west-2
   configure-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -328,7 +336,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-ios.test.ts
-      CLI_REGION: eu-west-2
+      CLI_REGION: eu-central-1
   configure-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -336,7 +344,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-android.test.ts
-      CLI_REGION: eu-central-1
+      CLI_REGION: ap-northeast-1
   configure-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -344,7 +352,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/configure-codegen-js.test.ts
-      CLI_REGION: ap-northeast-1
+      CLI_REGION: ap-southeast-1
   graphql-codegen-android-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -352,7 +360,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-android.test.ts
-      CLI_REGION: ap-southeast-1
+      CLI_REGION: ap-southeast-2
   graphql-codegen-js-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -360,7 +368,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-js.test.ts
-      CLI_REGION: ap-southeast-2
+      CLI_REGION: us-east-2
   graphql-codegen-ios-e2e-test:
     working_directory: ~/repo
     parameters: *ref_0
@@ -368,7 +376,7 @@ jobs:
     steps: *ref_4
     environment:
       TEST_SUITE: src/__tests__/graphql-codegen-ios.test.ts
-      CLI_REGION: us-east-2
+      CLI_REGION: us-west-1
 workflows:
   version: 2
   e2e_resource_cleanup:
@@ -429,27 +437,28 @@ workflows:
           os: l
           requires:
             - push-codegen-ios-e2e-test
-            - add-codegen-android-e2e-test
-            - remove-codegen-js-e2e-test
-            - graphql-codegen-ios-e2e-test
-            - push-codegen-android-e2e-test
-            - datastore-modelgen-flutter-e2e-test
-            - feature-flags-e2e-test
-            - push-codegen-js-e2e-test
-            - datastore-modelgen-ios-e2e-test
-            - configure-codegen-ios-e2e-test
-            - pull-codegen-e2e-test
-            - datastore-modelgen-android-e2e-test
-            - configure-codegen-android-e2e-test
-            - env-codegen-e2e-test
-            - datastore-modelgen-js-e2e-test
-            - configure-codegen-js-e2e-test
-            - add-codegen-js-e2e-test
-            - remove-codegen-android-e2e-test
-            - graphql-codegen-android-e2e-test
             - add-codegen-ios-e2e-test
             - remove-codegen-ios-e2e-test
             - graphql-codegen-js-e2e-test
+            - push-codegen-android-e2e-test
+            - add-codegen-android-e2e-test
+            - remove-codegen-js-e2e-test
+            - graphql-codegen-ios-e2e-test
+            - push-codegen-js-e2e-test
+            - datastore-modelgen-flutter-e2e-test
+            - feature-flags-e2e-test
+            - pull-codegen-e2e-test
+            - datastore-modelgen-ios-e2e-test
+            - configure-codegen-ios-e2e-test
+            - env-codegen-e2e-test
+            - datastore-modelgen-android-e2e-test
+            - configure-codegen-android-e2e-test
+            - add-codegen-js-e2e-test
+            - datastore-modelgen-js-e2e-test
+            - configure-codegen-js-e2e-test
+            - model-introspection-codegen-e2e-test
+            - remove-codegen-android-e2e-test
+            - graphql-codegen-android-e2e-test
       - push-codegen-ios-e2e-test:
           context: &ref_6
             - cleanup-resources
@@ -464,6 +473,34 @@ workflows:
                 - main
                 - e2e-testing
                 - /tagged-release\/.*/
+      - add-codegen-ios-e2e-test:
+          context: *ref_6
+          os: l
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_7
+          filters: *ref_8
+      - remove-codegen-ios-e2e-test:
+          context: *ref_6
+          os: l
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_7
+          filters: *ref_8
+      - graphql-codegen-js-e2e-test:
+          context: *ref_6
+          os: l
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_7
+          filters: *ref_8
+      - push-codegen-android-e2e-test:
+          context: *ref_6
+          os: l
+          requires:
+            - publish_to_local_registry
+          post-steps: *ref_7
+          filters: *ref_8
       - add-codegen-android-e2e-test:
           context: *ref_6
           os: l
@@ -485,7 +522,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_7
           filters: *ref_8
-      - push-codegen-android-e2e-test:
+      - push-codegen-js-e2e-test:
           context: *ref_6
           os: l
           requires:
@@ -506,7 +543,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_7
           filters: *ref_8
-      - push-codegen-js-e2e-test:
+      - pull-codegen-e2e-test:
           context: *ref_6
           os: l
           requires:
@@ -527,7 +564,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_7
           filters: *ref_8
-      - pull-codegen-e2e-test:
+      - env-codegen-e2e-test:
           context: *ref_6
           os: l
           requires:
@@ -548,7 +585,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_7
           filters: *ref_8
-      - env-codegen-e2e-test:
+      - add-codegen-js-e2e-test:
           context: *ref_6
           os: l
           requires:
@@ -569,7 +606,7 @@ workflows:
             - publish_to_local_registry
           post-steps: *ref_7
           filters: *ref_8
-      - add-codegen-js-e2e-test:
+      - model-introspection-codegen-e2e-test:
           context: *ref_6
           os: l
           requires:
@@ -584,27 +621,6 @@ workflows:
           post-steps: *ref_7
           filters: *ref_8
       - graphql-codegen-android-e2e-test:
-          context: *ref_6
-          os: l
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_7
-          filters: *ref_8
-      - add-codegen-ios-e2e-test:
-          context: *ref_6
-          os: l
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_7
-          filters: *ref_8
-      - remove-codegen-ios-e2e-test:
-          context: *ref_6
-          os: l
-          requires:
-            - publish_to_local_registry
-          post-steps: *ref_7
-          filters: *ref_8
-      - graphql-codegen-js-e2e-test:
           context: *ref_6
           os: l
           requires:

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -133,3 +133,16 @@ export function configureCodegen(cwd: string, settings: any = {}): Promise<void>
   });
 }
 
+export function generateModelIntrospection(cwd: string, settings: { outputDir?: string} = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['codegen', 'model-introspection', '--output-dir', settings.outputDir ?? ''], { cwd, stripColors: true })
+    .run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
+

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/model-introspection-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/model-introspection-codegen.test.ts
@@ -1,0 +1,50 @@
+import { addApiWithoutSchema, createNewProjectDir, generateModelIntrospection, initJSProjectWithProfile, updateApiSchema } from "@aws-amplify/amplify-codegen-e2e-core";
+import { deleteAmplifyProject } from '../codegen-tests-base';
+import { isNotEmptyDir } from "../utils";
+import { join } from 'path';
+
+const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
+
+describe('Model Introspection Codegen test', () => {
+    let projectRoot: string;
+    const apiName = 'modelintrospection';
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('modelIntrospection');
+    });
+
+    afterEach(async () => {
+        await deleteAmplifyProject(projectRoot);
+    });
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+      // init project and add API category
+      await initJSProjectWithProfile(projectRoot);
+      await addApiWithoutSchema(projectRoot, { apiName });
+      await updateApiSchema(projectRoot, apiName, schema);
+      const outputDir = 'output';
+      //generate introspection schema
+      await expect(generateModelIntrospection(projectRoot, { outputDir })).resolves.not.toThrow();
+      // Model introspection is generated at correct location
+      expect(isNotEmptyDir(join(projectRoot, outputDir))).toBe(true);
+    });
+    it('should throw error when the output directory is not defined in the command', async () => {
+      // init project and add API category
+      await initJSProjectWithProfile(projectRoot);
+      await addApiWithoutSchema(projectRoot, { apiName });
+      await updateApiSchema(projectRoot, apiName, schema);
+      //generate introspection schema
+      await expect(generateModelIntrospection(projectRoot)).rejects.toThrowError();
+    });
+    it('should throw error if the GraphQL schema is invalid', async () => {
+      const invalidSchema = 'modelgen/model_gen_schema_with_errors.graphql';
+      // init project and add API category
+      await initJSProjectWithProfile(projectRoot);
+      await addApiWithoutSchema(projectRoot, { apiName });
+      await updateApiSchema(projectRoot, apiName, invalidSchema);
+      const outputDir = 'output';
+      //generate introspection schema
+      await expect(generateModelIntrospection(projectRoot, { outputDir })).rejects.toThrowError();
+    });
+});
+

--- a/packages/amplify-codegen/amplify-plugin.json
+++ b/packages/amplify-codegen/amplify-plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codegen",
   "type": "util",
-  "commands": ["add", "codegen", "configure", "remove", "statements", "types", "models"],
+  "commands": ["add", "codegen", "configure", "remove", "statements", "types", "models", "model-introspection"],
   "commandAliases": {
     "update": "configure",
     "statement": "statements",

--- a/packages/amplify-codegen/commands/codegen/model-introspection.js
+++ b/packages/amplify-codegen/commands/codegen/model-introspection.js
@@ -1,19 +1,12 @@
 const codeGen = require('../../src');
 const { exitOnNextTick } = require('amplify-cli-core');
 const featureName = 'model-introspection';
-const path = require('path');
 
 module.exports = {
   name: featureName,
   run: async context => {
     try {
-      // Verify override path flag is provided
-      const outputDirParam = context.parameters.options ? context.parameters.options['output-dir'] : null;
-      if ( !outputDirParam ) {
-        throw new Error('Expected --output-dir flag to be set for model introspection command.');
-      }
-      const outputDirPath = path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
-      await codeGen.generateModels(context, outputDirPath, true);
+      await codeGen.generateModelIntrospection(context);
     } catch (ex) {
       context.print.info(ex.message);
       console.log(ex.stack);

--- a/packages/amplify-codegen/commands/codegen/model-introspection.js
+++ b/packages/amplify-codegen/commands/codegen/model-introspection.js
@@ -1,0 +1,24 @@
+const codeGen = require('../../src');
+const { exitOnNextTick } = require('amplify-cli-core');
+const featureName = 'model-introspection';
+const path = require('path');
+
+module.exports = {
+  name: featureName,
+  run: async context => {
+    try {
+      // Verify override path flag is provided
+      const outputDirParam = context.parameters.options ? context.parameters.options['output-dir'] : null;
+      if ( !outputDirParam ) {
+        throw new Error('Expected --output-dir flag to be set for model introspection command.');
+      }
+      const outputDirPath = path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
+      await codeGen.generateModels(context, outputDirPath, true);
+    } catch (ex) {
+      context.print.info(ex.message);
+      console.log(ex.stack);
+      await context.usageData.emitError(ex);
+      exitOnNextTick(1);
+    }
+  },
+};

--- a/packages/amplify-codegen/src/commands/model-intropection.js
+++ b/packages/amplify-codegen/src/commands/model-intropection.js
@@ -1,0 +1,14 @@
+const generateModels = require('./models');
+const path = require('path');
+
+async function generateModelIntrospection(context) {
+  // Verify override path flag is provided
+  const outputDirParam = context.parameters.options ? context.parameters.options['output-dir'] : null;
+  if ( !outputDirParam ) {
+    throw new Error('Expected --output-dir flag to be set for model introspection command.');
+  }
+  const outputDirPath = path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
+  await generateModels(context, outputDirPath, true);
+}
+
+module.exports = generateModelIntrospection;

--- a/packages/amplify-codegen/src/commands/model-intropection.js
+++ b/packages/amplify-codegen/src/commands/model-intropection.js
@@ -4,8 +4,8 @@ const path = require('path');
 async function generateModelIntrospection(context) {
   // Verify override path flag is provided
   const outputDirParam = context.parameters.options ? context.parameters.options['output-dir'] : null;
-  if ( !outputDirParam ) {
-    throw new Error('Expected --output-dir flag to be set for model introspection command.');
+  if ( !outputDirParam || typeof(outputDirParam) !== 'string' ) {
+    throw new Error('Expected --output-dir flag with value to be set for model introspection command.');
   }
   const outputDirPath = path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
   await generateModels(context, outputDirPath, true);

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -44,7 +44,7 @@ const readNumericFeatureFlag = key => {
   }
 };
 
-async function generateModels(context) {
+async function generateModels(context, outputDirPath = null, isIntrospection = false) {
   // steps:
   // 1. Load the schema and validate using transformer
   // 2. get all the directives supported by transformer
@@ -76,7 +76,7 @@ async function generateModels(context) {
   });
 
   const schemaContent = loadSchema(apiResourcePath);
-  const outputPath = path.join(projectRoot, getModelOutputPath(context));
+  const outputPath = outputDirPath || path.join(projectRoot, getModelOutputPath(context));
   const schema = parse(schemaContent);
   const projectConfig = context.amplify.getProjectConfig();
 
@@ -116,7 +116,7 @@ async function generateModels(context) {
     baseOutputDir: outputPath,
     schema,
     config: {
-      target: platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend,
+      target: isIntrospection ? 'introspection' : (platformToLanguageMap[projectConfig.frontend] || projectConfig.frontend),
       directives: directiveDefinitions,
       isTimestampFieldsAdded,
       emitAuthProvider,

--- a/packages/amplify-codegen/src/index.js
+++ b/packages/amplify-codegen/src/index.js
@@ -5,6 +5,7 @@ const add = require('./commands/add');
 const remove = require('./commands/remove');
 const configure = require('./commands/configure');
 const generateModels = require('./commands/models');
+const generateModelIntrospection = require('./commands/model-intropection');
 const { isCodegenConfigured, switchToSDLSchema } = require('./utils');
 const prePushAddGraphQLCodegenHook = require('./callbacks/prePushAddCallback');
 const prePushUpdateGraphQLCodegenHook = require('./callbacks/prePushUpdateCallback');
@@ -26,4 +27,5 @@ module.exports = {
   executeAmplifyCommand,
   handleAmplifyEvent,
   generateModels,
+  generateModelIntrospection,
 };

--- a/packages/amplify-codegen/tests/commands/model-introspection.test.js
+++ b/packages/amplify-codegen/tests/commands/model-introspection.test.js
@@ -1,0 +1,84 @@
+const generateModelIntrospection = require('../../src/commands/model-intropection');
+const graphqlCodegen = require('@graphql-codegen/core');
+const mockFs = require('mock-fs');
+const path = require('path');
+const fs = require('fs');
+
+jest.mock('@graphql-codegen/core');
+
+const MOCK_OUTPUT_DIR = 'output';
+const MOCK_PROJECT_ROOT = 'project';
+const MOCK_PROJECT_NAME = 'myapp';
+const MOCK_BACKEND_DIRECTORY = 'backend';
+const MOCK_GENERATED_CODE = 'This code is auto-generated!';
+const MOCK_CONTEXT = {
+  print: {
+    info: jest.fn(),
+    warning: jest.fn(),
+  },
+  amplify: {
+    getProjectMeta: jest.fn(),
+    getEnvInfo: jest.fn().mockReturnValue({ projectPath: MOCK_PROJECT_ROOT }),
+    getResourceStatus: jest.fn().mockReturnValue({
+      allResources: [
+        {
+          service: 'AppSync',
+          providerPlugin: 'awscloudformation',
+          resourceName: MOCK_PROJECT_NAME,
+        },
+      ],
+    }),
+    executeProviderUtils: jest.fn().mockReturnValue([]),
+    pathManager: {
+      getBackendDirPath: jest.fn().mockReturnValue(MOCK_BACKEND_DIRECTORY),
+    },
+    getProjectConfig: jest.fn().mockReturnValue('frontend'),
+  },
+  parameters: {}
+};
+
+
+
+describe('model-intropection command test', () => {
+  graphqlCodegen.codegen.mockReturnValue(MOCK_GENERATED_CODE);
+  const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
+  const outputDirectory = path.join(MOCK_PROJECT_ROOT, MOCK_OUTPUT_DIR);
+  const mockedFiles = {};
+  mockedFiles[schemaFilePath] = {
+    'schema.graphql': ' type SimpleModel { id: ID! status: String } ',
+  };
+  mockedFiles[outputDirectory] = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should generate model intropection schema', async () => {
+    mockFs(mockedFiles);
+    // assert empty folder before generation
+    expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+    const contextWithOutputDir = {
+      ...MOCK_CONTEXT,
+      parameters: {
+        options:{
+          ["output-dir"]: MOCK_OUTPUT_DIR
+        }
+      }
+    }
+    await expect(generateModelIntrospection(contextWithOutputDir)).resolves.not.toThrow();
+    // assert model generation succeeds with a single schema file
+    expect(graphqlCodegen.codegen).toBeCalled();
+    expect(fs.readdirSync(outputDirectory).length).toBeGreaterThan(0); 
+  });
+  it('should throw error if the output dir is not included in the command', async () => {
+    mockFs(mockedFiles);
+    // assert empty folder before generation
+    expect(fs.readdirSync(outputDirectory).length).toEqual(0);
+    await expect(generateModelIntrospection(MOCK_CONTEXT)).rejects.toThrowError();
+    // assert model generation failure with no file found
+    expect(graphqlCodegen.codegen).not.toBeCalled();
+    expect(fs.readdirSync(outputDirectory).length).toEqual(0); 
+  });
+
+  afterEach(mockFs.restore);
+});

--- a/packages/appsync-modelgen-plugin/.npmignore
+++ b/packages/appsync-modelgen-plugin/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
 src
+scripts
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/appsync-modelgen-plugin/package.json
+++ b/packages/appsync-modelgen-plugin/package.json
@@ -21,7 +21,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test-watch": "jest --watch",
-    "test": "jest"
+    "test": "jest",
+    "generate-schemas": "ts-node ./scripts/generateSchemas.ts"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^1.18.8",
@@ -40,7 +41,8 @@
   "devDependencies": {
     "@graphql-codegen/testing": "^1.17.7",
     "graphql": "^14.5.8",
-    "java-ast": "^0.1.0"
+    "java-ast": "^0.1.0",
+    "ts-json-schema-generator": "1.0.0"
   },
   "peerDependencies": {
     "graphql": "^14.5.8"

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -1,0 +1,370 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "number",
+            "const": 1
+        },
+        "models": {
+            "$ref": "#/definitions/SchemaModels"
+        },
+        "nonModels": {
+            "$ref": "#/definitions/SchemaNonModels"
+        },
+        "enums": {
+            "$ref": "#/definitions/SchemaEnums"
+        }
+    },
+    "required": [
+        "version",
+        "models",
+        "nonModels",
+        "enums"
+    ],
+    "additionalProperties": false,
+    "description": "Root Schema Representation",
+    "definitions": {
+        "SchemaModels": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaModel%3E",
+            "description": "Top-level Entities on a Schema"
+        },
+        "Record<string,SchemaModel>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaModel"
+            }
+        },
+        "SchemaModel": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelAttribute"
+                    }
+                },
+                "fields": {
+                    "$ref": "#/definitions/Fields"
+                },
+                "pluralName": {
+                    "type": "string"
+                },
+                "syncable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name",
+                "fields",
+                "pluralName"
+            ],
+            "additionalProperties": false
+        },
+        "ModelAttribute": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "properties": {
+                    "type": "object"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "additionalProperties": false
+        },
+        "Fields": {
+            "$ref": "#/definitions/Record%3Cstring%2CField%3E",
+            "description": "Field Definition"
+        },
+        "Record<string,Field>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Field"
+            }
+        },
+        "Field": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/FieldType"
+                },
+                "isArray": {
+                    "type": "boolean"
+                },
+                "isRequired": {
+                    "type": "boolean"
+                },
+                "isReadOnly": {
+                    "type": "boolean"
+                },
+                "isArrayNullable": {
+                    "type": "boolean"
+                },
+                "attributes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/FieldAttribute"
+                    }
+                },
+                "association": {
+                    "$ref": "#/definitions/AssociationType"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "isArray",
+                "isRequired"
+            ],
+            "additionalProperties": false
+        },
+        "FieldType": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "const": "ID"
+                },
+                {
+                    "type": "string",
+                    "const": "String"
+                },
+                {
+                    "type": "string",
+                    "const": "Int"
+                },
+                {
+                    "type": "string",
+                    "const": "Float"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSDate"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSTime"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSDateTime"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSTimestamp"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSEmail"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSURL"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSIPAddress"
+                },
+                {
+                    "type": "string",
+                    "const": "Boolean"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSJSON"
+                },
+                {
+                    "type": "string",
+                    "const": "AWSPhone"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "enum": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "enum"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "model": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "model"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "nonModel": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "nonModel"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "FieldAttribute": {
+            "$ref": "#/definitions/ModelAttribute"
+        },
+        "AssociationType": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssociationHasMany"
+                },
+                {
+                    "$ref": "#/definitions/AssociationHasOne"
+                },
+                {
+                    "$ref": "#/definitions/AssociationBelongsTo"
+                }
+            ]
+        },
+        "AssociationHasMany": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "connectionType": {
+                    "$ref": "#/definitions/CodeGenConnectionType"
+                },
+                "associatedWith": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "associatedWith",
+                "connectionType"
+            ]
+        },
+        "CodeGenConnectionType": {
+            "type": "string",
+            "enum": [
+                "HAS_ONE",
+                "BELONGS_TO",
+                "HAS_MANY"
+            ],
+            "description": "Field-level Relationship Definitions"
+        },
+        "AssociationHasOne": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "connectionType": {
+                    "$ref": "#/definitions/CodeGenConnectionType"
+                },
+                "associatedWith": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "targetNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "associatedWith",
+                "connectionType",
+                "targetNames"
+            ]
+        },
+        "AssociationBelongsTo": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "connectionType": {
+                    "$ref": "#/definitions/CodeGenConnectionType"
+                },
+                "targetNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "connectionType",
+                "targetNames"
+            ]
+        },
+        "SchemaNonModels": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaNonModel%3E"
+        },
+        "Record<string,SchemaNonModel>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaNonModel"
+            }
+        },
+        "SchemaNonModel": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "fields": {
+                    "$ref": "#/definitions/Fields"
+                }
+            },
+            "required": [
+                "name",
+                "fields"
+            ],
+            "additionalProperties": false
+        },
+        "SchemaEnums": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaEnum%3E"
+        },
+        "Record<string,SchemaEnum>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaEnum"
+            }
+        },
+        "SchemaEnum": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "values"
+            ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/packages/appsync-modelgen-plugin/scripts/generateSchemas.ts
+++ b/packages/appsync-modelgen-plugin/scripts/generateSchemas.ts
@@ -1,0 +1,47 @@
+import { createGenerator, Config, Definition } from 'ts-json-schema-generator';
+import fs from 'fs-extra';
+import path from 'path';
+
+// Interface types are expected to be exported as "typeName" in the file
+type TypeDef = {
+  typeName: string;
+  category: string;
+  path: string;
+};
+
+// paths are relative to the package root
+const schemaFilesRoot = './schemas';
+
+// defines the type names and the paths to the TS files that define them
+const typeDefs: TypeDef[] = [
+  {
+    typeName: 'ModelIntrospectionSchema',
+    category: 'introspection',
+    path: './src/interfaces/introspection/*.ts',
+  },
+];
+
+const schemaFileName = (typeName: string) => `${typeName}.json`;
+const forceFlag = '--overwrite';
+const force = process.argv.includes(forceFlag);
+
+// schema generation configs. See https://www.npmjs.com/package/ts-json-schema-generator
+
+typeDefs.forEach(typeDef => {
+  const config = { path: typeDef.path, type: typeDef.typeName, expose: "all", topRef: false } as Config;
+  const typeSchema = createGenerator(config).createSchema(config.type)
+  const version = (typeSchema.properties!.version as Definition).const! as number;
+  const schemaFilePath = path.resolve(path.join(schemaFilesRoot, typeDef.category, version.toString(), schemaFileName(typeDef.typeName)));
+  if (!force && fs.existsSync(schemaFilePath)) {
+    console.error(`Schema version ${version} already exists for type ${typeDef.typeName}.`);
+    console.info('The interface version must be bumped after any changes.');
+    console.info(`Use the ${forceFlag} flag to overwrite existing versions`);
+    console.info('Skipping this schema');
+    return;
+  }
+  fs.ensureFileSync(schemaFilePath);
+  fs.writeFileSync(schemaFilePath, JSON.stringify(typeSchema, undefined, 4) + '\n');
+  console.log(`Schema version ${version} written for type ${typeDef.typeName}.`);
+});
+
+

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1,0 +1,1702 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Custom primary key tests should generate correct model intropection file validated by JSON schema and not throw error when custom PK is enabled 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"Project1\\": {
+            \\"name\\": \\"Project1\\",
+            \\"fields\\": {
+                \\"projectId\\": {
+                    \\"name\\": \\"projectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"team\\": {
+                    \\"name\\": \\"team\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Team1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"project\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"project1TeamTeamId\\",
+                            \\"project1TeamName\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"project1TeamTeamId\\": {
+                    \\"name\\": \\"project1TeamTeamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"project1TeamName\\": {
+                    \\"name\\": \\"project1TeamName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Project1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"projectId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Team1\\": {
+            \\"name\\": \\"Team1\\",
+            \\"fields\\": {
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"project\\": {
+                    \\"name\\": \\"project\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Project1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"team1ProjectProjectId\\",
+                            \\"team1ProjectName\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"team1ProjectProjectId\\": {
+                    \\"name\\": \\"team1ProjectProjectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"team1ProjectName\\": {
+                    \\"name\\": \\"team1ProjectName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Team1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Project2\\": {
+            \\"name\\": \\"Project2\\",
+            \\"fields\\": {
+                \\"projectId\\": {
+                    \\"name\\": \\"projectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"team\\": {
+                    \\"name\\": \\"team\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Team2\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"project2TeamTeamId\\",
+                            \\"project2TeamName\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"project2TeamTeamId\\": {
+                    \\"name\\": \\"project2TeamTeamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"project2TeamName\\": {
+                    \\"name\\": \\"project2TeamName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Project2s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"projectId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Team2\\": {
+            \\"name\\": \\"Team2\\",
+            \\"fields\\": {
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Team2s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Project3\\": {
+            \\"name\\": \\"Project3\\",
+            \\"fields\\": {
+                \\"projectId\\": {
+                    \\"name\\": \\"projectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"team\\": {
+                    \\"name\\": \\"team\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Team3\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"project\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"teamId\\",
+                            \\"teamName\\"
+                        ]
+                    }
+                },
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"teamName\\": {
+                    \\"name\\": \\"teamName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Project3s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"projectId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Team3\\": {
+            \\"name\\": \\"Team3\\",
+            \\"fields\\": {
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"project\\": {
+                    \\"name\\": \\"project\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Project3\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"projectId\\",
+                            \\"projectName\\"
+                        ]
+                    }
+                },
+                \\"projectId\\": {
+                    \\"name\\": \\"projectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"projectName\\": {
+                    \\"name\\": \\"projectName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Team3s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Project4\\": {
+            \\"name\\": \\"Project4\\",
+            \\"fields\\": {
+                \\"projectId\\": {
+                    \\"name\\": \\"projectId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"team\\": {
+                    \\"name\\": \\"team\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Team4\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"teamId\\",
+                            \\"teamName\\"
+                        ]
+                    }
+                },
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"teamName\\": {
+                    \\"name\\": \\"teamName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Project4s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"projectId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Team4\\": {
+            \\"name\\": \\"Team4\\",
+            \\"fields\\": {
+                \\"teamId\\": {
+                    \\"name\\": \\"teamId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Team4s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"teamId\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post1CommentsPostId\\",
+                            \\"post1CommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"post1CommentsPostId\\",
+                            \\"post1CommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"post1CommentsPostId\\": {
+                    \\"name\\": \\"post1CommentsPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"post1CommentsTitle\\": {
+                    \\"name\\": \\"post1CommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post2\\": {
+            \\"name\\": \\"Post2\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment2\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post2CommentsPostId\\",
+                            \\"post2CommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post2s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment2\\": {
+            \\"name\\": \\"Comment2\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"post2CommentsPostId\\": {
+                    \\"name\\": \\"post2CommentsPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"post2CommentsTitle\\": {
+                    \\"name\\": \\"post2CommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment2s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post3\\": {
+            \\"name\\": \\"Post3\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment3\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post3s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment3\\": {
+            \\"name\\": \\"Comment3\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post3\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment3s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post4\\": {
+            \\"name\\": \\"Post4\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment4\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post4s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment4\\": {
+            \\"name\\": \\"Comment4\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment4s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"customPostId\\": {
+                    \\"name\\": \\"customPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"tags\\": {
+                    \\"name\\": \\"tags\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"PostTags\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customPostId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Tag\\": {
+            \\"name\\": \\"Tag\\",
+            \\"fields\\": {
+                \\"customTagId\\": {
+                    \\"name\\": \\"customTagId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"label\\": {
+                    \\"name\\": \\"label\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"posts\\": {
+                    \\"name\\": \\"posts\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"PostTags\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"tag\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Tags\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customTagId\\",
+                            \\"label\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"PostTags\\": {
+            \\"name\\": \\"PostTags\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postCustomPostId\\": {
+                    \\"name\\": \\"postCustomPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"posttitle\\": {
+                    \\"name\\": \\"posttitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"tagCustomTagId\\": {
+                    \\"name\\": \\"tagCustomTagId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"taglabel\\": {
+                    \\"name\\": \\"taglabel\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCustomPostId\\",
+                            \\"posttitle\\"
+                        ]
+                    }
+                },
+                \\"tag\\": {
+                    \\"name\\": \\"tag\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Tag\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"tagCustomTagId\\",
+                            \\"taglabel\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"PostTags\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postCustomPostId\\",
+                            \\"posttitle\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byTag\\",
+                        \\"fields\\": [
+                            \\"tagCustomTagId\\",
+                            \\"taglabel\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}"
+`;
+
+exports[`Model Introspection Visitor Metadata snapshot should generate correct model intropection file validated by JSON schema 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"SimpleModel\\": {
+            \\"name\\": \\"SimpleModel\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"bar\\": {
+                    \\"name\\": \\"bar\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"children\\": {
+                    \\"name\\": \\"children\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Child\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"simpleModelChildrenId\\"
+                        ]
+                    }
+                },
+                \\"ssn\\": {
+                    \\"name\\": \\"ssn\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"SSN\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [
+                            \\"user\\"
+                        ],
+                        \\"targetNames\\": [
+                            \\"simpleModelSsnId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"simpleModelSsnId\\": {
+                    \\"name\\": \\"simpleModelSsnId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"SimpleModels\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"Child\\": {
+            \\"name\\": \\"Child\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"parent\\": {
+                    \\"name\\": \\"parent\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"SimpleModel\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"simpleModelChildrenId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Children\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        },
+        \\"SSN\\": {
+            \\"name\\": \\"SSN\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"user\\": {
+                    \\"name\\": \\"user\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"SimpleModel\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"sSNUserId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"SSNS\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        }
+    },
+    \\"enums\\": {
+        \\"SimpleEnum\\": {
+            \\"name\\": \\"SimpleEnum\\",
+            \\"values\\": [
+                \\"enumVal1\\",
+                \\"enumVal2\\"
+            ]
+        }
+    },
+    \\"nonModels\\": {
+        \\"SimpleNonModelType\\": {
+            \\"name\\": \\"SimpleNonModelType\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"names\\": {
+                    \\"name\\": \\"names\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true
+                }
+            }
+        }
+    }
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -1,0 +1,191 @@
+import { buildSchema, GraphQLSchema, parse, visit } from 'graphql';
+import { METADATA_SCALAR_MAP } from '../../scalars';
+import { directives, scalars } from '../../scalars/supported-directives';
+import {
+  CodeGenConnectionType,
+  CodeGenFieldConnectionBelongsTo,
+  CodeGenFieldConnectionHasMany,
+  CodeGenFieldConnectionHasOne,
+} from '../../utils/process-connections';
+import { AppSyncModelIntrospectionVisitor } from '../../visitors/appsync-model-introspection-visitor';
+import { CodeGenEnum, CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
+
+const defaultModelIntropectionVisitorSettings = {
+  isTimestampFieldsAdded: true,
+  respectPrimaryKeyAttributesOnConnectionField: false,
+  transformerVersion: 2
+}
+
+const buildSchemaWithDirectives = (schema: String): GraphQLSchema => {
+  return buildSchema([schema, directives, scalars].join('\n'));
+};
+
+const getVisitor = (schema: string, settings: any = {}): AppSyncModelIntrospectionVisitor => {
+  const visitorConfig = { ...defaultModelIntropectionVisitorSettings, ...settings }
+  const ast = parse(schema);
+  const builtSchema = buildSchemaWithDirectives(schema);
+  const visitor = new AppSyncModelIntrospectionVisitor(
+    builtSchema,
+    { directives, scalars: METADATA_SCALAR_MAP, ...visitorConfig },
+    {},
+  );
+  visit(ast, { leave: visitor });
+  return visitor;
+};
+
+describe('Model Introspection Visitor', () => {
+  const schema = /* GraphQL */ `
+    type SimpleModel @model {
+      id: ID!
+      name: String
+      bar: String
+      children: [Child] @hasMany
+      ssn: SSN @hasOne
+    }
+    type Child @model {
+      id: ID!
+      parent: SimpleModel @belongsTo
+    }
+    type SSN @model {
+      id: ID!
+      user: SimpleModel @belongsTo
+    }
+    enum SimpleEnum {
+      enumVal1
+      enumVal2
+    }
+    type SimpleNonModelType {
+      id: ID!
+      names: [String]
+    }
+  `;
+  const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema);
+  describe('getType', () => {
+    it('should return model type for Models', () => {
+      expect((visitor as any).getType('SimpleModel')).toEqual({ model: 'SimpleModel' });
+    });
+
+    it('should return EnumType for Enum', () => {
+      expect((visitor as any).getType('SimpleEnum')).toEqual({ enum: 'SimpleEnum' });
+    });
+
+    it('should return NonModel type for Non-model', () => {
+      expect((visitor as any).getType('SimpleNonModelType')).toEqual({ nonModel: 'SimpleNonModelType' });
+    });
+
+    it('should throw error for unknown type', () => {
+      expect(() => (visitor as any).getType('unknown')).toThrowError('Unknown type');
+    });
+  });
+  describe('Metadata snapshot', () => {
+    it('should generate correct model intropection file validated by JSON schema', () => {
+      expect(visitor.generate()).toMatchSnapshot();
+    });
+  });
+});
+
+describe('Custom primary key tests', () => {
+  const schema = /* GraphQL */ `
+    type Project1 @model {
+      projectId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      team: Team1 @hasOne
+    }
+    type Team1 @model {
+      teamId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      project: Project1 @belongsTo
+    }
+    type Project2 @model {
+      projectId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      team: Team2 @hasOne
+    }
+    type Team2 @model {
+      teamId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+    }
+    type Project3 @model {
+      projectId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      team: Team3 @hasOne(fields:["teamId", "teamName"])
+      teamId: ID # customized foreign key for child primary key
+      teamName: String # customized foreign key for child sort key
+    }
+    type Team3 @model {
+      teamId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      project: Project3 @belongsTo(fields:["projectId", "projectName"])
+      projectId: ID # customized foreign key for parent primary key
+      projectName: String # customized foreign key for parent sort key
+    }
+    type Project4 @model {
+      projectId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+      team: Team4 @hasOne(fields:["teamId", "teamName"])
+      teamId: ID # customized foreign key for child primary key
+      teamName: String # customized foreign key for child sort key
+    }
+    type Team4 @model {
+      teamId: ID! @primaryKey(sortKeyFields:["name"])
+      name: String!
+    }
+    type Post1 @model {
+      postId: ID! @primaryKey(sortKeyFields:["title"])
+      title: String!
+      comments: [Comment1] @hasMany
+    }
+    type Comment1 @model {
+      commentId: ID! @primaryKey(sortKeyFields:["content"])
+      content: String!
+      post: Post1 @belongsTo
+    }
+    type Post2 @model {
+      postId: ID! @primaryKey(sortKeyFields:["title"])
+      title: String!
+      comments: [Comment2] @hasMany
+    }
+    type Comment2 @model {
+      commentId: ID! @primaryKey(sortKeyFields:["content"])
+      content: String!
+    }
+    type Post3 @model {
+      postId: ID! @primaryKey(sortKeyFields:["title"])
+      title: String!
+      comments: [Comment3] @hasMany(indexName:"byPost", fields:["postId", "title"])
+    }
+    type Comment3 @model {
+      commentId: ID! @primaryKey(sortKeyFields:["content"])
+      content: String!
+      post: Post3 @belongsTo(fields:["postId", "postTitle"])
+      postId: ID @index(name: "byPost", sortKeyFields:["postTitle"]) # customized foreign key for parent primary key
+      postTitle: String # customized foreign key for parent sort key
+    }
+    type Post4 @model {
+      postId: ID! @primaryKey(sortKeyFields:["title"])
+      title: String!
+      comments: [Comment4] @hasMany(indexName:"byPost", fields:["postId", "title"])
+    }
+    type Comment4 @model {
+      commentId: ID! @primaryKey(sortKeyFields:["content"])
+      content: String!
+      postId: ID @index(name: "byPost", sortKeyFields:["postTitle"]) # customized foreign key for parent primary key
+      postTitle: String # customized foreign key for parent sort key
+    }
+    type Post @model {
+      customPostId: ID! @primaryKey(sortKeyFields: ["title"])
+      title: String!
+      content: String
+      tags: [Tag] @manyToMany(relationName: "PostTags")
+    }
+    type Tag @model {
+        customTagId: ID! @primaryKey(sortKeyFields: ["label"])
+        label: String!
+        posts: [Post] @manyToMany(relationName: "PostTags")
+    }
+  `;
+  it('should generate correct model intropection file validated by JSON schema and not throw error when custom PK is enabled', () => {
+    const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema, { respectPrimaryKeyAttributesOnConnectionField: true });
+    expect(visitor.generate()).toMatchSnapshot();
+  });
+})

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/index.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/index.ts
@@ -1,0 +1,1 @@
+export * from './model-schema';

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -1,0 +1,94 @@
+/**
+ * Root Schema Representation
+ */
+ export type ModelIntrospectionSchema = {
+  version: 1;
+  models: SchemaModels;
+  nonModels: SchemaNonModels;
+  enums: SchemaEnums;
+};
+/**
+ * Top-level Entities on a Schema
+ */
+export type SchemaModels = Record<string, SchemaModel>;
+export type SchemaNonModels = Record<string, SchemaNonModel>;
+export type SchemaEnums = Record<string, SchemaEnum>;
+
+export type SchemaModel = {
+  name: string;
+  attributes?: ModelAttribute[];
+  fields: Fields;
+  pluralName: string;
+  syncable?: boolean;
+};
+export type SchemaNonModel = {
+  name: string;
+  fields: Fields;
+};
+export type SchemaEnum = {
+  name: string;
+  values: string[];
+};
+
+export type ModelAttribute = { type: string; properties?: {[key: string]: any} };
+/**
+ * Field Definition
+ */
+export type Fields = Record<string, Field>;
+export type Field = {
+  name: string;
+  type: FieldType;
+  isArray: boolean;
+  isRequired: boolean;
+  isReadOnly?: boolean;
+  isArrayNullable?: boolean;
+  attributes?: FieldAttribute[];
+  association?: AssociationType;
+};
+export type FieldType = 'ID'
+  | 'String'
+  | 'Int'
+  | 'Float'
+  | 'AWSDate'
+  | 'AWSTime'
+  | 'AWSDateTime'
+  | 'AWSTimestamp'
+  | 'AWSEmail'
+  | 'AWSURL'
+  | 'AWSIPAddress'
+  | 'Boolean'
+  | 'AWSJSON'
+  | 'AWSPhone'
+  | { enum: string }
+  | { model: string }
+  | { nonModel: string };
+export type FieldAttribute = ModelAttribute;
+/**
+ * Field-level Relationship Definitions
+ */
+export enum CodeGenConnectionType {
+  HAS_ONE = 'HAS_ONE',
+  BELONGS_TO = 'BELONGS_TO',
+  HAS_MANY = 'HAS_MANY',
+}
+export type AssociationBaseType = {
+  connectionType: CodeGenConnectionType;
+};
+
+export type AssociationHasMany = AssociationBaseType & {
+  connectionType: CodeGenConnectionType.HAS_MANY;
+  associatedWith: string[];
+};
+export type AssociationHasOne = AssociationBaseType & {
+  connectionType: CodeGenConnectionType.HAS_ONE;
+  associatedWith: string[];
+  targetNames: string[];
+};
+
+export type AssociationBelongsTo = AssociationBaseType & {
+  connectionType: CodeGenConnectionType.BELONGS_TO;
+  targetNames: string[];
+};
+export type AssociationType = AssociationHasMany
+| AssociationHasOne
+| AssociationBelongsTo;

--- a/packages/appsync-modelgen-plugin/src/plugin.ts
+++ b/packages/appsync-modelgen-plugin/src/plugin.ts
@@ -8,6 +8,7 @@ import { AppSyncModelJavaVisitor } from './visitors/appsync-java-visitor';
 import { AppSyncModelTypeScriptVisitor } from './visitors/appsync-typescript-visitor';
 import { AppSyncModelJavascriptVisitor } from './visitors/appsync-javascript-visitor';
 import { AppSyncModelDartVisitor } from './visitors/appsync-dart-visitor';
+import { AppSyncModelIntrospectionVisitor } from './visitors/appsync-model-introspection-visitor';
 export const plugin: PluginFunction<RawAppSyncModelConfig> = (
   schema: GraphQLSchema,
   rawDocuments: Types.DocumentFile[],
@@ -41,6 +42,9 @@ export const plugin: PluginFunction<RawAppSyncModelConfig> = (
         selectedType: config.selectedType,
         generate: config.generate,
       });
+      break;
+    case 'introspection':
+      visitor = new AppSyncModelIntrospectionVisitor(schema, config, {});
       break;
     default:
       return '';

--- a/packages/appsync-modelgen-plugin/src/preset.ts
+++ b/packages/appsync-modelgen-plugin/src/preset.ts
@@ -1,7 +1,7 @@
 import { Types } from '@graphql-codegen/plugin-helpers';
 import { Kind, TypeDefinitionNode } from 'graphql';
 import { join } from 'path';
-import { JAVA_SCALAR_MAP, SWIFT_SCALAR_MAP, TYPESCRIPT_SCALAR_MAP, DART_SCALAR_MAP } from './scalars';
+import { JAVA_SCALAR_MAP, SWIFT_SCALAR_MAP, TYPESCRIPT_SCALAR_MAP, DART_SCALAR_MAP, METADATA_SCALAR_MAP } from './scalars';
 import { LOADER_CLASS_NAME, GENERATED_PACKAGE_NAME } from './configs/java-config';
 import { graphqlName, toUpper } from 'graphql-transformer-common';
 
@@ -248,6 +248,24 @@ const generateManyToManyModelStubs = (options: Types.PresetFnArgs<AppSyncModelCo
   return models;
 }
 
+const generateIntrospectionPreset = (
+  options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>,
+  models: TypeDefinitionNode[],
+): Types.GenerateOptions[] => {
+  const config: Types.GenerateOptions[] = [];
+  // model-intropection.json
+  config.push({
+    ...options,
+    filename: join(options.baseOutputDir, 'model-introspection.json'),
+    config: {
+      ...options.config,
+      scalars: { ...METADATA_SCALAR_MAP, ...options.config.scalars },
+      target: 'introspection',
+    },
+  });
+  return config;
+}
+
 export const preset: Types.OutputPreset<AppSyncModelCodeGenPresetConfig> = {
   buildGeneratesSection: (options: Types.PresetFnArgs<AppSyncModelCodeGenPresetConfig>): Types.GenerateOptions[] => {
     const codeGenTarget = options.config.target;
@@ -272,6 +290,8 @@ export const preset: Types.OutputPreset<AppSyncModelCodeGenPresetConfig> = {
         return generateTypeScriptPreset(options, models);
       case 'dart':
         return generateDartPreset(options, models);
+      case 'introspection':
+        return generateIntrospectionPreset(options, models);
       default:
         throw new Error(
           `amplify-codegen-appsync-model-plugin not support language target ${codeGenTarget}. Supported codegen targets arr ${APPSYNC_DATA_STORE_CODEGEN_TARGETS.join(

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -1,0 +1,143 @@
+import { DEFAULT_SCALARS, NormalizedScalarsMap } from "@graphql-codegen/visitor-plugin-common";
+import { GraphQLSchema } from "graphql";
+import { AssociationType, Field, Fields, FieldType, ModelAttribute, ModelIntrospectionSchema, SchemaEnum, SchemaModel, SchemaNonModel } from "../interfaces/introspection";
+import { METADATA_SCALAR_MAP } from "../scalars";
+import { CodeGenConnectionType } from "../utils/process-connections";
+import { RawAppSyncModelConfig, ParsedAppSyncModelConfig, AppSyncModelVisitor, CodeGenEnum, CodeGenField, CodeGenModel } from "./appsync-visitor";
+import fs from 'fs';
+import path from 'path';
+import Ajv from 'ajv';
+
+export interface RawAppSyncModelIntrospectionConfig extends RawAppSyncModelConfig {};
+export interface ParsedAppSyncModelIntrospectionConfig extends ParsedAppSyncModelConfig {};
+export class AppSyncModelIntrospectionVisitor<
+  TRawConfig extends RawAppSyncModelIntrospectionConfig = RawAppSyncModelIntrospectionConfig,
+  TPluginConfig extends ParsedAppSyncModelIntrospectionConfig = ParsedAppSyncModelIntrospectionConfig
+> extends AppSyncModelVisitor<TRawConfig, TPluginConfig> {
+  private readonly introspectionVersion = 1;
+  private schemaValidator: Ajv.ValidateFunction;
+  constructor(
+    schema: GraphQLSchema,
+    rawConfig: TRawConfig,
+    additionalConfig: Partial<TPluginConfig>,
+    defaultScalars: NormalizedScalarsMap = DEFAULT_SCALARS,
+  ) {
+    super(schema, rawConfig, additionalConfig, defaultScalars);
+    const modelIntrospectionSchemaText = fs.readFileSync(path.join(__dirname, '..', '..', 'schemas', 'introspection', this.introspectionVersion.toString(), 'ModelIntrospectionSchema.json'), 'utf8');
+    const modelIntrospectionSchema = JSON.parse(modelIntrospectionSchemaText);
+    this.schemaValidator = new Ajv().compile(modelIntrospectionSchema);
+  }
+  generate(): string {
+    const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
+    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    const modelIntrosepctionSchema = this.generateModelIntrospectionSchema();
+    if (!this.schemaValidator(modelIntrosepctionSchema)) {
+      throw new Error(`Data did not validate against the supplied schema. Underlying errors were ${JSON.stringify(this.schemaValidator.errors)}`);
+    }
+    return JSON.stringify(modelIntrosepctionSchema, null, 4);
+  }
+
+  protected generateModelIntrospectionSchema(): ModelIntrospectionSchema {
+    const result: ModelIntrospectionSchema = {
+      version: this.introspectionVersion,
+      models: {},
+      enums: {},
+      nonModels: {},
+    };
+
+    const models = Object.values(this.getSelectedModels()).reduce((acc, model: CodeGenModel) => {
+      return { ...acc, [model.name]: this.generateModelMetadata(model) };
+    }, {});
+    const nonModels = Object.values(this.getSelectedNonModels()).reduce((acc, nonModel: CodeGenModel) => {
+      return { ...acc, [nonModel.name]: this.generateNonModelMetadata(nonModel) };
+    }, {});
+    const enums = Object.values(this.enumMap).reduce((acc, enumObj) => {
+      return { ...acc, [this.getEnumName(enumObj)]: this.generateEnumMetadata(enumObj) };
+    }, {});
+    return { ...result, models, nonModels, enums };
+  }
+
+  private getFieldAssociation(field: CodeGenField): AssociationType | void {
+    if (field.connectionInfo) {
+      const { connectionInfo } = field;
+      const connectionAttribute: any = { connectionType: connectionInfo.kind };
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
+        connectionAttribute.associatedWith = connectionInfo.associatedWithFields.map(f => this.getFieldName(f));
+      } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+          connectionAttribute.associatedWith = connectionInfo.associatedWithFields.map(f => this.getFieldName(f));
+          connectionAttribute.targetNames = connectionInfo.targetNames;
+      } else {
+        connectionAttribute.targetNames = connectionInfo.targetNames;
+      }
+      return connectionAttribute;
+    }
+  }
+
+  private generateModelAttributes(model: CodeGenModel): ModelAttribute[] {
+    return model.directives.map(d => ({
+      type: d.name,
+      properties: d.arguments,
+    }));
+  }
+  private generateModelMetadata(model: CodeGenModel): SchemaModel {
+    return {
+      ...this.generateNonModelMetadata(model),
+      syncable: true,
+      pluralName: this.pluralizeModelName(model),
+      attributes: this.generateModelAttributes(model),
+    };
+  }
+
+  private generateNonModelMetadata(nonModel: CodeGenModel): SchemaNonModel {
+    return {
+      name: this.getModelName(nonModel),
+      fields: nonModel.fields.reduce((acc: Fields, field: CodeGenField) => {
+        const fieldMeta: Field = {
+          name: this.getFieldName(field),
+          isArray: field.isList,
+          type: this.getType(field.type),
+          isRequired: !field.isNullable,
+          attributes: [],
+        };
+
+        if (field.isListNullable !== undefined) {
+          fieldMeta.isArrayNullable = field.isListNullable;
+        }
+
+        if (field.isReadOnly !== undefined) {
+          fieldMeta.isReadOnly = field.isReadOnly;
+        }
+
+        const association: AssociationType | void = this.getFieldAssociation(field);
+        if (association) {
+          fieldMeta.association = association;
+        }
+        acc[field.name] = fieldMeta;
+        return acc;
+      }, {}),
+    };
+  }
+  private generateEnumMetadata(enumObj: CodeGenEnum): SchemaEnum {
+    return {
+      name: enumObj.name,
+      values: Object.values(enumObj.values),
+    };
+  }
+
+  protected getType(gqlType: string): FieldType {
+    // Todo: Handle unlisted scalars
+    if (gqlType in METADATA_SCALAR_MAP) {
+      return METADATA_SCALAR_MAP[gqlType] as FieldType;
+    }
+    if (gqlType in this.enumMap) {
+      return { enum: this.enumMap[gqlType].name };
+    }
+    if (gqlType in this.nonModelMap) {
+      return { nonModel: gqlType };
+    }
+    if (gqlType in this.modelMap) {
+      return { model: gqlType };
+    }
+    throw new Error(`Unknown type ${gqlType}`);
+  }
+}

--- a/packages/appsync-modelgen-plugin/tsconfig.json
+++ b/packages/appsync-modelgen-plugin/tsconfig.json
@@ -3,5 +3,11 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib"
-  }
+  },
+  "exclude": [
+    "scripts",
+    "schemas",
+    "lib",
+    "src/__tests__"
+  ]
 }

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -35,6 +35,7 @@ const KNOWN_SUITES_SORTED_ACCORDING_TO_RUNTIME = [
   'src/__tests__/datastore-modelgen-flutter.test.ts',
   'src/__tests__/add-codegen-android.test.ts',
   'src/__tests__/add-codegen-ios.test.ts',
+  'src/__tests__/model-introspection-codegen.test.ts',
   // <11m
   'src/__tests__/add-codegen-js.test.ts',
   'src/__tests__/env-codegen.test.ts',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add new codegen command which will generate the `model-introspection.json` file under the given directory path.
```bash
$ amplify codegen model-introspection --output-dir ${dir_path_input}
```
The changes include:
- New introspection visitor
- JSON schema and its validator
- Script for generating JSON schema from TS type definition file
- Unit and E2E tests

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.