### PR TITLE
fix: support pre-release version tags for dart version check

### DIFF
--- a/packages/amplify-codegen/src/utils/validateDartSDK.js
+++ b/packages/amplify-codegen/src/utils/validateDartSDK.js
@@ -9,7 +9,7 @@ function validateDartSDK(context, projectRoot) {
   try {
     const config = yaml.load(fs.readFileSync(path.join(projectRoot, PUBSPEC_FILE_NAME), 'utf8'));
     const version = semver.minVersion(config.environment.sdk);
-    if (semver.satisfies(version, '>= 2.12.0')) {
+    if (semver.satisfies(version, '>= 2.12.0', { includePrerelease: true })) {
       context.print.warning('\nDetected Dart SDK version 2.12.0 or above');
       return true;
     }

--- a/packages/amplify-codegen/tests/utils/validateDartSDK.test.js
+++ b/packages/amplify-codegen/tests/utils/validateDartSDK.test.js
@@ -26,6 +26,7 @@ describe('Validate Dart SDK version tests', () => {
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
       expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(true);
     });
+
     it('with caret version', () => {
       const config = {
         environment: {
@@ -35,10 +36,31 @@ describe('Validate Dart SDK version tests', () => {
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
       expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(true);
     });
+
+    it('with preRelease caret version', () => {
+      const config = {
+        environment: {
+          sdk: '^2.18.0-release1',
+        },
+      };
+      mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
+      expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(true);
+    });
+
     it('with ranged version', () => {
       const config = {
         environment: {
           sdk: '>=2.12.0 <3.0.0',
+        },
+      };
+      mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
+      expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(true);
+    });
+
+    it('with preRelease range', () => {
+      const config = {
+        environment: {
+          sdk: '>=2.18.0-release1 <3.0.0',
         },
       };
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
@@ -56,6 +78,7 @@ describe('Validate Dart SDK version tests', () => {
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
       expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(false);
     });
+
     it('with caret version', () => {
       const config = {
         environment: {
@@ -65,10 +88,31 @@ describe('Validate Dart SDK version tests', () => {
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
       expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(false);
     });
+
+    it('with preRelease caret version', () => {
+      const config = {
+        environment: {
+          sdk: '^2.0.0-release1',
+        },
+      };
+      mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
+      expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(false);
+    });
+
     it('with ranged version', () => {
       const config = {
         environment: {
           sdk: '>=2.0.0 <3.0.0',
+        },
+      };
+      mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });
+      expect(validateDartSDK(MOCK_CONTEXT, MOCK_PROJECT_ROOT)).toBe(false);
+    });
+
+    it('with preRelease range', () => {
+      const config = {
+        environment: {
+          sdk: '>=2.0.0-release1 <3.0.0',
         },
       };
       mockFs({ [MOCK_PUBSPEC_FILE_PATH]: yaml.dump(config) });


### PR DESCRIPTION
#### Description of changes
Enable the `allowPreRelease` flag for our semver check to enable capturing tagged releases correctly.

#### Issue #, if available
https://github.com/aws-amplify/amplify-codegen/issues/437

#### Description of how you validated changes
Added unit tests to cover the cases described in the issue which failed, then made the change and they pass.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.