### PR TITLE
Add support for output dir arg on models

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -1,9 +1,10 @@
 import { AmplifyFrontend } from '../utils';
 import { getCLIPath, nspawn as spawn } from '..';
 
-export function generateModels(cwd: string): Promise<void> {
+export function generateModels(cwd: string, outputDir?: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['codegen', 'models'], { cwd, stripColors: true })
+    const params = ['codegen', 'models', ...(outputDir ? ['--output-dir', outputDir] : [])]
+    spawn(getCLIPath(), params, { cwd, stripColors: true })
     .run((err: Error) => {
       if (!err) {
         resolve();

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
@@ -16,5 +16,9 @@ describe('Datastore Modelgen tests - Android', () => {
 
     it(`should generate files at desired location and not delete src files`, async () => {
         await testCodegenModels(DEFAULT_ANDROID_CONFIG, projectRoot, schema);
+    });
+
+    it('Should generate files at overridden output path', async () => {
+        await testCodegenModels(DEFAULT_ANDROID_CONFIG, projectRoot, schema, 'app/src/main/guava');
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
@@ -17,4 +17,8 @@ describe('Datastore Modelgen tests - Flutter', () => {
     it(`should generate files at desired location and not delete src files`, async () => {
         await testCodegenModels(DEFAULT_FLUTTER_CONFIG, projectRoot, schema);
     });
+
+  it(`should generate files at overridden location`, async () => {
+    await testCodegenModels(DEFAULT_FLUTTER_CONFIG, projectRoot, schema, 'lib/blueprints');
+  });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_IOS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_IOS_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
@@ -16,5 +16,9 @@ describe('Datastore Modelgen tests - iOS', () => {
 
     it(`should generate files at desired location and not delete src files`, async () => {
         await testCodegenModels(DEFAULT_IOS_CONFIG, projectRoot, schema);
+    });
+
+    it(`should generate files at overridden location`, async () => {
+      await testCodegenModels(DEFAULT_IOS_CONFIG, projectRoot, schema, 'amplification/manufactured/models');
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
@@ -1,4 +1,4 @@
-import { createNewProjectDir, DEFAULT_JS_CONFIG } from "@aws-amplify/amplify-codegen-e2e-core";
+import { createNewProjectDir, DEFAULT_JS_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
@@ -16,5 +16,9 @@ describe('Datastore Modelgen tests - JS', () => {
 
     it(`should generate files at desired location and not delete src files`, async () => {
         await testCodegenModels(DEFAULT_JS_CONFIG, projectRoot, schema);
+    });
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+      await testCodegenModels(DEFAULT_JS_CONFIG, projectRoot, schema, 'src/backmodels');
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -5,12 +5,12 @@ import {
     createRandomName,
     generateModels,
     AmplifyFrontendConfig
-} from "@aws-amplify/amplify-codegen-e2e-core";
+} from '@aws-amplify/amplify-codegen-e2e-core';
 import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';
 
-export async function testCodegenModels(config: AmplifyFrontendConfig, projectRoot: string, schema: string) {
+export async function testCodegenModels(config: AmplifyFrontendConfig, projectRoot: string, schema: string, outputDir?: string) {
     const name = createRandomName();
 
     // init project and add API category
@@ -24,10 +24,10 @@ export async function testCodegenModels(config: AmplifyFrontendConfig, projectRo
     const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);
 
     //generate models
-    await expect(generateModels(projectRoot)).resolves.not.toThrow();
+    await expect(generateModels(projectRoot, outputDir)).resolves.not.toThrow();
 
     // pre-existing file should still exist
     expect(existsSync(userSourceCodePath)).toBe(true);
     // datastore models are generated at correct location
-    expect(isNotEmptyDir(path.join(projectRoot, config.modelgenDir))).toBe(true);
+    expect(isNotEmptyDir(outputDir ? outputDir : path.join(projectRoot, config.modelgenDir))).toBe(true);
 }

--- a/packages/amplify-codegen/src/commands/model-intropection.js
+++ b/packages/amplify-codegen/src/commands/model-intropection.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 async function generateModelIntrospection(context) {
   // Verify override path flag is provided
-  const outputDirParam = context.parameters.options ? context.parameters.options['output-dir'] : null;
+  const outputDirParam = context.parameters?.options?.['output-dir'];
   if ( !outputDirParam || typeof(outputDirParam) !== 'string' ) {
     throw new Error('Expected --output-dir flag with value to be set for model introspection command.');
   }

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -78,7 +78,7 @@ async function generateModels(context, outputDirPath = null, isIntrospection = f
   const schemaContent = loadSchema(apiResourcePath);
 
   const outputDirParam = context.parameters?.options?.['output-dir'];
-  if ( !outputDirPath && typeof(outputDirParam) !== 'string' ) {
+  if ( !outputDirPath && outputDirParam && typeof(outputDirParam) !== 'string' ) {
     throw new Error('Expected provided --output-dir flag to be given output location as input.');
   }
   const outputPath = outputDirPath ?? outputDirParam ?? path.join(projectRoot, getModelOutputPath(context));

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -77,7 +77,7 @@ async function generateModels(context, outputDirPath = null, isIntrospection = f
 
   const schemaContent = loadSchema(apiResourcePath);
 
-  const outputDirParam = context.parameters.options?.['output-dir'];
+  const outputDirParam = context.parameters?.options?.['output-dir'];
   if ( !outputDirPath && typeof(outputDirParam) !== 'string' ) {
     throw new Error('Expected provided --output-dir flag to be given output location as input.');
   }

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -76,7 +76,12 @@ async function generateModels(context, outputDirPath = null, isIntrospection = f
   });
 
   const schemaContent = loadSchema(apiResourcePath);
-  const outputPath = outputDirPath || path.join(projectRoot, getModelOutputPath(context));
+
+  const outputDirParam = context.parameters.options?.['output-dir'];
+  if ( !outputDirPath && typeof(outputDirParam) !== 'string' ) {
+    throw new Error('Expected provided --output-dir flag to be given output location as input.');
+  }
+  const outputPath = outputDirPath ?? outputDirParam ?? path.join(projectRoot, getModelOutputPath(context));
   const schema = parse(schemaContent);
   const projectConfig = context.amplify.getProjectConfig();
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Add support for new `--output-dir` flag when invoking models directly. The parameter is not required


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
N/A


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.