### PR TITLE
fix(e2e): Resolve the local version codegen for e2e tests

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -36,9 +36,10 @@ install_cli_with_local_codegen: &install_cli
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
-    sudo npm install -g @aws-amplify/cli-internal
+    changeNpmGlobalPath
+    npm install -g @aws-amplify/cli-internal
     amplify -v
-    sudo npm list --global --depth=1
+    npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
         

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -37,9 +37,7 @@ install_cli_with_local_codegen: &install_cli
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     sudo npm install -g @aws-amplify/cli-internal
-    sudo npm install -g amplify-app
     amplify -v
-    amplify-app --version
     sudo npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
@@ -155,6 +153,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
+      - restore_cache:
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
           key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run: *install_cli

--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -40,6 +40,7 @@ install_cli_with_local_codegen: &install_cli
     sudo npm install -g amplify-app
     amplify -v
     amplify-app --version
+    sudo npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
         

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,7 @@ install_cli_with_local_codegen: &ref_3
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
     sudo npm install -g @aws-amplify/cli-internal
-    sudo npm install -g amplify-app
     amplify -v
-    amplify-app --version
     sudo npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
@@ -158,6 +156,8 @@ jobs:
     steps: &ref_4
       - attach_workspace:
           at: ./
+      - restore_cache:
+          key: 'amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}'
       - restore_cache:
           key: 'amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}'
       - run: *ref_3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ install_cli_with_local_codegen: &ref_3
     sudo npm install -g amplify-app
     amplify -v
     amplify-app --version
+    sudo npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
 clean_up_e2e_resources: &ref_5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,10 @@ install_cli_with_local_codegen: &ref_3
     source .circleci/local_publish_helpers.sh
     startLocalRegistry "$(pwd)/.circleci/verdaccio.yaml"
     setNpmRegistryUrlToLocal
-    sudo npm install -g @aws-amplify/cli-internal
+    changeNpmGlobalPath
+    npm install -g @aws-amplify/cli-internal
     amplify -v
-    sudo npm list --global --depth=1
+    npm list --global --depth=1
     unsetNpmRegistryUrl
   working_directory: ~/repo
 clean_up_e2e_resources: &ref_5

--- a/.circleci/local_publish_helpers.sh
+++ b/.circleci/local_publish_helpers.sh
@@ -28,3 +28,9 @@ function setNpmRegistryUrlToLocal {
   npm set registry "$custom_registry_url"
   yarn config set registry "$custom_registry_url"
 }
+
+function changeNpmGlobalPath {
+  mkdir -p ~/.npm-global
+  npm config set prefix '~/.npm-global'
+  export PATH=~/.npm-global/bin:$PATH
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The e2e tests are now resolved to the real local version of `amplify-codegen`

- Added script to change npm global directory to give correct access for `npm install` on CI
- Removed `amplify-app` installation
- Added `npm list` to check the installed amplify CLI plugin versions


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.