### PR TITLE
fix: simplify outputDirParam handling, and plumb through to models

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-android.test.ts
@@ -1,5 +1,6 @@
 import { createNewProjectDir, DEFAULT_ANDROID_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
 
@@ -19,6 +20,6 @@ describe('Datastore Modelgen tests - Android', () => {
     });
 
     it('Should generate files at overridden output path', async () => {
-        await testCodegenModels(DEFAULT_ANDROID_CONFIG, projectRoot, schema, 'app/src/main/guava');
+        await testCodegenModels(DEFAULT_ANDROID_CONFIG, projectRoot, schema, path.join('app', 'src', 'main', 'guava'));
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-flutter.test.ts
@@ -1,5 +1,6 @@
 import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
 
@@ -19,6 +20,6 @@ describe('Datastore Modelgen tests - Flutter', () => {
     });
 
   it(`should generate files at overridden location`, async () => {
-    await testCodegenModels(DEFAULT_FLUTTER_CONFIG, projectRoot, schema, 'lib/blueprints');
+    await testCodegenModels(DEFAULT_FLUTTER_CONFIG, projectRoot, schema, path.join('lib', 'blueprints'));
   });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-ios.test.ts
@@ -1,5 +1,6 @@
 import { createNewProjectDir, DEFAULT_IOS_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
 
@@ -19,6 +20,6 @@ describe('Datastore Modelgen tests - iOS', () => {
     });
 
     it(`should generate files at overridden location`, async () => {
-      await testCodegenModels(DEFAULT_IOS_CONFIG, projectRoot, schema, 'amplification/manufactured/models');
+      await testCodegenModels(DEFAULT_IOS_CONFIG, projectRoot, schema, path.join('amplification', 'manufactured', 'models'));
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/datastore-modelgen-js.test.ts
@@ -1,5 +1,6 @@
 import { createNewProjectDir, DEFAULT_JS_CONFIG } from '@aws-amplify/amplify-codegen-e2e-core';
 import { deleteAmplifyProject, testCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
 
 const schema = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
 
@@ -19,6 +20,6 @@ describe('Datastore Modelgen tests - JS', () => {
     });
 
     it(`should generate files at desired location and not delete src files`, async () => {
-      await testCodegenModels(DEFAULT_JS_CONFIG, projectRoot, schema, 'src/backmodels');
+      await testCodegenModels(DEFAULT_JS_CONFIG, projectRoot, schema, path.join('src', 'backmodels'));
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -29,5 +29,8 @@ export async function testCodegenModels(config: AmplifyFrontendConfig, projectRo
     // pre-existing file should still exist
     expect(existsSync(userSourceCodePath)).toBe(true);
     // datastore models are generated at correct location
-    expect(isNotEmptyDir(outputDir ? outputDir : path.join(projectRoot, config.modelgenDir))).toBe(true);
+    const dirToCheck = outputDir
+        ? path.join(projectRoot, outputDir)
+        : path.join(projectRoot, config.modelgenDir);
+    expect(isNotEmptyDir(dirToCheck)).toBe(true);
 }

--- a/packages/amplify-codegen/commands/codegen/models.js
+++ b/packages/amplify-codegen/commands/codegen/models.js
@@ -1,12 +1,14 @@
 const codeGen = require('../../src');
 const { exitOnNextTick } = require('amplify-cli-core');
+const getOutputDirParam = require('../../src/utils/getOutputDirParam');
+
 const featureName = 'models';
 
 module.exports = {
   name: featureName,
   run: async context => {
     try {
-      await codeGen.generateModels(context);
+      await codeGen.generateModels(context, getOutputDirParam(context, false));
     } catch (ex) {
       context.print.info(ex.message);
       console.log(ex.stack);

--- a/packages/amplify-codegen/src/commands/model-intropection.js
+++ b/packages/amplify-codegen/src/commands/model-intropection.js
@@ -1,14 +1,8 @@
 const generateModels = require('./models');
-const path = require('path');
+const getOutputDirParam = require('../utils/getOutputDirParam');
 
 async function generateModelIntrospection(context) {
-  // Verify override path flag is provided
-  const outputDirParam = context.parameters?.options?.['output-dir'];
-  if ( !outputDirParam || typeof(outputDirParam) !== 'string' ) {
-    throw new Error('Expected --output-dir flag with value to be set for model introspection command.');
-  }
-  const outputDirPath = path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
-  await generateModels(context, outputDirPath, true);
+  await generateModels(context, getOutputDirParam(context, true), true);
 }
 
 module.exports = generateModelIntrospection;

--- a/packages/amplify-codegen/src/utils/getOutputDirParam.js
+++ b/packages/amplify-codegen/src/utils/getOutputDirParam.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+/**
+ * Retrieve the output directory parameter from the command line. Throws on invalid value,
+ *   or if isRequired is set and the flag isn't in the options. Returns null on optional and not defined.
+ * @param context the CLI invocation context
+ * @param isRequired whether or not the flag is required
+ * @returns the absolute path to the output directory
+ */
+function getOutputDirParam(context, isRequired) {
+  const outputDirParam = context.parameters?.options?.['output-dir'];
+  if ( isRequired && !outputDirParam ) {
+    throw new Error('Expected --output-dir flag to be set');
+  }
+  if ( !outputDirParam ) {
+    return null;
+  }
+  return path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
+}
+
+module.exports = getOutputDirParam;

--- a/packages/amplify-codegen/tests/utils/getOutputDirParam.test.js
+++ b/packages/amplify-codegen/tests/utils/getOutputDirParam.test.js
@@ -1,0 +1,37 @@
+const getOutputDirParam = require('../../src/utils/getOutputDirParam');
+const path = require('path');
+
+const PROJECT_PATH = path.join(__dirname, 'project');
+
+describe('getOutputDirParam', () => {
+  const createContextWithOptions = (options) => ({
+    amplify: {
+      getEnvInfo: () => ({
+        projectPath: PROJECT_PATH
+      }),
+    },
+    ...(options ? { parameters: { options } } : {})
+  });
+
+  it('should throw on missing flag when required is set', () => {
+    const context = createContextWithOptions(null);
+    expect(() => getOutputDirParam(context, true)).toThrowErrorMatchingInlineSnapshot('"Expected --output-dir flag to be set"');
+  });
+
+  it('should not throw on missing flag when required is not set', () => {
+    const context = createContextWithOptions(null);
+    expect(() => getOutputDirParam(context, false)).not.toThrowError();
+  });
+
+  it('should return for relative path set independent of whether is required', () => {
+    const context = createContextWithOptions({ 'output-dir': path.join('src', 'models') });
+    expect(getOutputDirParam(context, true)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+    expect(getOutputDirParam(context, false)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+  });
+
+  it('should return for absolute path set independent of whether is required', () => {
+    const context = createContextWithOptions({ 'output-dir': path.join(PROJECT_PATH, 'src', 'models') });
+    expect(getOutputDirParam(context, true)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+    expect(getOutputDirParam(context, false)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/preset.ts
+++ b/packages/appsync-modelgen-plugin/src/preset.ts
@@ -24,6 +24,7 @@ export type AppSyncModelCodeGenPresetConfig = {
    *    - amplify-codegen-appsync-model-plugin
    * ```
    */
+  overrideOutputDir: string | null;
   target: 'java' | 'swift' | 'javascript' | 'typescript' | 'dart';
 };
 
@@ -32,12 +33,12 @@ const generateJavaPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
-  const baseOutputDir = [options.baseOutputDir, ...GENERATED_PACKAGE_NAME.split('.')];
+  const modelFolder = options.config.overrideOutputDir ? [options.config.overrideOutputDir] : [options.baseOutputDir, ...GENERATED_PACKAGE_NAME.split('.')];
   models.forEach(model => {
     const modelName = model.name.value;
     config.push({
       ...options,
-      filename: join(...baseOutputDir, `${modelName}.java`),
+      filename: join(...modelFolder, `${modelName}.java`),
       config: {
         ...options.config,
         scalars: { ...JAVA_SCALAR_MAP, ...options.config.scalars },
@@ -49,7 +50,7 @@ const generateJavaPreset = (
   // Class loader
   config.push({
     ...options,
-    filename: join(...baseOutputDir, `${LOADER_CLASS_NAME}.java`),
+    filename: join(...modelFolder, `${LOADER_CLASS_NAME}.java`),
     config: {
       ...options.config,
       scalars: { ...JAVA_SCALAR_MAP, ...options.config.scalars },
@@ -65,11 +66,12 @@ const generateSwiftPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : options.baseOutputDir;
   models.forEach(model => {
     const modelName = model.name.value;
     config.push({
       ...options,
-      filename: join(options.baseOutputDir, `${modelName}.swift`),
+      filename: join(modelFolder, `${modelName}.swift`),
       config: {
         ...options.config,
         scalars: { ...SWIFT_SCALAR_MAP, ...options.config.scalars },
@@ -80,7 +82,7 @@ const generateSwiftPreset = (
     if (model.kind !== Kind.ENUM_TYPE_DEFINITION) {
       config.push({
         ...options,
-        filename: join(options.baseOutputDir, `${modelName}+Schema.swift`),
+        filename: join(modelFolder, `${modelName}+Schema.swift`),
         config: {
           ...options.config,
           target: 'swift',
@@ -95,7 +97,7 @@ const generateSwiftPreset = (
   // class loader
   config.push({
     ...options,
-    filename: join(options.baseOutputDir, `AmplifyModels.swift`),
+    filename: join(modelFolder, `AmplifyModels.swift`),
     config: {
       ...options.config,
       scalars: { ...SWIFT_SCALAR_MAP, ...options.config.scalars },
@@ -111,7 +113,7 @@ const generateTypeScriptPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
-  const modelFolder = join(options.baseOutputDir, 'models');
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : join(options.baseOutputDir, 'models');
   config.push({
     ...options,
     filename: join(modelFolder, 'index.ts'),
@@ -140,7 +142,7 @@ const generateJavasScriptPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
-  const modelFolder = join(options.baseOutputDir, 'models');
+  const modelFolder = options.config.overrideOutputDir ? options.config.overrideOutputDir : join(options.baseOutputDir, 'models');
   config.push({
     ...options,
     filename: join(modelFolder, 'index.js'),
@@ -193,11 +195,12 @@ const generateDartPreset = (
   models: TypeDefinitionNode[],
 ): Types.GenerateOptions[] => {
   const config: Types.GenerateOptions[] = [];
+  const modelFolder = options.config.overrideOutputDir ?? options.baseOutputDir;
   models.forEach(model => {
     const modelName = model.name.value;
     config.push({
       ...options,
-      filename: join(options.baseOutputDir, `${modelName}.dart`),
+      filename: join(modelFolder, `${modelName}.dart`),
       config: {
         ...options.config,
         scalars: { ...DART_SCALAR_MAP, ...options.config.scalars },
@@ -208,7 +211,7 @@ const generateDartPreset = (
   // Class loader
   config.push({
     ...options,
-    filename: join(options.baseOutputDir, `ModelProvider.dart`),
+    filename: join(modelFolder, `ModelProvider.dart`),
     config: {
       ...options.config,
       scalars: { ...DART_SCALAR_MAP, ...options.config.scalars },
@@ -256,7 +259,7 @@ const generateIntrospectionPreset = (
   // model-intropection.json
   config.push({
     ...options,
-    filename: join(options.baseOutputDir, 'model-introspection.json'),
+    filename: join(options.config.overrideOutputDir!, 'model-introspection.json'),
     config: {
       ...options.config,
       scalars: { ...METADATA_SCALAR_MAP, ...options.config.scalars },


### PR DESCRIPTION
#### Description of changes
`--output-dir` flag wasn't applying for `codegen models` correctly, we needed to plumb the flag all the way through, I also refactored how we detect the flag a bit to simplify the `generateModels` method a bit.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests, verified that both modelgen and model-introspection e2e tests are passing now.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.