### PR TITLE
chore: Bump cli core to next major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^8.10.1",
-    "typescript": "^4.7.4",
+    "typescript": "4.7.4",
     "amplify-cli-core":  "^3.0.0",
     "graphql-transformer-core": "^7.2.1",
     "amplify-headless-interface": "^1.13.1"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ts-jest": "^28.0.7",
     "ts-node": "^8.10.1",
     "typescript": "^4.7.4",
-    "amplify-cli-core":  "^2.3.0",
+    "amplify-cli-core":  "^3.0.0",
     "graphql-transformer-core": "^7.2.1",
     "amplify-headless-interface": "^1.13.1"
   },

--- a/packages/amplify-codegen-e2e-core/package.json
+++ b/packages/amplify-codegen-e2e-core/package.json
@@ -35,7 +35,7 @@
     "uuid": "7.0.1"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^2.3.0",
+    "amplify-cli-core": "^3.0.0",
     "amplify-headless-interface": "^1.13.1",
     "graphql-transformer-core": "^7.2.1"
   }

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^8.9.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^2.3.0",
+    "amplify-cli-core": "^3.0.0",
     "graphql-transformer-core": "^7.2.1"
   },
   "jest": {

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -37,7 +37,7 @@
     "slash": "^3.0.0"
   },
   "peerDependencies": {
-    "amplify-cli-core": "^2.3.0",
+    "amplify-cli-core": "^3.0.0",
     "graphql-transformer-core": "^7.2.1"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13868,15 +13868,15 @@ typescript-json-schema@~0.52.0:
     typescript "~4.4.4"
     yargs "^17.1.1"
 
+typescript@4.7.4, typescript@^4.6.4:
+  version "4.7.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 typescript@^3.2.1:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-typescript@^4.6.4, typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typescript@~4.4.4:
   version "4.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,12 +143,12 @@
     "@turf/boolean-clockwise" "6.5.0"
     camelcase-keys "6.2.2"
 
-"@aws-amplify/graphql-transformer-core@^0.17.6":
-  version "0.17.7"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.7.tgz#a9a2dba8fc6442eb9ba7f10e0caabc17818e3929"
-  integrity sha512-72eZ/EHlOgYtLUQGSfO0WjmKqFH9f0Sd4Apxkt2JmKXxFW8zxdaPiDWWKLFL3soMFcWTeCmpWAWXX03x3Kiwgg==
+"@aws-amplify/graphql-transformer-core@^0.17.11":
+  version "0.17.11"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-core/-/graphql-transformer-core-0.17.11.tgz#70243c53647382359852a7de8dba22133e5cb2f4"
+  integrity sha512-ErjsrZ9ZhZeLfFS9bqAQBxpIwF/p85KBc3iVvlEWj9WedEZrWWO0aQHSZuYjJ5ENl5yUCz0roamXeqdt6K3qsg==
   dependencies:
-    "@aws-amplify/graphql-transformer-interfaces" "1.14.4"
+    "@aws-amplify/graphql-transformer-interfaces" "1.14.7"
     "@aws-cdk/aws-applicationautoscaling" "~1.124.0"
     "@aws-cdk/aws-appsync" "~1.124.0"
     "@aws-cdk/aws-certificatemanager" "~1.124.0"
@@ -183,10 +183,10 @@
     ts-dedent "^2.0.0"
     vm2 "^3.9.8"
 
-"@aws-amplify/graphql-transformer-interfaces@1.14.4", "@aws-amplify/graphql-transformer-interfaces@^1.14.4":
-  version "1.14.4"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-1.14.4.tgz#84a768a6ec755f5b15ad6df7e4188eeff38cb8f6"
-  integrity sha512-FXGeRQVSdRMg5j51bg7t9MbiJ7F2AB1CHC+U1AcH9wgWbVraWN4+yfaYjKbmQv1NB9p6BsSsQsDNDH7C9KSjuw==
+"@aws-amplify/graphql-transformer-interfaces@1.14.7", "@aws-amplify/graphql-transformer-interfaces@^1.14.7":
+  version "1.14.7"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-1.14.7.tgz#20dbe66f30378433087afe83ec684f096f300bc2"
+  integrity sha512-UCpkRoYbt+GeZVnLSpasH96QZ0AOiZ59eXJWatMoRANMFbREytCP4xN/AyBV3MLEuWidAFpOXVB9e9TfLST5rQ==
   dependencies:
     "@aws-cdk/aws-appsync" "~1.124.0"
     "@aws-cdk/aws-cloudwatch" "~1.124.0"
@@ -6201,16 +6201,16 @@ amazon-cognito-identity-js@5.2.10:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
-amplify-cli-core@^2.3.0:
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-2.11.0.tgz#0cbd03f4feee6511ad37d15d8415c935e8704817"
-  integrity sha512-oCq0k/cHY+tqE/izlNyK/kvy46HNCPCSqA1jJxItclkGfov8nUCy2PKpvwR1sSOVszu5/tpttP46XRBM7/sMHA==
+amplify-cli-core@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-3.0.0.tgz#44a5768c2b8beaf56d805d099af9241ebfc879f8"
+  integrity sha512-0odc4IeyrqlCYCJdvpNnpTkTZr/sf/saEnjGc307UwmSr0B8FR+z94mCzQMvsjDU92B7wTpQDGkWwHPwBEonTA==
   dependencies:
-    "@aws-amplify/graphql-transformer-core" "^0.17.6"
-    "@aws-amplify/graphql-transformer-interfaces" "^1.14.4"
+    "@aws-amplify/graphql-transformer-core" "^0.17.11"
+    "@aws-amplify/graphql-transformer-interfaces" "^1.14.7"
     ajv "^6.12.6"
     amplify-cli-logger "1.2.0"
-    amplify-prompts "2.2.0"
+    amplify-prompts "2.3.0"
     chalk "^4.1.1"
     ci-info "^2.0.0"
     cloudform-types "^4.2.0"
@@ -6218,7 +6218,7 @@ amplify-cli-core@^2.3.0:
     execa "^5.1.1"
     fs-extra "^8.1.0"
     globby "^11.0.3"
-    graphql-transformer-core "^7.6.2"
+    graphql-transformer-core "^7.6.5"
     hjson "^3.2.1"
     js-yaml "^4.0.0"
     lodash "^4.17.21"
@@ -6248,10 +6248,10 @@ amplify-headless-interface@^1.13.1:
   resolved "https://registry.npmjs.org/amplify-headless-interface/-/amplify-headless-interface-1.15.0.tgz#a72d001d11d230ab48844b6e57b5f5c9f1cb030e"
   integrity sha512-6U22nhKLu67i6/zbBXZO+1TYmLXym+/e9fnwqeOhnctMCybU56RdWvj4/MhQIywn4DyOTHvYBkRT5o4f1hFSPg==
 
-amplify-prompts@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/amplify-prompts/-/amplify-prompts-2.2.0.tgz#288a52ee990eb19a51eed28c20bd43703980ec78"
-  integrity sha512-JZv9GTVz3//s8QlhNBZRuYcUCoxdAEJU6q2tivl2hN0XK3pckeofaXqv6Fi8e9c8NfUyA/u+JVRR7vE4QIMtyw==
+amplify-prompts@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/amplify-prompts/-/amplify-prompts-2.3.0.tgz#7449638bccb17729767d3bc7a0a2282af3a18d80"
+  integrity sha512-gUiCNhP1yv++qGGRQby3fs2VUBJK7C9Pg3IxPuLQ0CAbqNk0izHrGUEYFunmOF7W2InEgbZjUfjE6IhyeS7dwg==
   dependencies:
     amplify-cli-shared-interfaces "1.1.0"
     chalk "^4.1.1"
@@ -9286,10 +9286,23 @@ graphql-transformer-common@4.24.0:
     md5 "^2.2.1"
     pluralize "8.0.0"
 
-graphql-transformer-core@^7.2.1, graphql-transformer-core@^7.6.2:
+graphql-transformer-core@^7.2.1:
   version "7.6.3"
   resolved "https://registry.npmjs.org/graphql-transformer-core/-/graphql-transformer-core-7.6.3.tgz#8e50b5bb65fa5bcfdde25da4aa33272451911d5b"
   integrity sha512-ACBnFHd8tgSKGSXvskEd+ClulyjLFcUdw6QAoOX01bez8qpUV97Vo/PY0WG2TXaPzC599iEk8DDmCFhEXBUhkA==
+  dependencies:
+    cloudform-types "^4.2.0"
+    deep-diff "^1.0.2"
+    fs-extra "^8.1.0"
+    glob "^7.2.0"
+    graphql "^14.5.8"
+    graphql-transformer-common "4.24.0"
+    lodash "^4.17.21"
+
+graphql-transformer-core@^7.6.5:
+  version "7.6.5"
+  resolved "https://registry.npmjs.org/graphql-transformer-core/-/graphql-transformer-core-7.6.5.tgz#590862d962d35a7fb49f3cfb143ff22169ecf9a0"
+  integrity sha512-L+AzvLg7tHdmEJuHQchB188g5C4COKWvKGAUsC2qIEyPoTb9cfj5zD0aFjfC7tGD4fAnRbZ3pps2WqBX8887Sg==
   dependencies:
     cloudform-types "^4.2.0"
     deep-diff "^1.0.2"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

- Bumped the `amplify-cli-core` to `^3.0.0`
- Pinned `typescript` to `4.7.4` as `4.8+` causes compile error


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.