### PR TITLE
feat: allow model-introspection to be invoked internally to the CLI

### DIFF
--- a/packages/amplify-codegen/commands/codegen/models.js
+++ b/packages/amplify-codegen/commands/codegen/models.js
@@ -8,7 +8,7 @@ module.exports = {
   name: featureName,
   run: async context => {
     try {
-      await codeGen.generateModels(context, getOutputDirParam(context, false));
+      await codeGen.generateModels(context, { overrideOutputDir: getOutputDirParam(context, false) });
     } catch (ex) {
       context.print.info(ex.message);
       console.log(ex.stack);

--- a/packages/amplify-codegen/src/commands/model-intropection.js
+++ b/packages/amplify-codegen/src/commands/model-intropection.js
@@ -1,8 +1,37 @@
 const generateModels = require('./models');
 const getOutputDirParam = require('../utils/getOutputDirParam');
 
+/**
+ * Generate the model introspection file for the input schema, and write to disk based on
+ * the output-dir flag passed in by the customer.
+ */
 async function generateModelIntrospection(context) {
-  await generateModels(context, getOutputDirParam(context, true), true);
+  await generateModels(context, {
+    overrideOutputDir: getOutputDirParam(context, true),
+    isIntrospection: true,
+  });
 }
 
-module.exports = generateModelIntrospection;
+/**
+ * Compute the model introspection schema and return in-memory.
+ * @param context the CLI context, necessary for file locations and feature flags.
+ * @returns the latest version of the model introspection schema shape.
+ */
+async function getModelIntrospection(context) {
+  const generatedCode = await generateModels(context, {
+    overrideOutputDir: '.', // Needed to get output working, not used, since writeToDisk is disabled.
+    isIntrospection: true,
+    writeToDisk: false,
+  });
+
+  if (generatedCode.length !== 1) {
+    throw new Error('Expected a single output to be generated for model introspection.');
+  }
+
+  return JSON.parse(generatedCode[0]);
+}
+
+module.exports = {
+  generateModelIntrospection,
+  getModelIntrospection,
+};

--- a/packages/amplify-codegen/src/index.js
+++ b/packages/amplify-codegen/src/index.js
@@ -5,7 +5,7 @@ const add = require('./commands/add');
 const remove = require('./commands/remove');
 const configure = require('./commands/configure');
 const generateModels = require('./commands/models');
-const generateModelIntrospection = require('./commands/model-intropection');
+const { generateModelIntrospection, getModelIntrospection } = require('./commands/model-intropection');
 const { isCodegenConfigured, switchToSDLSchema } = require('./utils');
 const prePushAddGraphQLCodegenHook = require('./callbacks/prePushAddCallback');
 const prePushUpdateGraphQLCodegenHook = require('./callbacks/prePushUpdateCallback');
@@ -28,4 +28,5 @@ module.exports = {
   handleAmplifyEvent,
   generateModels,
   generateModelIntrospection,
+  getModelIntrospection,
 };


### PR DESCRIPTION
#### Description of changes
This exposes a new method over the plugin system called `getModelIntrospection` which can be invoked from elsewhere in the CLI.

This can be invoked from a location in the CLI which has access to the context via.

```js
const modelIntrospection = await context.amplify.invokePluginMethod(
  context,
  'codegen',
  undefined,
  'getModelIntrospection',
  [context],
);
```

#### Issue #, if available
N/A

#### Description of how you validated changes
Manually aliased this command to the `codegen model-introspection` and inspected the output.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.