### PR TITLE
fix: lazy codegen for schemas without relationships

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -368,6 +368,8 @@ describe('Javascript visitor with default owner auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+        // @ts-ignore
+        import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -460,6 +462,8 @@ describe('Javascript visitor with custom owner field auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+        // @ts-ignore
+        import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -554,6 +558,8 @@ describe('Javascript visitor with multiple owner field auth', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+        // @ts-ignore
+        import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
         export enum SimpleEnum {
           ENUM_VAL1 = \\"enumVal1\\",
@@ -638,6 +644,8 @@ describe('Javascript visitor with auth directives in field level', () => {
       validateTs(declarations);
       expect(declarations).toMatchInlineSnapshot(`
         "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+        // @ts-ignore
+        import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
         type EagerEmployee = {
           readonly id: string;
@@ -713,6 +721,8 @@ describe('Javascript visitor with custom primary key', () => {
     validateTs(declarations);
     expect(declarations).toMatchInlineSnapshot(`
       "import { ModelInit, MutableModel, __modelMeta__, ManagedIdentifier, CompositeIdentifier, CustomIdentifier, OptionallyManagedIdentifier } from \\"@aws-amplify/datastore\\";
+      // @ts-ignore
+      import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
 
 
@@ -943,6 +953,8 @@ describe('New model meta field test', () => {
     validateTs(declarations);
     expect(declarations).toMatchInlineSnapshot(`
       "import { ModelInit, MutableModel, __modelMeta__, ManagedIdentifier, OptionallyManagedIdentifier, CompositeIdentifier, CustomIdentifier } from \\"@aws-amplify/datastore\\";
+      // @ts-ignore
+      import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
 
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -443,6 +443,8 @@ export {
 
 exports[`AppSyncJavascriptVisitor - GQLv2 Regression Tests Works on record creation and updating timestamp 2`] = `
 "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+// @ts-ignore
+import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
 type TodoMetaData = {
   readOnlyFields: 'createdOn' | 'updatedOn';
@@ -777,6 +779,8 @@ export {
 
 exports[`AppSyncJavascriptVisitor - GQLv2 Regression Tests Works when configuring a secondary index 2`] = `
 "import { ModelInit, MutableModel } from \\"@aws-amplify/datastore\\";
+// @ts-ignore
+import { LazyLoading, LazyLoadingDisabled } from \\"@aws-amplify/datastore\\";
 
 type CustomerMetaData = {
   readOnlyFields: 'createdAt' | 'updatedAt';

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -35,7 +35,7 @@ export class AppSyncModelTypeScriptVisitor<
   ];
 
   protected BASE_DATASTORE_IMPORT = new Set(['ModelInit', 'MutableModel']);
-  protected TS_IGNORE_DATASTORE_IMPORT = new Set();
+  protected TS_IGNORE_DATASTORE_IMPORT = new Set(['LazyLoading', 'LazyLoadingDisabled']);
 
   protected MODEL_META_FIELD_NAME = '__modelMeta__';
 
@@ -299,8 +299,6 @@ export class AppSyncModelTypeScriptVisitor<
       const typeNameStr = this.generateModelTypeDeclarationName(modelType);
 
       if (options?.lazy) {
-        this.TS_IGNORE_DATASTORE_IMPORT.add('LazyLoading');
-        this.TS_IGNORE_DATASTORE_IMPORT.add('LazyLoadingDisabled');
         if (field.isList) {
           this.TS_IGNORE_DATASTORE_IMPORT.add('AsyncCollection');
         } else {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Always import `LazyLoading` and `LazyLoadingDisabled` in TypeScript generation. 


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Any schema that does not contain any relationships will result in a type declaration file for TypeScript that is invalid. This is effecting >= 10.3.1 of the CLI and >= 3.2.0 of codegen.

Minimum reproduction:
```
type Todo @model {
  id: ID!
  name: String!
}
```


The generated file 
```
import { ModelInit, MutableModel } from "@aws-amplify/datastore";

type EagerTodo = {
  readonly id: string;
  readonly name: string;
}

type LazyTodo = {
  readonly id: string;
  readonly name: string;
}

export declare type Todo = LazyLoading extends LazyLoadingDisabled ? EagerTodo : LazyTodo

export declare const Todo: (new (init: ModelInit<Todo>) => Todo)
```

The file is missing the lines.
```
// @ts-ignore
import { LazyLoading, LazyLoadingDisabled } from "@aws-amplify/datastore";
```

This results in a compilation error.

```
error TS2304: Cannot find name 'LazyLoading'.
```


#### Description of how you validated changes

* Unit tests
* Create an app with min repro and attempt to build

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.