### PR TITLE
fix: addressing missing key for unidirectional @hasMany on JS

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-has-many.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-has-many.test.ts
@@ -246,6 +246,13 @@ describe('addHasManyKey', () => {
      *   id: ID!
      * }
      */
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    };
     const fooModel: CodeGenModel = {
       name: 'Foo',
       type: 'model',
@@ -260,13 +267,7 @@ describe('addHasManyKey', () => {
           isNullable: false,
           directives: [],
         },
-        {
-          name: 'bar',
-          type: 'Bar',
-          isList: true,
-          isNullable: true,
-          directives: [{ name: 'hasMany', arguments: {} }],
-        },
+        hasManyField,
       ],
     };
     const associationField: CodeGenField = {
@@ -300,9 +301,9 @@ describe('addHasManyKey', () => {
       associatedWith: associationField,
       associatedWithFields: [associationField],
     };
-    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.fooBarsId', fields: ['fooBarsId'] } };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.bar', fields: ['fooBarsId'] } };
 
-    addHasManyKey(fooModel, connection);
+    addHasManyKey(hasManyField, fooModel, connection);
     expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
   });
 
@@ -320,7 +321,14 @@ describe('addHasManyKey', () => {
      *   id: ID!
      * }
      */
-     const fooModel: CodeGenModel = {
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    };
+    const fooModel: CodeGenModel = {
       name: 'Foo',
       type: 'model',
       directives: [
@@ -341,13 +349,7 @@ describe('addHasManyKey', () => {
           isNullable: false,
           directives: [],
         },
-        {
-          name: 'bar',
-          type: 'Bar',
-          isList: true,
-          isNullable: true,
-          directives: [{ name: 'hasMany', arguments: {} }],
-        },
+        hasManyField,
       ],
     };
     const associationFieldPartitionKey: CodeGenField = {
@@ -389,13 +391,20 @@ describe('addHasManyKey', () => {
       associatedWith: associationFieldPartitionKey,
       associatedWithFields: [associationFieldPartitionKey, associationFieldSortKey],
     };
-    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.fooBarsId', fields: ['fooBarsId', 'fooBarsWarehouseId'] } };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.bar', fields: ['fooBarsId', 'fooBarsWarehouseId'] } };
 
-    addHasManyKey(fooModel, connection);
+    addHasManyKey(hasManyField, fooModel, connection);
     expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
   });
 
   it('works with non-cpk fallback connection for empty list', () => {
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    };
     const fooModel: CodeGenModel = {
       name: 'Foo',
       type: 'model',
@@ -410,13 +419,7 @@ describe('addHasManyKey', () => {
           isNullable: false,
           directives: [],
         },
-        {
-          name: 'bar',
-          type: 'Bar',
-          isList: true,
-          isNullable: true,
-          directives: [{ name: 'hasMany', arguments: {} }],
-        },
+        hasManyField,
       ],
     };
     const associationField: CodeGenField = {
@@ -450,13 +453,20 @@ describe('addHasManyKey', () => {
       associatedWith: associationField,
       associatedWithFields: [],
     };
-    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.fooBarsId', fields: ['fooBarsId'] } };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.bar', fields: ['fooBarsId'] } };
 
-    addHasManyKey(fooModel, connection);
+    addHasManyKey(hasManyField, fooModel, connection);
     expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
   });
 
   it('works with non-cpk fallback connection for null assocatedWithFields', () => {
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    };
     const fooModel: CodeGenModel = {
       name: 'Foo',
       type: 'model',
@@ -471,13 +481,7 @@ describe('addHasManyKey', () => {
           isNullable: false,
           directives: [],
         },
-        {
-          name: 'bar',
-          type: 'Bar',
-          isList: true,
-          isNullable: true,
-          directives: [{ name: 'hasMany', arguments: {} }],
-        },
+        hasManyField,
       ],
     };
     const associationField: CodeGenField = {
@@ -511,9 +515,9 @@ describe('addHasManyKey', () => {
       associatedWith: associationField,
       associatedWithFields: null,
     } as any;
-    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.fooBarsId', fields: ['fooBarsId'] } };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Foo.bar', fields: ['fooBarsId'] } };
 
-    addHasManyKey(fooModel, connection);
+    addHasManyKey(hasManyField, fooModel, connection);
     expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
   });
 });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-has-many.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-has-many.test.ts
@@ -1,0 +1,382 @@
+import { CodeGenConnectionType, CodeGenFieldConnectionHasMany } from '../../utils/process-connections';
+import { hasManyHasImplicitKey, addHasManyKey } from '../../utils/process-has-many';
+import { CodeGenField, CodeGenModel } from '../../visitors/appsync-visitor';
+
+describe('hasManyHasImplicitKey', () => {
+  it('returns true for implicit primary key, no belongsTo', () => {
+    /**
+     * Example using the following schema:
+     *
+     * type Foo @model {
+     *   id: ID!
+     *   bar: [Bar] @hasMany
+     * }
+     *
+     * type Bar @model {
+     *   id: ID!
+     * }
+     */
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    };
+    const fooModel: CodeGenModel = {
+      name: 'Foo',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        hasManyField,
+      ],
+    };
+    const associationField: CodeGenField = {
+      name: 'fooBarsId',
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        associationField,
+      ],
+    }
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationField,
+      associatedWithFields: [associationField],
+    };
+    expect(hasManyHasImplicitKey(hasManyField, fooModel, connection)).toBeTruthy();
+  });
+
+  it('returns false for implicit primary key with belongsTo', () => {
+    /**
+     * Example using the following schema:
+     *
+     * type Foo @model {
+     *   id: ID!
+     *   bar: [Bar] @hasMany
+     * }
+     *
+     * type Bar @model {
+     *   id: ID!
+     *   foo: Foo @belongsTo
+     * }
+     */
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: {} }],
+    }
+    const fooModel: CodeGenModel = {
+      name: 'Foo',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        hasManyField,
+      ],
+    };
+    const associationField: CodeGenField = {
+      name: 'fooBarsId',
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        {
+          name: 'foo',
+          type: 'Foo',
+          isList: false,
+          isNullable: true,
+          directives: [{ name: 'belongsTo', arguments: {} }],
+        },
+        associationField,
+      ],
+    }
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationField,
+      associatedWithFields: [associationField],
+    };
+    expect(hasManyHasImplicitKey(hasManyField, fooModel, connection)).toBeFalsy();
+  });
+
+  it('returns false for explicit index and id', () => {
+    /**
+     * Example using the following schema:
+     *
+     * type Foo @model {
+     *   id: ID!
+     *   bar: [Bar] @hasMany(indexName: "byFoo", fields: ["id"])
+     * }
+     *
+     * type Bar @model {
+     *   id: ID!
+     *   fooId: ID @index(name: "byFoo")
+     * }
+     */
+    const hasManyField: CodeGenField = {
+      name: 'bar',
+      type: 'Bar',
+      isList: true,
+      isNullable: true,
+      directives: [{ name: 'hasMany', arguments: { indexName: 'byFoo', fields: ['id'] } }],
+    };
+    const fooModel: CodeGenModel = {
+      name: 'Foo',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        hasManyField,
+      ],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        {
+          name: 'fooId',
+          type: 'ID',
+          isList: false,
+          isNullable: true,
+          directives: [{ name: 'index', arguments: { name: 'byFoo' } }],
+        },
+      ],
+    }
+    const associationField: CodeGenField = {
+      type: 'ID',
+      isList: false,
+      isNullable: false,
+      name: 'id',
+      directives: [],
+    };
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationField,
+      associatedWithFields: [associationField],
+    };
+    expect(hasManyHasImplicitKey(hasManyField, fooModel, connection)).toBeFalsy();
+  });
+});
+
+describe('addHasManyKey', () => {
+  it('adds a key for implicit primary key', () => {
+    /**
+     * Example using the following schema:
+     *
+     * type Foo @model {
+     *   id: ID!
+     *   bar: [Bar] @hasMany
+     * }
+     *
+     * type Bar @model {
+     *   id: ID!
+     * }
+     */
+    const associationField: CodeGenField = {
+      name: 'fooBarsId',
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        associationField,
+      ],
+    }
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationField,
+      associatedWithFields: [associationField],
+    };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Bar.fooBarsId', fields: ['fooBarsId'] } };
+
+    addHasManyKey(connection);
+    expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
+  });
+
+  it('adds a key composite primary key', () => {
+    /**
+     * Example using the following schema:
+     *
+     * type Foo @model {
+     *   id: ID! @primaryKey(sortKeyFields: ["warehouseId"])
+     *   warehouseId: String!
+     *   bar: [Bar] @hasMany
+     * }
+     *
+     * type Bar @model {
+     *   id: ID!
+     * }
+     */
+    const associationFieldPartitionKey: CodeGenField = {
+      name: 'fooBarsId',
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const associationFieldSortKey: CodeGenField = {
+      name: 'fooBarsWarehouseId',
+      type: 'String',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        associationFieldPartitionKey,
+        associationFieldSortKey,
+      ],
+    }
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationFieldPartitionKey,
+      associatedWithFields: [associationFieldPartitionKey, associationFieldSortKey],
+    };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Bar.fooBarsId', fields: ['fooBarsId', 'fooBarsWarehouseId'] } };
+
+    addHasManyKey(connection);
+    expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
+  });
+
+  it('works with non-cpk fallback connection', () => {
+    const associationField: CodeGenField = {
+      name: 'fooBarsId',
+      type: 'ID',
+      isList: false,
+      isNullable: true,
+      directives: [],
+    };
+    const barModel: CodeGenModel = {
+      name: 'Bar',
+      type: 'model',
+      directives: [
+        { name: 'model', arguments: {} },
+      ],
+      fields: [
+        {
+          name: 'id',
+          type: 'ID',
+          isList: false,
+          isNullable: false,
+          directives: [],
+        },
+        associationField,
+      ],
+    }
+    const connection: CodeGenFieldConnectionHasMany = {
+      kind: CodeGenConnectionType.HAS_MANY,
+      connectedModel: barModel,
+      isConnectingFieldAutoCreated: true,
+      associatedWith: associationField,
+      associatedWithFields: [],
+    };
+    const expectedKeyDirective = { name: 'key', arguments: { name: 'gsi-Bar.fooBarsId', fields: ['fooBarsId'] } };
+
+    addHasManyKey(connection);
+    expect(barModel.directives).toEqual(expect.arrayContaining([expectedKeyDirective]));
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -146,6 +146,78 @@ export declare const Comment: (new (init: ModelInit<Comment>) => Comment) & {
 }"
 `;
 
+exports[`Javascript visitor with connected models of custom pk hasMany/belongsTo relation should generate correct declaration for hasMany uni-connection model with custom index 1`] = `
+"import { ModelInit, MutableModel, __modelMeta__, CompositeIdentifier } from \\"@aws-amplify/datastore\\";
+// @ts-ignore
+import { LazyLoading, LazyLoadingDisabled, AsyncCollection } from \\"@aws-amplify/datastore\\";
+
+
+
+
+
+type EagerPost = {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Post, ['id', 'title']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly comments?: (Comment | null)[] | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+type LazyPost = {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Post, ['id', 'title']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly title: string;
+  readonly comments: AsyncCollection<Comment>;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+export declare type Post = LazyLoading extends LazyLoadingDisabled ? EagerPost : LazyPost
+
+export declare const Post: (new (init: ModelInit<Post>) => Post) & {
+  copyOf(source: Post, mutator: (draft: MutableModel<Post>) => MutableModel<Post> | void): Post;
+}
+
+type EagerComment = {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Comment, ['id', 'content']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly content: string;
+  readonly thePostId?: string | null;
+  readonly thePostTitle?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+type LazyComment = {
+  readonly [__modelMeta__]: {
+    identifier: CompositeIdentifier<Comment, ['id', 'content']>;
+    readOnlyFields: 'createdAt' | 'updatedAt';
+  };
+  readonly id: string;
+  readonly content: string;
+  readonly thePostId?: string | null;
+  readonly thePostTitle?: string | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+}
+
+export declare type Comment = LazyLoading extends LazyLoadingDisabled ? EagerComment : LazyComment
+
+export declare const Comment: (new (init: ModelInit<Comment>) => Comment) & {
+  copyOf(source: Comment, mutator: (draft: MutableModel<Comment>) => MutableModel<Comment> | void): Comment;
+}"
+`;
+
 exports[`Javascript visitor with connected models of custom pk hasOne/belongsTo relation should generate correct declaration when custom pk support is enabled 1`] = `
 "import { ModelInit, MutableModel, __modelMeta__, CompositeIdentifier } from \\"@aws-amplify/datastore\\";
 // @ts-ignore

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Metadata visitor for custom PK support relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in js 1`] = `
+exports[`Metadata visitor for custom PK support HasMany without corresponding belongsTo generates for composite pk 1`] = `
 "export const schema = {
     \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
+        \\"Project\\": {
+            \\"name\\": \\"Project\\",
             \\"fields\\": {
-                \\"customPostId\\": {
-                    \\"name\\": \\"customPostId\\",
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
+                \\"teams\\": {
+                    \\"name\\": \\"teams\\",
                     \\"isArray\\": true,
                     \\"type\\": {
-                        \\"model\\": \\"Comment\\"
+                        \\"model\\": \\"Team\\"
                     },
                     \\"isRequired\\": false,
                     \\"attributes\\": [],
@@ -32,8 +32,8 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_MANY\\",
                         \\"associatedWith\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
+                            \\"projectTeamsId\\",
+                            \\"projectTeamsName\\"
                         ]
                     }
                 },
@@ -55,7 +55,7 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                 }
             },
             \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
+            \\"pluralName\\": \\"Projects\\",
             \\"attributes\\": [
                 {
                     \\"type\\": \\"model\\",
@@ -65,45 +65,29 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
                         \\"fields\\": [
-                            \\"customPostId\\",
-                            \\"title\\"
+                            \\"id\\",
+                            \\"name\\"
                         ]
                     }
                 }
             ]
         },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
+        \\"Team\\": {
+            \\"name\\": \\"Team\\",
             \\"fields\\": {
-                \\"customCommentId\\": {
-                    \\"name\\": \\"customCommentId\\",
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
                 },
                 \\"createdAt\\": {
                     \\"name\\": \\"createdAt\\",
@@ -121,15 +105,15 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                     \\"attributes\\": [],
                     \\"isReadOnly\\": true
                 },
-                \\"postCommentsCustomPostId\\": {
-                    \\"name\\": \\"postCommentsCustomPostId\\",
+                \\"projectTeamsId\\": {
+                    \\"name\\": \\"projectTeamsId\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
                     \\"isRequired\\": false,
                     \\"attributes\\": []
                 },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
+                \\"projectTeamsName\\": {
+                    \\"name\\": \\"projectTeamsName\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": false,
@@ -137,7 +121,7 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                 }
             },
             \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
+            \\"pluralName\\": \\"Teams\\",
             \\"attributes\\": [
                 {
                     \\"type\\": \\"model\\",
@@ -146,169 +130,10 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
+                        \\"name\\": \\"gsi-Team.projectTeamsId\\",
                         \\"fields\\": [
-                            \\"customCommentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"post\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
+                            \\"projectTeamsId\\",
+                            \\"projectTeamsName\\"
                         ]
                     }
                 }
@@ -318,37 +143,35 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
     \\"enums\\": {},
     \\"nonModels\\": {},
     \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+    \\"version\\": \\"6b1bad408fb4d771f3219e585d3db29b\\"
 };"
 `;
 
-exports[`Metadata visitor for custom PK support relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in ts 1`] = `
-"import { Schema } from \\"@aws-amplify/datastore\\";
-
-export const schema: Schema = {
+exports[`Metadata visitor for custom PK support HasMany without corresponding belongsTo generates for implicit pk 1`] = `
+"export const schema = {
     \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
+        \\"Project\\": {
+            \\"name\\": \\"Project\\",
             \\"fields\\": {
-                \\"customPostId\\": {
-                    \\"name\\": \\"customPostId\\",
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
+                \\"teams\\": {
+                    \\"name\\": \\"teams\\",
                     \\"isArray\\": true,
                     \\"type\\": {
-                        \\"model\\": \\"Comment\\"
+                        \\"model\\": \\"Team\\"
                     },
                     \\"isRequired\\": false,
                     \\"attributes\\": [],
@@ -356,8 +179,7 @@ export const schema: Schema = {
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_MANY\\",
                         \\"associatedWith\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
+                            \\"projectTeamsId\\"
                         ]
                     }
                 },
@@ -379,55 +201,30 @@ export const schema: Schema = {
                 }
             },
             \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
+            \\"pluralName\\": \\"Projects\\",
             \\"attributes\\": [
                 {
                     \\"type\\": \\"model\\",
                     \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"customPostId\\",
-                            \\"title\\"
-                        ]
-                    }
                 }
             ]
         },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
+        \\"Team\\": {
+            \\"name\\": \\"Team\\",
             \\"fields\\": {
-                \\"customCommentId\\": {
-                    \\"name\\": \\"customCommentId\\",
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": true,
                     \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
                 },
                 \\"createdAt\\": {
                     \\"name\\": \\"createdAt\\",
@@ -445,23 +242,16 @@ export const schema: Schema = {
                     \\"attributes\\": [],
                     \\"isReadOnly\\": true
                 },
-                \\"postCommentsCustomPostId\\": {
-                    \\"name\\": \\"postCommentsCustomPostId\\",
+                \\"projectTeamsId\\": {
+                    \\"name\\": \\"projectTeamsId\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
                     \\"isRequired\\": false,
                     \\"attributes\\": []
                 }
             },
             \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
+            \\"pluralName\\": \\"Teams\\",
             \\"attributes\\": [
                 {
                     \\"type\\": \\"model\\",
@@ -470,169 +260,9 @@ export const schema: Schema = {
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
+                        \\"name\\": \\"gsi-Team.projectTeamsId\\",
                         \\"fields\\": [
-                            \\"customCommentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"post\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
+                            \\"projectTeamsId\\"
                         ]
                     }
                 }
@@ -642,11 +272,164 @@ export const schema: Schema = {
     \\"enums\\": {},
     \\"nonModels\\": {},
     \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+    \\"version\\": \\"cb4c9a5805faf864220f95ebc3e346de\\"
 };"
 `;
 
-exports[`Metadata visitor for custom PK support relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in js 1`] = `
+exports[`Metadata visitor for custom PK support generates with belongsTo 1`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Project\\": {
+            \\"name\\": \\"Project\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"teams\\": {
+                    \\"name\\": \\"teams\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Team\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"projectTeamsId\\",
+                            \\"projectTeamsName\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Projects\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"name\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Team\\": {
+            \\"name\\": \\"Team\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"project\\": {
+                    \\"name\\": \\"project\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Project\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"projectTeamsId\\",
+                            \\"projectTeamsName\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"projectTeamsId\\": {
+                    \\"name\\": \\"projectTeamsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"projectTeamsName\\": {
+                    \\"name\\": \\"projectTeamsName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Teams\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"version\\": \\"8b37aacc0491d9d130e918d8ee88197c\\"
+};"
+`;
+
+exports[`Metadata visitor for custom PK support generates with explicit index 1`] = `
 "export const schema = {
     \\"models\\": {
         \\"Post\\": {
@@ -678,8 +461,7 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_MANY\\",
                         \\"associatedWith\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
+                            \\"thePostId\\"
                         ]
                     }
                 },
@@ -735,6 +517,20 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                     \\"isRequired\\": true,
                     \\"attributes\\": []
                 },
+                \\"thePostId\\": {
+                    \\"name\\": \\"thePostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"thePostTitle\\": {
+                    \\"name\\": \\"thePostTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
                 \\"createdAt\\": {
                     \\"name\\": \\"createdAt\\",
                     \\"isArray\\": false,
@@ -750,20 +546,6 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                     \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"isReadOnly\\": true
-                },
-                \\"postCommentsId\\": {
-                    \\"name\\": \\"postCommentsId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
                 }
             },
             \\"syncable\\": true,
@@ -785,154 +567,10 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
+                        \\"name\\": \\"byCommentIds\\",
                         \\"fields\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postId\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
+                            \\"thePostId\\",
+                            \\"thePostTitle\\"
                         ]
                     }
                 }
@@ -942,309 +580,7 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
     \\"enums\\": {},
     \\"nonModels\\": {},
     \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
-};"
-`;
-
-exports[`Metadata visitor for custom PK support relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in ts 1`] = `
-"import { Schema } from \\"@aws-amplify/datastore\\";
-
-export const schema: Schema = {
-    \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"postCommentsId\\": {
-                    \\"name\\": \\"postCommentsId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
-                        \\"fields\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postId\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    \\"enums\\": {},
-    \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
+    \\"version\\": \\"b4f818e9f626f398b3ce56e741314a5b\\"
 };"
 `;
 
@@ -1606,7 +942,1255 @@ export const schema: Schema = {
 };"
 `;
 
-exports[`Metadata visitor for custom PK support relation metadata for manyToMany when custom PK is enabled should generate correct metadata in js 1`] = `
+exports[`relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in js 1`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"customPostId\\": {
+                    \\"name\\": \\"customPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customPostId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"customCommentId\\": {
+                    \\"name\\": \\"customCommentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsCustomPostId\\": {
+                    \\"name\\": \\"postCommentsCustomPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customCommentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+};"
+`;
+
+exports[`relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in ts 1`] = `
+"import { Schema } from \\"@aws-amplify/datastore\\";
+
+export const schema: Schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"customPostId\\": {
+                    \\"name\\": \\"customPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customPostId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"customCommentId\\": {
+                    \\"name\\": \\"customCommentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsCustomPostId\\": {
+                    \\"name\\": \\"postCommentsCustomPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customCommentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+};"
+`;
+
+exports[`relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in js 1`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
+                        \\"fields\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
+};"
+`;
+
+exports[`relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in ts 1`] = `
+"import { Schema } from \\"@aws-amplify/datastore\\";
+
+export const schema: Schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
+                        \\"fields\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
+};"
+`;
+
+exports[`relation metadata for manyToMany when custom PK is enabled should generate correct metadata in js 1`] = `
 "export const schema = {
     \\"models\\": {
         \\"Post\\": {
@@ -1876,7 +2460,7 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
 };"
 `;
 
-exports[`Metadata visitor for custom PK support relation metadata for manyToMany when custom PK is enabled should generate correct metadata in ts 1`] = `
+exports[`relation metadata for manyToMany when custom PK is enabled should generate correct metadata in ts 1`] = `
 "import { Schema } from \\"@aws-amplify/datastore\\";
 
 export const schema: Schema = {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -151,15 +151,6 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                             \\"content\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ]
         },
@@ -318,15 +309,6 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -493,15 +475,6 @@ export const schema: Schema = {
                             \\"content\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ]
         },
@@ -662,15 +635,6 @@ export const schema: Schema = {
                             \\"postTitle\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ]
         }
@@ -821,9 +785,10 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
+                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
                         \\"fields\\": [
-                            \\"fooBarsId\\"
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
                         ]
                     }
                 }
@@ -968,15 +933,6 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1131,9 +1087,10 @@ export const schema: Schema = {
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
+                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
                         \\"fields\\": [
-                            \\"fooBarsId\\"
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
                         ]
                     }
                 }
@@ -1278,15 +1235,6 @@ export const schema: Schema = {
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1917,24 +1865,6 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
                             \\"taglabel\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ]
         }
@@ -2205,24 +2135,6 @@ export const schema: Schema = {
                         \\"fields\\": [
                             \\"tagCustomTagId\\",
                             \\"taglabel\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
                         ]
                     }
                 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -130,7 +130,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Team.projectTeamsId\\",
+                        \\"name\\": \\"gsi-Project.projectTeamsId\\",
                         \\"fields\\": [
                             \\"projectTeamsId\\",
                             \\"projectTeamsName\\"
@@ -260,7 +260,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Team.projectTeamsId\\",
+                        \\"name\\": \\"gsi-Project.projectTeamsId\\",
                         \\"fields\\": [
                             \\"projectTeamsId\\"
                         ]
@@ -1727,7 +1727,7 @@ exports[`relation metadata for hasMany uni when custom PK is enabled should gene
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
+                        \\"name\\": \\"gsi-Post.postCommentsId\\",
                         \\"fields\\": [
                             \\"postCommentsId\\",
                             \\"postCommentsTitle\\"
@@ -2029,7 +2029,7 @@ export const schema: Schema = {
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Comment.postCommentsId\\",
+                        \\"name\\": \\"gsi-Post.postCommentsId\\",
                         \\"fields\\": [
                             \\"postCommentsId\\",
                             \\"postCommentsTitle\\"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -130,7 +130,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Project.projectTeamsId\\",
+                        \\"name\\": \\"gsi-Project.teams\\",
                         \\"fields\\": [
                             \\"projectTeamsId\\",
                             \\"projectTeamsName\\"
@@ -260,7 +260,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Project.projectTeamsId\\",
+                        \\"name\\": \\"gsi-Project.teams\\",
                         \\"fields\\": [
                             \\"projectTeamsId\\"
                         ]
@@ -1727,7 +1727,7 @@ exports[`relation metadata for hasMany uni when custom PK is enabled should gene
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Post.postCommentsId\\",
+                        \\"name\\": \\"gsi-Post.comments\\",
                         \\"fields\\": [
                             \\"postCommentsId\\",
                             \\"postCommentsTitle\\"
@@ -2029,7 +2029,7 @@ export const schema: Schema = {
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Post.postCommentsId\\",
+                        \\"name\\": \\"gsi-Post.comments\\",
                         \\"fields\\": [
                             \\"postCommentsId\\",
                             \\"postCommentsTitle\\"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -151,6 +151,15 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                             \\"content\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         },
@@ -309,6 +318,15 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany & 
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -475,6 +493,15 @@ export const schema: Schema = {
                             \\"content\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         },
@@ -635,6 +662,15 @@ export const schema: Schema = {
                             \\"postTitle\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         }
@@ -781,6 +817,15 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                             \\"content\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         },
@@ -923,6 +968,15 @@ exports[`Metadata visitor for custom PK support relation metadata for hasMany un
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1073,6 +1127,15 @@ export const schema: Schema = {
                             \\"content\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         },
@@ -1215,6 +1278,15 @@ export const schema: Schema = {
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1845,6 +1917,24 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
                             \\"taglabel\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ]
         }
@@ -2115,6 +2205,24 @@ export const schema: Schema = {
                         \\"fields\\": [
                             \\"tagCustomTagId\\",
                             \\"taglabel\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -978,7 +978,7 @@ exports[`Custom primary key tests should generate correct model intropection fil
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Post2.post2CommentsPostId\\",
+                        \\"name\\": \\"gsi-Post2.comments\\",
                         \\"fields\\": [
                             \\"post2CommentsPostId\\",
                             \\"post2CommentsTitle\\"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -978,7 +978,7 @@ exports[`Custom primary key tests should generate correct model intropection fil
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"gsi-Comment2.post2CommentsPostId\\",
+                        \\"name\\": \\"gsi-Post2.post2CommentsPostId\\",
                         \\"fields\\": [
                             \\"post2CommentsPostId\\",
                             \\"post2CommentsTitle\\"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -825,15 +825,6 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"content\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -987,9 +978,10 @@ exports[`Custom primary key tests should generate correct model intropection fil
                 {
                     \\"type\\": \\"key\\",
                     \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
+                        \\"name\\": \\"gsi-Comment2.post2CommentsPostId\\",
                         \\"fields\\": [
-                            \\"fooBarsId\\"
+                            \\"post2CommentsPostId\\",
+                            \\"post2CommentsTitle\\"
                         ]
                     }
                 }
@@ -1166,15 +1158,6 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"postTitle\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -1331,15 +1314,6 @@ exports[`Custom primary key tests should generate correct model intropection fil
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1622,24 +1596,6 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"taglabel\\"
                         ]
                     }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -1802,15 +1758,6 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                 {
                     \\"type\\": \\"model\\",
                     \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byFoo\\",
-                        \\"fields\\": [
-                            \\"fooBarsId\\"
-                        ]
-                    }
                 }
             ],
             \\"primaryKeyInfo\\": {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -825,6 +825,15 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"content\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -972,6 +981,15 @@ exports[`Custom primary key tests should generate correct model intropection fil
                         \\"fields\\": [
                             \\"commentId\\",
                             \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1148,6 +1166,15 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"postTitle\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -1304,6 +1331,15 @@ exports[`Custom primary key tests should generate correct model intropection fil
                         \\"fields\\": [
                             \\"postId\\",
                             \\"postTitle\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
                         ]
                     }
                 }
@@ -1586,6 +1622,24 @@ exports[`Custom primary key tests should generate correct model intropection fil
                             \\"taglabel\\"
                         ]
                     }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ],
             \\"primaryKeyInfo\\": {
@@ -1748,6 +1802,15 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                 {
                     \\"type\\": \\"model\\",
                     \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byFoo\\",
+                        \\"fields\\": [
+                            \\"fooBarsId\\"
+                        ]
+                    }
                 }
             ],
             \\"primaryKeyInfo\\": {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -1194,6 +1194,30 @@ describe('Javascript visitor with connected models of custom pk', () => {
       validateTs(declarations);
       expect(declarations).toMatchSnapshot();
     });
+    it('should generate correct declaration for hasMany uni-connection model with custom index', () => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          id: ID! @primaryKey(sortKeyFields: ["title"])
+          title: String!
+          comments: [Comment] @hasMany(indexName: "byCommentIds", fields: ["id", "title"])
+        }
+        type Comment @model {
+          id: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          thePostId: ID @index(name: "byCommentIds", sortKeyFields: ["thePostTitle"])
+          thePostTitle: String
+        }
+      `;
+      const visitor = getVisitor(schema, {
+        isDeclaration: true,
+        isTimestampFieldsAdded: true,
+        respectPrimaryKeyAttributesOnConnectionField: true,
+        transformerVersion: 2,
+      });
+      const declarations = visitor.generate();
+      validateTs(declarations);
+      expect(declarations).toMatchSnapshot();
+    });
     it('should generate correct declaration for hasMany bi-connection model when custom pk support is enabled', () => {
       const schema = /* GraphQL */ `
         type Post @model {

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -176,7 +176,7 @@ function doesHasManyConnectionHaveCorrespondingBelongsTo(model: CodeGenModel, ha
 }
 
 /**
- * This is a bit backwards, but we need to check if this connection directive specifies an index.
+ * Check if the @hasMany directive on this field specifies an indexName.
  */
 function doesHasManySpecifyIndexName(field: CodeGenField): boolean {
   return field.directives.some(d => d.name === TransformerV2DirectiveName.HAS_MANY && d.arguments.indexName);
@@ -196,11 +196,11 @@ export function hasManyHasImplicitKey(field: CodeGenField, model: CodeGenModel, 
  * Extract the name and list of keys from the connection information, and add the key to
  * the related model.
  */
-export function addHasManyKey(hasManyConnection: CodeGenFieldConnectionHasMany): void {
+export function addHasManyKey(model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): void {
   const associatedFieldNames = getConnectionAssociatedFields(hasManyConnection).map(f => f.name);
   const connectedModel = hasManyConnection.connectedModel;
   // Applying consistent auto-naming as the transformer does today
   // https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-relational-transformer/src/resolvers.ts#L334-L396
-  const name = `gsi-${connectedModel.name}.${associatedFieldNames[0]}`;
+  const name = `gsi-${model.name}.${associatedFieldNames[0]}`;
   addKeyToModel(connectedModel, name, associatedFieldNames);
 }

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -7,6 +7,7 @@ import {
   CodeGenFieldConnection,
   makeConnectionAttributeName,
   flattenFieldDirectives,
+  CodeGenFieldConnectionHasMany,
 } from './process-connections';
 import { getConnectedFieldV2 } from './process-connections-v2';
 
@@ -133,4 +134,35 @@ export function getConnectedFieldsForHasMany(
         isNullable: true,
       }
     });
+}
+
+/**
+ * Helper to add a key directive to a given model.
+ */
+ function addKeyToModel(model: CodeGenModel, name: string, fields: string[]): void {
+  model.directives.push({
+    name: 'key',
+    arguments: {
+      name,
+      fields,
+    },
+  });
+}
+
+/**
+ * Return whether or not a hasMany connection has an implicit key defined.
+ */
+export function hasManyHasImplicitKey(hasManyConnection: CodeGenFieldConnectionHasMany): boolean {
+  return true;
+}
+
+/**
+ * Extract the name and list of keys from the connection information, and add the key to
+ * the related model.
+ */
+export function addHasManyKey(hasManyConnection: CodeGenFieldConnectionHasMany): void {
+  const model = hasManyConnection.connectedModel;
+  const name = 'byFoo';
+  const fields = ['fooBarsId'];
+  addKeyToModel(model, name, fields);
 }

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -176,29 +176,19 @@ function doesHasManyConnectionHaveCorrespondingBelongsTo(model: CodeGenModel, ha
 }
 
 /**
- * Couple of helper types to make the filtering logic below more concise.
- */
-type FieldFilter = (f: CodeGenField) => boolean;
-type DirectiveFiter = (d: CodeGenDirective) => boolean;
-
-/**
  * This is a bit backwards, but we need to check if this connection directive specifies an index.
  */
-function doesHasManySpecifyIndexName(model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): boolean {
-  const directiveIsHasMany: DirectiveFiter = (d) => d.name === TransformerV2DirectiveName.HAS_MANY;
-  const directiveHasIndexName: DirectiveFiter = (d) => d.arguments.indexName;
-  const fieldHasHasManyDirectiveWithIndex: FieldFilter = (f) => f.directives.some(d => directiveIsHasMany(d) && directiveHasIndexName(d));
-  const fieldMatchesConnectedModelName: FieldFilter = (f) => f.type === hasManyConnection.connectedModel.name;
-  return model.fields.some(f => fieldMatchesConnectedModelName(f) && fieldHasHasManyDirectiveWithIndex(f));
+function doesHasManySpecifyIndexName(field: CodeGenField): boolean {
+  return field.directives.some(d => d.name === TransformerV2DirectiveName.HAS_MANY && d.arguments.indexName);
 }
 
 /**
  * Return whether or not a hasMany connection has an implicit key defined.
  * This is determined if there is a belongsTo directive on the connected model, or if there is an index defined on the directive.
  */
-export function hasManyHasImplicitKey(model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): boolean {
+export function hasManyHasImplicitKey(field: CodeGenField, model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): boolean {
   const hasCorrespondingBelongsTo = doesHasManyConnectionHaveCorrespondingBelongsTo(model, hasManyConnection);
-  const hasIndexNameSpecified = doesHasManySpecifyIndexName(model, hasManyConnection);
+  const hasIndexNameSpecified = doesHasManySpecifyIndexName(field);
   return !(hasCorrespondingBelongsTo || hasIndexNameSpecified);
 }
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -196,11 +196,11 @@ export function hasManyHasImplicitKey(field: CodeGenField, model: CodeGenModel, 
  * Extract the name and list of keys from the connection information, and add the key to
  * the related model.
  */
-export function addHasManyKey(model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): void {
+export function addHasManyKey(field: CodeGenField, model: CodeGenModel, hasManyConnection: CodeGenFieldConnectionHasMany): void {
   const associatedFieldNames = getConnectionAssociatedFields(hasManyConnection).map(f => f.name);
   const connectedModel = hasManyConnection.connectedModel;
   // Applying consistent auto-naming as the transformer does today
   // https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-relational-transformer/src/resolvers.ts#L334-L396
-  const name = `gsi-${model.name}.${associatedFieldNames[0]}`;
+  const name = `gsi-${model.name}.${field.name}`;
   addKeyToModel(connectedModel, name, associatedFieldNames);
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -77,7 +77,13 @@ export class AppSyncModelDartVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = false;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
+
     this.validateReservedKeywords();
     if (this._parsedConfig.generate === CodeGenGenerateEnum.loader) {
       return this.generateClassLoader();

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -78,10 +78,10 @@ export class AppSyncModelDartVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = false;
+    const shouldImputeKeyForUniDirectionalHasMany = false;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     this.validateReservedKeywords();

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -30,10 +30,10 @@ export class AppSyncModelJavaVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = false;
+    const shouldImputeKeyForUniDirectionalHasMany = false;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     if (this._parsedConfig.generate === 'loader') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -29,7 +29,13 @@ export class AppSyncModelJavaVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = false;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
+
     if (this._parsedConfig.generate === 'loader') {
       return this.generateClassLoader();
     }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -46,10 +46,10 @@ export class AppSyncModelJavascriptVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = true;
+    const shouldImputeKeyForUniDirectionalHasMany = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     if (this._parsedConfig.isDeclaration) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -45,7 +45,13 @@ export class AppSyncModelJavascriptVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = true;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
+
     if (this._parsedConfig.isDeclaration) {
       const enumDeclarations = Object.values(this.enumMap)
         .map(enumObj => this.generateEnumDeclarations(enumObj, true))

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -112,7 +112,13 @@ export class AppSyncJSONVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = true;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
+
     if (this._parsedConfig.metadataTarget === 'typescript') {
       return this.generateTypeScriptMetadata();
     } else if (this._parsedConfig.metadataTarget === 'javascript') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -113,10 +113,10 @@ export class AppSyncJSONVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = true;
+    const shouldImputeKeyForUniDirectionalHasMany = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     if (this._parsedConfig.metadataTarget === 'typescript') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -30,10 +30,10 @@ export class AppSyncModelIntrospectionVisitor<
   generate(): string {
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = true;
+    const shouldImputeKeyForUniDirectionalHasMany = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     const modelIntrosepctionSchema = this.generateModelIntrospectionSchema();

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -29,7 +29,13 @@ export class AppSyncModelIntrospectionVisitor<
   }
   generate(): string {
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = true;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
+
     const modelIntrosepctionSchema = this.generateModelIntrospectionSchema();
     if (!this.schemaValidator(modelIntrosepctionSchema)) {
       throw new Error(`Data did not validate against the supplied schema. Underlying errors were ${JSON.stringify(this.schemaValidator.errors)}`);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -61,10 +61,10 @@ export class AppSyncSwiftVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = false;
+    const shouldImputeKeyForUniDirectionalHasMany = false;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
 
     const code = [`// swiftlint:disable all`];

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -60,7 +60,12 @@ export class AppSyncSwiftVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = false;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
 
     const code = [`// swiftlint:disable all`];
     if (this._parsedConfig.generate === CodeGenGenerateEnum.metadata) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -43,10 +43,10 @@ export class AppSyncModelTypeScriptVisitor<
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
-    const shouldImputeKeyForUnidirectionalHasMany = true;
+    const shouldImputeKeyForUniDirectionalHasMany = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUnidirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany
     );
     const imports = this.generateImports();
     const enumDeclarations = Object.values(this.enumMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -42,7 +42,12 @@ export class AppSyncModelTypeScriptVisitor<
   generate(): string {
     // TODO: Remove us, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    const shouldImputeKeyForUnidirectionalHasMany = true;
+    this.processDirectives(
+      shouldUseModelNameFieldInHasManyAndBelongsTo,
+      shouldImputeKeyForUnidirectionalHasMany
+    );
     const imports = this.generateImports();
     const enumDeclarations = Object.values(this.enumMap)
       .map(enumObj => this.generateEnumDeclarations(enumObj))

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -923,7 +923,7 @@ export class AppSyncModelVisitor<
             // Add the key to the connected model if it's not explicitly defined
             //   (either via @index or @belongsTo)
             if (shouldImputeKeyForUniDirectionalHasMany && hasManyHasImplicitKey(field, model, connectionInfo)) {
-              addHasManyKey(connectionInfo);
+              addHasManyKey(model, connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             if (isCustomPKEnabled) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -923,7 +923,7 @@ export class AppSyncModelVisitor<
             // Add the key to the connected model if it's not explicitly defined
             //   (either via @index or @belongsTo)
             if (shouldImputeKeyForUniDirectionalHasMany && hasManyHasImplicitKey(field, model, connectionInfo)) {
-              addHasManyKey(model, connectionInfo);
+              addHasManyKey(field, model, connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             if (isCustomPKEnabled) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -32,6 +32,7 @@ import { graphqlName, toUpper } from 'graphql-transformer-common';
 import { processPrimaryKey } from '../utils/process-primary-key';
 import { processIndex } from '../utils/process-index';
 import { DEFAULT_HASH_KEY_FIELD, DEFAULT_CREATED_TIME, DEFAULT_UPDATED_TIME } from '../utils/constants';
+import { hasManyHasImplicitKey, addHasManyKey } from '../utils/process-has-many';
 
 export enum CodeGenGenerateEnum {
   metadata = 'metadata',
@@ -325,10 +326,15 @@ export class AppSyncModelVisitor<
   processDirectives(
     // TODO: Remove us when we have a fix to roll-forward.
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    shouldImputeKeyForUnidirectionalHasMany: boolean,
   ) {
     if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
       this.processV2KeyDirectives();
-      this.processConnectionDirectivesV2(shouldUseModelNameFieldInHasManyAndBelongsTo);
+      this.processConnectionDirectivesV2(
+        shouldUseModelNameFieldInHasManyAndBelongsTo,
+        shouldImputeKeyForUnidirectionalHasMany
+      );
     } else {
       this.processConnectionDirective();
     }
@@ -337,7 +343,9 @@ export class AppSyncModelVisitor<
   generate(): string {
     // TODO: Remove me, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo);
+    // TODO: Remove me, leaving in to be explicit on why this flag is here.
+    const shouldImputeKeyForUnidirectionalHasMany = false;
+    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo, shouldImputeKeyForUnidirectionalHasMany);
     return '';
   }
 
@@ -888,6 +896,8 @@ export class AppSyncModelVisitor<
   protected processConnectionDirectivesV2(
     // TODO: Remove us when we have a fix to roll-forward.
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
+    // This flag is going to be used to tight-trigger on JS implementations only.
+    shouldImputeKeyForUnidirectionalHasMany: boolean,
   ): void {
     this.processManyToManyDirectives();
 
@@ -909,6 +919,11 @@ export class AppSyncModelVisitor<
               connectionInfo.associatedWithFields.forEach(associateField => addFieldToModel(connectionInfo.connectedModel, associateField));
             } else {
               addFieldToModel(connectionInfo.connectedModel, connectionInfo.associatedWith);
+            }
+            // Add the key to the connected model if it's not explicitly defined
+            //   (either via @index or @belongsTo)
+            if (shouldImputeKeyForUnidirectionalHasMany && hasManyHasImplicitKey(connectionInfo)) {
+              addHasManyKey(connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             if (isCustomPKEnabled) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -327,13 +327,13 @@ export class AppSyncModelVisitor<
     // TODO: Remove us when we have a fix to roll-forward.
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
     // This flag is going to be used to tight-trigger on JS implementations only.
-    shouldImputeKeyForUnidirectionalHasMany: boolean,
+    shouldImputeKeyForUniDirectionalHasMany: boolean,
   ) {
     if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
       this.processV2KeyDirectives();
       this.processConnectionDirectivesV2(
         shouldUseModelNameFieldInHasManyAndBelongsTo,
-        shouldImputeKeyForUnidirectionalHasMany
+        shouldImputeKeyForUniDirectionalHasMany
       );
     } else {
       this.processConnectionDirective();
@@ -344,8 +344,8 @@ export class AppSyncModelVisitor<
     // TODO: Remove me, leaving in to be explicit on why this flag is here.
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // TODO: Remove me, leaving in to be explicit on why this flag is here.
-    const shouldImputeKeyForUnidirectionalHasMany = false;
-    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo, shouldImputeKeyForUnidirectionalHasMany);
+    const shouldImputeKeyForUniDirectionalHasMany = false;
+    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo, shouldImputeKeyForUniDirectionalHasMany);
     return '';
   }
 
@@ -897,7 +897,7 @@ export class AppSyncModelVisitor<
     // TODO: Remove us when we have a fix to roll-forward.
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
     // This flag is going to be used to tight-trigger on JS implementations only.
-    shouldImputeKeyForUnidirectionalHasMany: boolean,
+    shouldImputeKeyForUniDirectionalHasMany: boolean,
   ): void {
     this.processManyToManyDirectives();
 
@@ -922,7 +922,7 @@ export class AppSyncModelVisitor<
             }
             // Add the key to the connected model if it's not explicitly defined
             //   (either via @index or @belongsTo)
-            if (shouldImputeKeyForUnidirectionalHasMany && hasManyHasImplicitKey(model, connectionInfo)) {
+            if (shouldImputeKeyForUniDirectionalHasMany && hasManyHasImplicitKey(model, connectionInfo)) {
               addHasManyKey(connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -922,7 +922,7 @@ export class AppSyncModelVisitor<
             }
             // Add the key to the connected model if it's not explicitly defined
             //   (either via @index or @belongsTo)
-            if (shouldImputeKeyForUnidirectionalHasMany && hasManyHasImplicitKey(connectionInfo)) {
+            if (shouldImputeKeyForUnidirectionalHasMany && hasManyHasImplicitKey(model, connectionInfo)) {
               addHasManyKey(connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -922,7 +922,7 @@ export class AppSyncModelVisitor<
             }
             // Add the key to the connected model if it's not explicitly defined
             //   (either via @index or @belongsTo)
-            if (shouldImputeKeyForUniDirectionalHasMany && hasManyHasImplicitKey(model, connectionInfo)) {
+            if (shouldImputeKeyForUniDirectionalHasMany && hasManyHasImplicitKey(field, model, connectionInfo)) {
               addHasManyKey(connectionInfo);
             }
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {


### PR DESCRIPTION
#### Description of changes
Today, if you add a `@hasMany` directive to your schema without a corresponding `@belongsTo` on the related model, then the JS library will fail to cascade delete the related item. It appears this is because the Javascript Model Intermediate Platform Representation (MIPR) file is missing an implicit `key` in the related model.

This is being generated implicitly in the transformer today, since a DynamoDB GSI is required to query correctly, but this appears to have been missed in Codegen when the GQLv2 transformer support was launched at the end of 2021.

Because we haven't confirmed this behavior is in error on other platforms, I'm implementing this behind a boolean switch, so only the Javascript, Typescript, JSON, and Model Introspection outputs will see this change, but Flutter, Java, and Swift will not change.

#### Issue #, if available
N/A, reported internally.

#### Description of how you validated changes
The missing `key` as an issue was verified by manually editing the MIPR, and running a minimal reproduction of the issue.

Repro Schema:

```graphql
type Foo @model @auth(rules: [{ allow: public }]) {
  title: String
  bars: [Bar] @hasMany
}

type Bar @model @auth(rules: [{ allow: public }]) {
  title: String
}
```

Repro App Code:
```javascript
import { useState } from 'react';
import { DataStore, Amplify } from 'aws-amplify';
import awsconfig from "./aws-exports";
import { Foo, Bar } from './models';

Amplify.configure(awsconfig);

export default function App() {
  const [currentFoo, setCurrentFoo] = useState();

  const create = async () => {
    const foo = await DataStore.save(new Foo({ title: "foo" }));
    await DataStore.save(new Bar({ title: "bar", fooBarsId: foo.id }));
    setCurrentFoo(foo);
  };

  const deleteFoo = async () => {
    await DataStore.delete(currentFoo);
    setCurrentFoo(null);
  };

  return (
    <div>
      <button onClick={create}>Create</button>
      <button onClick={deleteFoo}>Delete</button>
    </div>
  );
}
```

Exploratory testing against this case, to ensure correctness.

Additionally, I will verify the following cases in order to protect against regressions via snapshot tests:

- [x] When parent model has implicit primary key, and there is no belongsTo directive then the implicit `key` should be added.
- [x] When parent model has explicit primary key (`id` field), and there is no belongsTo directive then the implicit `key` should be added.
- [x] When parent model has explicit primary key (custom `name` field), and there is no belongsTo directive then the implicit `key` should be added.
- [x] When parent model has explicit primary key (custom `name` field, sort key), and there is no belongsTo directive then the implicit `key` should be added.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.