### PR TITLE
fix(appsync-modelgen-plugin): associatedWith fields in HasOne bi-directional with CPK enabled

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
@@ -955,7 +955,7 @@ describe('Connection process with custom Primary Key support tests', () => {
       });
     });
 
-    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one with CPK', () => {
+    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one with composite primary key', () => {
       const schema = /* GraphQL */ `
         type CompositeOwner @model {
           lastName: ID! @primaryKey(sortKeyFields: ["firstName"])
@@ -994,7 +994,7 @@ describe('Connection process with custom Primary Key support tests', () => {
       });
     });
 
-    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one without CPK', () => {
+    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one without Composite primary key', () => {
       const schema = /* GraphQL */ `
         type BoringOwner @model {
           id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections-v2.test.ts
@@ -9,6 +9,7 @@ import {
 import { buildSchema, parse, visit } from 'graphql';
 import { directives, scalars } from '../../scalars/supported-directives';
 import { AppSyncModelVisitor, CodeGenGenerateEnum } from '../../visitors/appsync-visitor';
+
 describe('GraphQL V2 process connections tests', () => {
   describe('GraphQL vNext getConnectedField tests with @primaryKey and @index', () => {
     let hasOneWithFieldsModelMap: CodeGenModelMap;
@@ -625,6 +626,7 @@ describe('GraphQL V2 process connections tests', () => {
     });
   });
 });
+
 describe('Connection process with custom Primary Key support tests', () => {
   const createBaseVisitorWithCustomPrimaryKeyEnabled = (schema: string) => {
     const visitorConfig = {
@@ -901,6 +903,7 @@ describe('Connection process with custom Primary Key support tests', () => {
       });
     });
   });
+
   describe('belongsTo special case tests', () => {
     it('should return correct connection info in multiple hasOne defined in parent', () => {
       const schema = /* GraphQL */ `
@@ -948,6 +951,84 @@ describe('Connection process with custom Primary Key support tests', () => {
         targetName: 'teamProjectProjectId',
         targetNames: ['teamProjectProjectId', 'teamProjectName'],
         connectedModel: project,
+        isConnectingFieldAutoCreated: false,
+      });
+    });
+
+    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one with CPK', () => {
+      const schema = /* GraphQL */ `
+        type CompositeOwner @model {
+          lastName: ID! @primaryKey(sortKeyFields: ["firstName"])
+          firstName: String!
+          compositeDog: CompositeDog @hasOne
+        }
+        type CompositeDog @model {
+          name: ID! @primaryKey(sortKeyFields: ["description"])
+          description: String!
+          compositeOwner: CompositeOwner @belongsTo
+        }
+      `;
+      const modelMap: CodeGenModelMap = createBaseVisitorWithCustomPrimaryKeyEnabled(schema).models;
+      const compositeOwner: CodeGenModel = modelMap.CompositeOwner;
+      const compositeDog: CodeGenModel = modelMap.CompositeDog;
+      const hasOneField = compositeOwner.fields.find(f => f.name === 'compositeDog')!;
+      const belongsToField = compositeDog.fields.find(f => f.name === 'compositeOwner')!;
+      const hasOneAssociatedWithFields = compositeDog.fields.filter(f => f.name === 'name' || f.name === 'description')!;
+      const hasOneRelationInfo = processConnectionsV2(hasOneField, compositeOwner, modelMap, false, true, true);
+      const belongsToRelationInfo = processConnectionsV2(belongsToField, compositeDog, modelMap, false, true, true);
+      expect(hasOneRelationInfo).toEqual({
+        kind: CodeGenConnectionType.HAS_ONE,
+        associatedWith: hasOneAssociatedWithFields[0],
+        associatedWithFields: hasOneAssociatedWithFields,
+        targetName: 'compositeOwnerCompositeDogName',
+        targetNames: ['compositeOwnerCompositeDogName', 'compositeOwnerCompositeDogDescription'],
+        connectedModel: compositeDog,
+        isConnectingFieldAutoCreated: true,
+      });
+      expect(belongsToRelationInfo).toEqual({
+        kind: CodeGenConnectionType.BELONGS_TO,
+        targetName: 'compositeDogCompositeOwnerLastName',
+        targetNames: ['compositeDogCompositeOwnerLastName', 'compositeDogCompositeOwnerFirstName'],
+        connectedModel: compositeOwner,
+        isConnectingFieldAutoCreated: false,
+      });
+    });
+
+    it('With shouldUseFieldsInAssociatedWithInHasOne and CPK enabled, should return correct connection info for bi-directional has-one without CPK', () => {
+      const schema = /* GraphQL */ `
+        type BoringOwner @model {
+          id: ID!
+          name: String
+          boringDog: BoringDog @hasOne
+        }
+        type BoringDog @model {
+          id: ID!
+          name: String
+          boringOwner: BoringOwner @belongsTo
+        }
+      `;
+      const modelMap: CodeGenModelMap = createBaseVisitorWithCustomPrimaryKeyEnabled(schema).models;
+      const boringOwner: CodeGenModel = modelMap.BoringOwner;
+      const boringDog: CodeGenModel = modelMap.BoringDog;
+      const hasOneField = boringOwner.fields.find(f => f.name === 'boringDog')!;
+      const belongsToField = boringDog.fields.find(f => f.name === 'boringOwner')!;
+      const hasOneAssociatedWithFields = boringDog.fields.filter(f => f.name === 'id')!;
+      const hasOneRelationInfo = processConnectionsV2(hasOneField, boringOwner, modelMap, false, true, true);
+      const belongsToRelationInfo = processConnectionsV2(belongsToField, boringDog, modelMap, false, true, true);
+      expect(hasOneRelationInfo).toEqual({
+        kind: CodeGenConnectionType.HAS_ONE,
+        associatedWith: hasOneAssociatedWithFields[0],
+        associatedWithFields: hasOneAssociatedWithFields,
+        targetName: 'boringOwnerBoringDogId',
+        targetNames: ['boringOwnerBoringDogId'],
+        connectedModel: boringDog,
+        isConnectingFieldAutoCreated: true,
+      });
+      expect(belongsToRelationInfo).toEqual({
+        kind: CodeGenConnectionType.BELONGS_TO,
+        targetName: 'boringDogBoringOwnerId',
+        targetNames: ['boringDogBoringOwnerId'],
+        connectedModel: boringOwner,
         isConnectingFieldAutoCreated: false,
       });
     });

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -615,7 +615,8 @@ exports[`Metadata visitor for custom PK support relation metadata for hasOne/bel
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_ONE\\",
                         \\"associatedWith\\": [
-                            \\"project\\"
+                            \\"id\\",
+                            \\"name\\"
                         ],
                         \\"targetNames\\": [
                             \\"projectTeamId\\",
@@ -795,7 +796,8 @@ export const schema: Schema = {
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_ONE\\",
                         \\"associatedWith\\": [
-                            \\"project\\"
+                            \\"id\\",
+                            \\"name\\"
                         ],
                         \\"targetNames\\": [
                             \\"projectTeamId\\",

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -32,7 +32,8 @@ exports[`Custom primary key tests should generate correct model intropection fil
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_ONE\\",
                         \\"associatedWith\\": [
-                            \\"project\\"
+                            \\"teamId\\",
+                            \\"name\\"
                         ],
                         \\"targetNames\\": [
                             \\"project1TeamTeamId\\",
@@ -365,7 +366,8 @@ exports[`Custom primary key tests should generate correct model intropection fil
                     \\"association\\": {
                         \\"connectionType\\": \\"HAS_ONE\\",
                         \\"associatedWith\\": [
-                            \\"project\\"
+                            \\"teamId\\",
+                            \\"name\\"
                         ],
                         \\"targetNames\\": [
                             \\"teamId\\",

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -129,14 +129,15 @@ export function processConnectionsV2(
   model: CodeGenModel,
   modelMap: CodeGenModelMap,
   shouldUseModelNameFieldInHasManyAndBelongsTo: boolean = false,
-  isCustomPKEnabled: boolean = false
+  isCustomPKEnabled: boolean = false,
+  shouldUseFieldsInAssociatedWithInHasOne: boolean = false,
 ): CodeGenFieldConnection | undefined {
   const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
 
   if (connectionDirective) {
     switch (connectionDirective.name) {
       case 'hasOne':
-        return processHasOneConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled);
+        return processHasOneConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled, shouldUseFieldsInAssociatedWithInHasOne);
       case 'belongsTo':
         return processBelongsToConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled);
       case 'hasMany':

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -58,6 +58,7 @@ export function processHasOneConnection(
  * Get connected fields for hasOne relation
  * @param otherSideBelongsToField belongsTo field on other side
  * @param otherSide other side model of hasOne connection
+ * @param shouldUseFieldsInAssociatedWithInHasOne Return the connected fields instead of the connected model
  * @returns Array of connected fields. Return belongsTo field when in bi direction connenction. Otherwise return child pk and sk fields
  */
 export function getConnectedFieldsForHasOne(otherSideBelongsToField: CodeGenField | undefined, otherSide: CodeGenModel, shouldUseFieldsInAssociatedWithInHasOne: boolean = false): CodeGenField[] {

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -13,7 +13,8 @@ export function processHasOneConnection(
   model: CodeGenModel,
   modelMap: CodeGenModelMap,
   connectionDirective: CodeGenDirective,
-  isCustomPKEnabled: boolean = false
+  isCustomPKEnabled: boolean = false,
+  shouldUseFieldsInAssociatedWithInHasOne:boolean = false
 ): CodeGenFieldConnection | undefined {
   const otherSide = modelMap[field.type];
   // Find other side belongsTo field when in bi direction connection
@@ -23,7 +24,7 @@ export function processHasOneConnection(
   }
   let associatedWithFields;
   if (isCustomPKEnabled) {
-    associatedWithFields = getConnectedFieldsForHasOne(otherSideBelongsToField, otherSide);
+    associatedWithFields = getConnectedFieldsForHasOne(otherSideBelongsToField, otherSide, shouldUseFieldsInAssociatedWithInHasOne);
   } else {
     const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
     associatedWithFields = [otherSideField];
@@ -59,6 +60,6 @@ export function processHasOneConnection(
  * @param otherSide other side model of hasOne connection
  * @returns Array of connected fields. Return belongsTo field when in bi direction connenction. Otherwise return child pk and sk fields
  */
-export function getConnectedFieldsForHasOne(otherSideBelongsToField: CodeGenField | undefined, otherSide: CodeGenModel): CodeGenField[] {
-  return otherSideBelongsToField ? [otherSideBelongsToField] : getModelPrimaryKeyComponentFields(otherSide);
+export function getConnectedFieldsForHasOne(otherSideBelongsToField: CodeGenField | undefined, otherSide: CodeGenModel, shouldUseFieldsInAssociatedWithInHasOne: boolean = false): CodeGenField[] {
+  return (!shouldUseFieldsInAssociatedWithInHasOne && otherSideBelongsToField) ? [otherSideBelongsToField] : getModelPrimaryKeyComponentFields(otherSide);
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -47,9 +47,11 @@ export class AppSyncModelJavascriptVisitor<
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
     const shouldImputeKeyForUniDirectionalHasMany = true;
+    const shouldUseFieldsInAssociatedWithInHasOne = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUniDirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany,
+      shouldUseFieldsInAssociatedWithInHasOne
     );
 
     if (this._parsedConfig.isDeclaration) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -114,9 +114,12 @@ export class AppSyncJSONVisitor<
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
     const shouldImputeKeyForUniDirectionalHasMany = true;
+    const shouldUseFieldsInAssociatedWithInHasOne = true;
+
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUniDirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany,
+      shouldUseFieldsInAssociatedWithInHasOne
     );
 
     if (this._parsedConfig.metadataTarget === 'typescript') {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -31,9 +31,11 @@ export class AppSyncModelIntrospectionVisitor<
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
     const shouldImputeKeyForUniDirectionalHasMany = true;
+    const shouldUseFieldsInAssociatedWithInHasOne = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUniDirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany,
+      shouldUseFieldsInAssociatedWithInHasOne
     );
 
     const modelIntrosepctionSchema = this.generateModelIntrospectionSchema();

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -44,9 +44,11 @@ export class AppSyncModelTypeScriptVisitor<
     const shouldUseModelNameFieldInHasManyAndBelongsTo = false;
     // This flag is going to be used to tight-trigger on JS implementations only.
     const shouldImputeKeyForUniDirectionalHasMany = true;
+    const shouldUseFieldsInAssociatedWithInHasOne = true;
     this.processDirectives(
       shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUniDirectionalHasMany
+      shouldImputeKeyForUniDirectionalHasMany,
+      shouldUseFieldsInAssociatedWithInHasOne
     );
     const imports = this.generateImports();
     const enumDeclarations = Object.values(this.enumMap)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -328,12 +328,15 @@ export class AppSyncModelVisitor<
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
     // This flag is going to be used to tight-trigger on JS implementations only.
     shouldImputeKeyForUniDirectionalHasMany: boolean,
+    // This flag is currently used only in the Model Introspection visitor
+    shouldUseFieldsInAssociatedWithInHasOne: boolean = false
   ) {
     if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {
       this.processV2KeyDirectives();
       this.processConnectionDirectivesV2(
         shouldUseModelNameFieldInHasManyAndBelongsTo,
-        shouldImputeKeyForUniDirectionalHasMany
+        shouldImputeKeyForUniDirectionalHasMany,
+        shouldUseFieldsInAssociatedWithInHasOne
       );
     } else {
       this.processConnectionDirective();
@@ -898,6 +901,7 @@ export class AppSyncModelVisitor<
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
     // This flag is going to be used to tight-trigger on JS implementations only.
     shouldImputeKeyForUniDirectionalHasMany: boolean,
+    shouldUseFieldsInAssociatedWithInHasOne: boolean
   ): void {
     this.processManyToManyDirectives();
 
@@ -911,6 +915,7 @@ export class AppSyncModelVisitor<
           this.modelMap,
           shouldUseModelNameFieldInHasManyAndBelongsTo,
           isCustomPKEnabled,
+          shouldUseFieldsInAssociatedWithInHasOne
         );
         if (connectionInfo) {
           if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -328,7 +328,7 @@ export class AppSyncModelVisitor<
     shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
     // This flag is going to be used to tight-trigger on JS implementations only.
     shouldImputeKeyForUniDirectionalHasMany: boolean,
-    // This flag is currently used only in the Model Introspection visitor
+    // This flag is currently used in JS/TS and Model introspection generation only.
     shouldUseFieldsInAssociatedWithInHasOne: boolean = false
   ) {
     if (this.config.usePipelinedTransformer || this.config.transformerVersion === 2) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
When the CPK feature flag is `ON`, this change fixes the `associatedWith` fields that are generated in a Bi-Directional Has-One relationship. 
We add an option `shouldUseFieldsInAssociatedWithInHasOne` to control this change and limit it only to the Model Introspection Visitor (produces `model-introspection.json` output), JS, TS and JSON metadata vistors (linked to `schema.js` output).


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit tests


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.