### PR TITLE
fix(amplify-codegen): swift - add has-many associatedFields for CPK use case

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -7,6 +7,242 @@ import Foundation
 "
 `;
 
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany bi-directional relation for model with CPK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let id: String
+  public let title: String
+  public var comments: List<Comment>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<Comment>? = []) {
+    self.init(id: id,
+      title: title,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      comments: List<Comment>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany bi-directional relation for model with CPK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post = Post.keys
+    
+    model.pluralName = \\"Posts\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\", \\"title\\"], name: nil),
+      .primaryKey(fields: [post.id, post.title])
+    )
+    
+    model.fields(
+      .field(post.id, is: .required, ofType: .string),
+      .field(post.title, is: .required, ofType: .string),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedFields: [Comment.keys.post]),
+      .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post.IdentifierProtocol {
+  public static func identifier(id: String,
+      title: String) -> Self {
+    .make(fields:[(name: \\"id\\", value: id), (name: \\"title\\", value: title)])
+  }
+}
+extension ModelPath where ModelType == Post {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var title: FieldPath<String>   {
+      string(\\"title\\") 
+    }
+  public var comments: ModelPath<Comment>   {
+      Comment.Path(name: \\"comments\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany bi-directional relation for model with CPK 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment: Model {
+  public let id: String
+  public let content: String
+  internal var _post: LazyReference<Post>
+  public var post: Post?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String,
+      post: Post? = nil) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String,
+      post: Post? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self._post = LazyReference(post)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post? = nil) {
+    self._post = LazyReference(post)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      content = try values.decode(String.self, forKey: .content)
+      _post = try values.decodeIfPresent(LazyReference<Post>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(content, forKey: .content)
+      try container.encode(_post, forKey: .post)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany bi-directional relation for model with CPK 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment = Comment.keys
+    
+    model.pluralName = \\"Comments\\"
+    
+    model.attributes(
+      .index(fields: [\\"id\\", \\"content\\"], name: nil),
+      .primaryKey(fields: [comment.id, comment.content])
+    )
+    
+    model.fields(
+      .field(comment.id, is: .required, ofType: .string),
+      .field(comment.content, is: .required, ofType: .string),
+      .belongsTo(comment.post, is: .optional, ofType: Post.self, targetNames: [\\"postCommentsId\\", \\"postCommentsTitle\\"]),
+      .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Comment.IdentifierProtocol {
+  public static func identifier(id: String,
+      content: String) -> Self {
+    .make(fields:[(name: \\"id\\", value: id), (name: \\"content\\", value: content)])
+  }
+}
+extension ModelPath where ModelType == Comment {
+  public var id: FieldPath<String>   {
+      string(\\"id\\") 
+    }
+  public var content: FieldPath<String>   {
+      string(\\"content\\") 
+    }
+  public var post: ModelPath<Post>   {
+      Post.Path(name: \\"post\\", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}"
+`;
+
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 1`] = `
 "// swiftlint:disable all
 import Amplify
@@ -225,6 +461,229 @@ extension ModelPath where ModelType == Comment {
     }
   public var postCommentsTitle: FieldPath<String>   {
       string(\\"postCommentsTitle\\") 
+    }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK customized foreign key names 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let postId: String
+  public let title: String
+  public var comments: List<Comment>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      title: String,
+      comments: List<Comment>? = []) {
+    self.init(postId: postId,
+      title: title,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      title: String,
+      comments: List<Comment>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.title = title
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK customized foreign key names 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case title
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post = Post.keys
+    
+    model.pluralName = \\"Posts\\"
+    
+    model.attributes(
+      .index(fields: [\\"postId\\", \\"title\\"], name: nil),
+      .primaryKey(fields: [post.postId, post.title])
+    )
+    
+    model.fields(
+      .field(post.postId, is: .required, ofType: .string),
+      .field(post.title, is: .required, ofType: .string),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedFields: [Comment.keys.postId]),
+      .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post.IdentifierProtocol {
+  public static func identifier(postId: String,
+      title: String) -> Self {
+    .make(fields:[(name: \\"postId\\", value: postId), (name: \\"title\\", value: title)])
+  }
+}
+extension ModelPath where ModelType == Post {
+  public var postId: FieldPath<String>   {
+      string(\\"postId\\") 
+    }
+  public var title: FieldPath<String>   {
+      string(\\"title\\") 
+    }
+  public var comments: ModelPath<Comment>   {
+      Comment.Path(name: \\"comments\\", isCollection: true, parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK customized foreign key names 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment: Model {
+  public let commentId: String
+  public let content: String
+  public var postId: String?
+  public var postTitle: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(commentId: String,
+      content: String,
+      postId: String? = nil,
+      postTitle: String? = nil) {
+    self.init(commentId: commentId,
+      content: content,
+      postId: postId,
+      postTitle: postTitle,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(commentId: String,
+      content: String,
+      postId: String? = nil,
+      postTitle: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.commentId = commentId
+      self.content = content
+      self.postId = postId
+      self.postTitle = postTitle
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK customized foreign key names 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case commentId
+    case content
+    case postId
+    case postTitle
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment = Comment.keys
+    
+    model.pluralName = \\"Comments\\"
+    
+    model.attributes(
+      .index(fields: [\\"commentId\\", \\"content\\"], name: nil),
+      .index(fields: [\\"postId\\", \\"postTitle\\"], name: \\"byPost\\"),
+      .primaryKey(fields: [comment.commentId, comment.content])
+    )
+    
+    model.fields(
+      .field(comment.commentId, is: .required, ofType: .string),
+      .field(comment.content, is: .required, ofType: .string),
+      .field(comment.postId, is: .optional, ofType: .string),
+      .field(comment.postTitle, is: .optional, ofType: .string),
+      .field(comment.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Comment.IdentifierProtocol {
+  public static func identifier(commentId: String,
+      content: String) -> Self {
+    .make(fields:[(name: \\"commentId\\", value: commentId), (name: \\"content\\", value: content)])
+  }
+}
+extension ModelPath where ModelType == Comment {
+  public var commentId: FieldPath<String>   {
+      string(\\"commentId\\") 
+    }
+  public var content: FieldPath<String>   {
+      string(\\"content\\") 
+    }
+  public var postId: FieldPath<String>   {
+      string(\\"postId\\") 
+    }
+  public var postTitle: FieldPath<String>   {
+      string(\\"postTitle\\") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
     }
 }"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -73,7 +73,7 @@ extension Post {
     model.fields(
       .field(post.id, is: .required, ofType: .string),
       .field(post.title, is: .required, ofType: .string),
-      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedWith: Comment.keys.postCommentsId),
+      .hasMany(post.comments, is: .optional, ofType: Comment.self, associatedFields: [Comment.keys.postCommentsId, Comment.keys.postCommentsTitle]),
       .field(post.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2945,5 +2945,70 @@ describe('AppSyncSwiftVisitor', () => {
       expect(generatedCodeComment).toMatchSnapshot();
       expect(generatedMetaComment).toMatchSnapshot();
     });
+
+    it('Should generate foreign key fields in hasMany uni relation for model with CPK customized foreign key names', () => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          postId: ID! @primaryKey(sortKeyFields: ["title"])
+          title: String!
+          comments: [Comment] @hasMany(indexName: "byPost", fields: ["postId", "title"])
+        }
+
+        type Comment @model {
+          commentId: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          postId: ID @index(name: "byPost", sortKeyFields: ["postTitle"]) # customized foreign key for parent primary key
+          postTitle: String # customized foreign key for parent sort key
+        }
+      `;
+      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      expect(generatedCodePost).toMatchSnapshot();
+      expect(generatedMetaPost).toMatchSnapshot();
+      expect(generatedCodeComment).toMatchSnapshot();
+      expect(generatedMetaComment).toMatchSnapshot();
+    });
+
+    it('Should generate foreign key fields in hasMany bi-directional relation for model with CPK', () => {
+      const schema = /* GraphQL */ `
+        type Post @model {
+          id: ID! @primaryKey(sortKeyFields: ["title"])
+          title: String!
+          comments: [Comment] @hasMany
+        }
+
+        type Comment @model {
+          id: ID! @primaryKey(sortKeyFields: ["content"])
+          content: String!
+          post: Post @belongsTo
+        }
+      `;
+      const generatedCodePost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaPost = getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedCodeComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaComment = getVisitorPipelinedTransformer(schema, 'Comment', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      expect(generatedCodePost).toMatchSnapshot();
+      expect(generatedMetaPost).toMatchSnapshot();
+      expect(generatedCodeComment).toMatchSnapshot();
+      expect(generatedMetaComment).toMatchSnapshot();
+    });
   });
 });

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -615,9 +615,13 @@ export class AppSyncSwiftVisitor<
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
-        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
-          connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        let connectedModelName = this.getModelName(connectionInfo.connectedModel);
+        const associatedWithAttrStr = this.isCustomPKEnabled()
+          ? `associatedFields: [${connectionInfo.associatedWithFields
+              .map(target => `${connectedModelName}.keys.${this.getFieldName(target)}`)
+              .join(', ')}]`
+          : `associatedWith: ${connectedModelName}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
+        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${associatedWithAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
         const targetNameAttrStr = this.isCustomPKEnabled()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->
## Table of contents

- Library Changes `data-dev-preview` https://github.com/aws-amplify/amplify-swift/pull/2730 
- Library Changes `v1` - https://github.com/aws-amplify/amplify-swift/pull/2734
- Library Changes `main` - https://github.com/aws-amplify/amplify-swift/pull/2735
- Codegen Changes - https://github.com/aws-amplify/amplify-codegen/pull/538 (You are here)

Tagged release `tagged-release-without-e2e-tests/cpk-has-many`

## Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR is a bug fix for CPK feature to add the foreign key fields of a has-many relationship as the "associatedFields" of the field. For uni-directional has-many relationships, with the parent having a CPK use case:
```
# LL.7. Implicit Uni-directional Has Many
# CLI.4. Implicit Uni-directional Has Many

type Post4 @model {
  postId: ID! @primaryKey(sortKeyFields:["title"])
  title: String!
  comments: [Comment4] @hasMany
}
type Comment4 @model {
  commentId: ID! @primaryKey(sortKeyFields:["content"])
  content: String!
}

# LL.11. Explicit Uni-directional Has Many
# CLI.8. Explicit Uni-directional Has Many

type Post8 @model {
  postId: ID! @primaryKey(sortKeyFields:["title"])
  title: String!
  comments: [Comment8] @hasMany(indexName:"byPost", fields:["postId", "title"])
}
type Comment8 @model {
  commentId: ID! @primaryKey(sortKeyFields:["content"])
  content: String!
  postId: ID @index(name: "byPost", sortKeyFields:["postTitle"]) # customized foreign key for parent primary key
  postTitle: String # customized foreign key for parent sort key
}
```

- The generated swift schema file for Comment does not have information about which fields are foreign keys to the Post. "postId" and "postTitle" are string fields. 
- The parent model, Post, has a reference to the hasMany Comments. This reference has an `associatedWith` field which points to the primary key of the Post, ie. 

```
.hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId),
```

The issue here is that it's missing the information about the entire CPK of Post, the library only knows that the comment is associated with the post by the field `Comment4.keys.post4CommentsPostId` on Comment.

By replacing `associatedWith` with `associatedFields` hasMany schema information to include all the foreign key composite key, we support CPK uni-directional has-many use cases. The final generated schema information will appear like this:
```
.hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
```

This is useful for querying for Comments by using `associatedFields`, done by the library's lazy loading list functionality. For more details on the library issue, see https://github.com/aws-amplify/amplify-swift/pull/2730 

Since this codegen change is behind the CPK feature flag and generates "associatedFields" on the hasMany, this means the library needs to define and release first, followed by the codegen changes. Since CPK feature is available for both `v1` and `main` (v2) of Amplify Swift library. We need to introduce the changes to `v1`, `main`, and not just `data-dev-preview` (lazy reference + custom selecion set feature branch) of the library.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.