### PR TITLE
[DO-NOT-MERGE] fix(amplify-codegen): swift - add has-one associatedFields for CPK use case

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -7,6 +7,256 @@ import Foundation
 "
 `;
 
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate associatedFields in hasOne uni-directional relation for models with a composite PK 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Project: Model {
+  public let projectId: String
+  public let name: String
+  internal var _team: LazyReference<Team>
+  public var team: Team?   {
+      get async throws { 
+        try await _team.get()
+      } 
+    }
+  public var teamId: String?
+  public var teamName: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(projectId: String,
+      name: String,
+      team: Team? = nil,
+      teamId: String? = nil,
+      teamName: String? = nil) {
+    self.init(projectId: projectId,
+      name: name,
+      team: team,
+      teamId: teamId,
+      teamName: teamName,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(projectId: String,
+      name: String,
+      team: Team? = nil,
+      teamId: String? = nil,
+      teamName: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.projectId = projectId
+      self.name = name
+      self._team = LazyReference(team)
+      self.teamId = teamId
+      self.teamName = teamName
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setTeam(_ team: Team? = nil) {
+    self._team = LazyReference(team)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      projectId = try values.decode(String.self, forKey: .projectId)
+      name = try values.decode(String.self, forKey: .name)
+      _team = try values.decodeIfPresent(LazyReference<Team>.self, forKey: .team) ?? LazyReference(identifiers: nil)
+      teamId = try? values.decode(String?.self, forKey: .teamId)
+      teamName = try? values.decode(String?.self, forKey: .teamName)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(projectId, forKey: .projectId)
+      try container.encode(name, forKey: .name)
+      try container.encode(_team, forKey: .team)
+      try container.encode(teamId, forKey: .teamId)
+      try container.encode(teamName, forKey: .teamName)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate associatedFields in hasOne uni-directional relation for models with a composite PK 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Project {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case projectId
+    case name
+    case team
+    case teamId
+    case teamName
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let project = Project.keys
+    
+    model.pluralName = \\"Projects\\"
+    
+    model.attributes(
+      .index(fields: [\\"projectId\\", \\"name\\"], name: nil),
+      .primaryKey(fields: [project.projectId, project.name])
+    )
+    
+    model.fields(
+      .field(project.projectId, is: .required, ofType: .string),
+      .field(project.name, is: .required, ofType: .string),
+      .hasOne(project.team, is: .optional, ofType: Team.self, associatedFields: [Team.keys.teamId, Team.keys.name], targetNames: [\\"teamId\\", \\"teamName\\"]),
+      .field(project.teamId, is: .optional, ofType: .string),
+      .field(project.teamName, is: .optional, ofType: .string),
+      .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Project> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Project: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Project.IdentifierProtocol {
+  public static func identifier(projectId: String,
+      name: String) -> Self {
+    .make(fields:[(name: \\"projectId\\", value: projectId), (name: \\"name\\", value: name)])
+  }
+}
+extension ModelPath where ModelType == Project {
+  public var projectId: FieldPath<String>   {
+      string(\\"projectId\\") 
+    }
+  public var name: FieldPath<String>   {
+      string(\\"name\\") 
+    }
+  public var team: ModelPath<Team>   {
+      Team.Path(name: \\"team\\", parent: self) 
+    }
+  public var teamId: FieldPath<String>   {
+      string(\\"teamId\\") 
+    }
+  public var teamName: FieldPath<String>   {
+      string(\\"teamName\\") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate associatedFields in hasOne uni-directional relation for models with a composite PK 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Team: Model {
+  public let teamId: String
+  public let name: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(teamId: String,
+      name: String) {
+    self.init(teamId: teamId,
+      name: name,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(teamId: String,
+      name: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.teamId = teamId
+      self.name = name
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Primary Key Tests Should generate associatedFields in hasOne uni-directional relation for models with a composite PK 4`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Team {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case teamId
+    case name
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let team = Team.keys
+    
+    model.pluralName = \\"Teams\\"
+    
+    model.attributes(
+      .index(fields: [\\"teamId\\", \\"name\\"], name: nil),
+      .primaryKey(fields: [team.teamId, team.name])
+    )
+    
+    model.fields(
+      .field(team.teamId, is: .required, ofType: .string),
+      .field(team.name, is: .required, ofType: .string),
+      .field(team.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(team.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Team> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Team: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Team.IdentifierProtocol {
+  public static func identifier(teamId: String,
+      name: String) -> Self {
+    .make(fields:[(name: \\"teamId\\", value: teamId), (name: \\"name\\", value: name)])
+  }
+}
+extension ModelPath where ModelType == Team {
+  public var teamId: FieldPath<String>   {
+      string(\\"teamId\\") 
+    }
+  public var name: FieldPath<String>   {
+      string(\\"name\\") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"createdAt\\") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime(\\"updatedAt\\") 
+    }
+}"
+`;
+
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 1`] = `
 "// swiftlint:disable all
 import Amplify
@@ -713,7 +963,7 @@ extension Project {
     model.fields(
       .field(project.projectId, is: .required, ofType: .string),
       .field(project.name, is: .required, ofType: .string),
-      .hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.project, targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
+      .hasOne(project.team, is: .optional, ofType: Team.self, associatedFields: [Team.keys.project], targetNames: [\\"projectTeamTeamId\\", \\"projectTeamName\\"]),
       .field(project.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(project.projectTeamTeamId, is: .optional, ofType: .string),

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2915,6 +2915,38 @@ describe('AppSyncSwiftVisitor', () => {
       expect(generatedMetaTeam).toMatchSnapshot();
     });
 
+    it('Should generate associatedFields in hasOne uni-directional relation for models with a composite PK', () => {
+      const schema = /* GraphQL */ `
+        type Project @model {
+          projectId: ID! @primaryKey(sortKeyFields: ["name"])
+          name: String!
+          team: Team @hasOne(fields: ["teamId", "teamName"])
+          teamId: ID # customized foreign key for child primary key
+          teamName: String # customized foreign key for child sort key
+        }
+        type Team @model {
+          teamId: ID! @primaryKey(sortKeyFields: ["name"])
+          name: String!
+        }
+      `;
+      const generatedCodeProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaProject = getVisitorPipelinedTransformer(schema, 'Project', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedCodeTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.code, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      const generatedMetaTeam = getVisitorPipelinedTransformer(schema, 'Team', CodeGenGenerateEnum.metadata, {
+        respectPrimaryKeyAttributesOnConnectionField: true,
+      }).generate();
+      expect(generatedCodeProject).toMatchSnapshot();
+      expect(generatedMetaProject).toMatchSnapshot();
+      expect(generatedCodeTeam).toMatchSnapshot();
+      expect(generatedMetaTeam).toMatchSnapshot();
+    });
+
     it('Should generate foreign key fields in hasMany uni relation for model with CPK', () => {
       const schema = /* GraphQL */ `
         type Post @model {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -620,12 +620,16 @@ export class AppSyncSwiftVisitor<
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        let connectedModelName = this.getModelName(connectionInfo.connectedModel);
+        const associatedWithAttrStr = this.isCustomPKEnabled()
+          ? `associatedFields: [${connectionInfo.associatedWithFields
+              .map(target => `${connectedModelName}.keys.${this.getFieldName(target)}`)
+              .join(', ')}]`
+          : `associatedWith: ${connectedModelName}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
         const targetNameAttrStr = this.isCustomPKEnabled()
           ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
           : `targetName: "${connectionInfo.targetName}"`;
-        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
-          connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
+        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, ${associatedWithAttrStr}, ${targetNameAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         const targetNameAttrStr = this.isCustomPKEnabled()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This PR is similar to https://github.com/aws-amplify/amplify-codegen/pull/538. We're looking to add the `associatedFields` for CPK use cases for has-one unidirectional relationships:

Before
```
.hasOne(project.team, is: .optional, ofType: Team.self, associatedWith: Team.keys.teamId, targetNames: [\\"teamId\\", \\"teamName\\"]),
```
With this PR
```
.hasOne(project.team, is: .optional, ofType: Team.self, associatedFields: [Team.keys.teamId, Team.keys.name], targetNames: [\\"teamId\\", \\"teamName\\"]),
```

This enables the library use caes for lazy loading hasOne models, related library changes https://github.com/aws-amplify/amplify-swift/pull/2737


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.