### PR TITLE
fix(ci): rm suffix of os in cache

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -82,11 +82,11 @@ jobs:
       - run: yarn cache clean --force
       - run: yarn run production-build
       - save_cache:
-          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
       - save_cache:
-          key: amplify-codegen-ssh-deps-{{ .Branch }}-<< parameters.os >>
+          key: amplify-codegen-ssh-deps-{{ .Branch }}
           paths:
             - ~/.ssh
       - persist_to_workspace:
@@ -116,7 +116,7 @@ jobs:
             - attach_workspace:
                 at: ./
             - restore_cache:
-                key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-l
+                key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Lint
           command: yarn lint
@@ -135,8 +135,8 @@ jobs:
           at: ./
       - restore_cache:
           keys:
-            - amplify-codegen-ssh-deps-{{ .Branch }}-l
-            - amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-l
+            - amplify-codegen-ssh-deps-{{ .Branch }}
+            - amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with npm
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
@@ -152,7 +152,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Publish to verdaccio
           command: |
@@ -165,7 +165,7 @@ jobs:
             yarn publish-to-verdaccio
             unsetNpmRegistryUrl
       - save_cache:
-          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}-<< parameters.os >>
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/verdaccio-cache/
 
@@ -176,9 +176,9 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}-<< parameters.os >>
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run: *install_cli
       - run:
           name: Run e2e tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,20 +6,20 @@ orbs:
   node: circleci/node@5.0.3
 machine:
   environment:
-    PATH: '${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin'
+    PATH: ${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin
 executors:
   w: &ref_1
     machine:
-      image: 'windows-server-2019-vs2019:stable'
+      image: windows-server-2019-vs2019:stable
       resource_class: windows.medium
       shell: bash.exe
     working_directory: ~/repo
     environment:
-      AMPLIFY_DIR: 'C:/home/circleci/repo/out'
-      AMPLIFY_PATH: 'C:/home/circleci/repo/out/amplify.exe'
+      AMPLIFY_DIR: C:/home/circleci/repo/out
+      AMPLIFY_PATH: C:/home/circleci/repo/out/amplify.exe
   l: &ref_2
     docker:
-      - image: 'public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest'
+      - image: public.ecr.aws/j4f5f3h7/amplify-cli-e2e-base-image-repo-public:latest
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -36,7 +36,7 @@ executors:
       AMPLIFY_PATH: /home/circleci/repo/out/amplify-pkg-linux-x64
   a:
     docker:
-      - image: 'cimg/android:2022.09'
+      - image: cimg/android:2022.09
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -77,13 +77,11 @@ jobs:
       - run: yarn cache clean --force
       - run: yarn run production-build
       - save_cache:
-          key: >-
-            amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock"
-            }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
       - save_cache:
-          key: 'amplify-codegen-ssh-deps-{{ .Branch }}-<< parameters.os >>'
+          key: amplify-codegen-ssh-deps-{{ .Branch }}
           paths:
             - ~/.ssh
       - persist_to_workspace:
@@ -119,7 +117,7 @@ jobs:
             - restore_cache:
                 key: >-
                   amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum
-                  "yarn.lock" }}-l
+                  "yarn.lock" }}
       - run:
           name: Lint
           command: yarn lint
@@ -138,13 +136,11 @@ jobs:
           at: ./
       - restore_cache:
           keys:
-            - 'amplify-codegen-ssh-deps-{{ .Branch }}-l'
-            - >-
-              amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock"
-              }}-l
+            - amplify-codegen-ssh-deps-{{ .Branch }}
+            - amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with npm
-          command: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc'
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run:
           name: Publish Amplify Codegen
           command: |
@@ -157,9 +153,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: >-
-            amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock"
-            }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Publish to verdaccio
           command: |
@@ -172,9 +166,7 @@ jobs:
             yarn publish-to-verdaccio
             unsetNpmRegistryUrl
       - save_cache:
-          key: >-
-            amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}-<<
-            parameters.os >>
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/verdaccio-cache/
   e2e-test:
@@ -185,13 +177,9 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: >-
-            amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock"
-            }}-<< parameters.os >>
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: >-
-            amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}-<<
-            parameters.os >>
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - run: *ref_3
       - run:
           name: Run e2e tests
@@ -242,9 +230,9 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: 'amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - restore_cache:
-          key: 'amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}'
+          key: amplify-verdaccio-cache-{{ .Branch }}-{{ .Revision }}
       - node/install:
           install-yarn: true
           node-version: '16.13'
@@ -274,7 +262,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: 'amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}'
+          key: amplify-codegen-yarn-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Run cleanup script
           command: |


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Removed the OS suffix for cache naming as there is a mismatch between `parameter.os` (which is a wrapped object rather than single string and its alias `l`/`w`. This causes the cache not restoring issue and the deploy job to fail.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.