### PR TITLE
Refactor the getPrimaryKeyComponentsField method

### DIFF
--- a/packages/amplify-codegen-e2e-tests/schemas/modelgen/schema_with_connected_pk.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/modelgen/schema_with_connected_pk.graphql
@@ -1,0 +1,10 @@
+type Post @model {
+  postId: ID! @primaryKey
+  node: PostNode! @belongsTo(fields: ["postId"])
+  title: String!
+}
+
+type PostNode @model {
+  id: ID!
+  post: Post! @hasOne
+}

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/model-introspection-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/model-introspection-codegen.test.ts
@@ -28,6 +28,7 @@ describe('Model Introspection Codegen test', () => {
       // Model introspection is generated at correct location
       expect(isNotEmptyDir(join(projectRoot, outputDir))).toBe(true);
     });
+
     it('should throw error when the output directory is not defined in the command', async () => {
       // init project and add API category
       await initJSProjectWithProfile(projectRoot);
@@ -36,6 +37,7 @@ describe('Model Introspection Codegen test', () => {
       //generate introspection schema
       await expect(generateModelIntrospection(projectRoot)).rejects.toThrowError();
     });
+
     it('should throw error if the GraphQL schema is invalid', async () => {
       const invalidSchema = 'modelgen/model_gen_schema_with_errors.graphql';
       // init project and add API category
@@ -45,6 +47,21 @@ describe('Model Introspection Codegen test', () => {
       const outputDir = 'output';
       //generate introspection schema
       await expect(generateModelIntrospection(projectRoot, { outputDir })).rejects.toThrowError();
+    });
+
+    it(`should handle a schema with connected PK`, async () => {
+      const schemaName = 'modelgen/schema_with_connected_pk.graphql';
+
+      // init project and add API category
+      await initJSProjectWithProfile(projectRoot);
+      await addApiWithoutSchema(projectRoot, { apiName });
+      await updateApiSchema(projectRoot, apiName, schemaName);
+
+      const outputDir = 'output';
+      //generate introspection schema
+      await expect(generateModelIntrospection(projectRoot, { outputDir })).resolves.not.toThrow();
+      // Model introspection is generated at correct location
+      expect(isNotEmptyDir(join(projectRoot, outputDir))).toBe(true);
     });
 });
 

--- a/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
@@ -25,8 +25,17 @@ export function getOtherSideBelongsToField(type: string, otherSideModel: CodeGen
   return otherSideModel.fields.filter(f => f.type === type).find(f => f.directives.find(d => d.name === TransformerV2DirectiveName.BELONGS_TO));
 }
 
+/**
+ * Given a model, it returns the primary and sort key fields if present, throws meaningful error otherwise.
+ * @param model Codegen Model object
+ * @returns Array of primary and sort key codegen fields
+ */
 export function getModelPrimaryKeyComponentFields(model: CodeGenModel): CodeGenField[] {
-  const primaryKeyField = model.fields.find(field => field.primaryKeyInfo)!;
-  const { sortKeyFields } = primaryKeyField.primaryKeyInfo!;
-  return [ primaryKeyField, ...sortKeyFields ];
+  const primaryKeyField = model.fields.find(field => field.primaryKeyInfo);
+  if (primaryKeyField && primaryKeyField?.primaryKeyInfo) {
+    const { sortKeyFields } = primaryKeyField.primaryKeyInfo;
+    return [ primaryKeyField, ...sortKeyFields ];
+  }
+
+  throw new Error(`Unable to get the primary key component fields for model ${model?.name}`);
 }

--- a/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
@@ -32,10 +32,12 @@ export function getOtherSideBelongsToField(type: string, otherSideModel: CodeGen
  */
 export function getModelPrimaryKeyComponentFields(model: CodeGenModel): CodeGenField[] {
   const primaryKeyField = model.fields.find(field => field.primaryKeyInfo);
-  if (primaryKeyField && primaryKeyField?.primaryKeyInfo) {
-    const { sortKeyFields } = primaryKeyField.primaryKeyInfo;
-    return [ primaryKeyField, ...sortKeyFields ];
+  const keyFields: CodeGenField[] = [];
+  if (primaryKeyField) {
+    keyFields.push(primaryKeyField);
+    if ( primaryKeyField?.primaryKeyInfo?.sortKeyFields ) {
+      keyFields.push(...primaryKeyField.primaryKeyInfo.sortKeyFields);
+    };
   }
-
-  throw new Error(`Unable to get the primary key component fields for model ${model?.name}`);
+  return keyFields;
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -1022,6 +1022,8 @@ export class AppSyncModelVisitor<
       }
     } else {
       Object.values(this.modelMap).forEach(model => {
+        const primaryKeyFields = getModelPrimaryKeyComponentFields(model);
+        const primaryKeyName = (primaryKeyFields?.length > 0) ? this.getFieldName(primaryKeyFields[0]) : undefined;
         model.fields.forEach(field => {
           const connectionInfo = field.connectionInfo;
           if (
@@ -1030,7 +1032,7 @@ export class AppSyncModelVisitor<
             connectionInfo.kind !== CodeGenConnectionType.HAS_ONE &&
             connectionInfo.targetName !== 'id' &&
             !(this.config.target === 'introspection' &&
-              this.getFieldName(getModelPrimaryKeyComponentFields(model)[0]) === connectionInfo.targetName)
+              primaryKeyName && primaryKeyName === connectionInfo.targetName)
           ) {
             // Need to remove the field that is targetName
             removeFieldFromModel(model, connectionInfo.targetName);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -941,15 +941,17 @@ export class AppSyncModelVisitor<
           } else if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             if (isCustomPKEnabled) {
               const connectedModelFields = getModelPrimaryKeyComponentFields(connectionInfo.connectedModel);
-              connectionInfo.targetNames.forEach((target, index) => {
-                addFieldToModel(model, {
-                  name: target,
-                  directives: [],
-                  type: connectedModelFields[index].type,
-                  isList: false,
-                  isNullable: field.isNullable,
+              if (connectedModelFields?.length > 0) {
+                connectionInfo.targetNames.forEach((target, index) => {
+                  addFieldToModel(model, {
+                    name: target,
+                    directives: [],
+                    type: connectedModelFields[index].type,
+                    isList: false,
+                    isNullable: field.isNullable,
+                  });
                 });
-              });
+              }
             } else {
               addFieldToModel(model, {
                 name: connectionInfo.targetName,
@@ -962,15 +964,17 @@ export class AppSyncModelVisitor<
           } else if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
             if (isCustomPKEnabled) {
               const connectedModelFields = getModelPrimaryKeyComponentFields(connectionInfo.connectedModel);
-              connectionInfo.targetNames.forEach((target, index) => {
-                addFieldToModel(model, {
-                  name: target,
-                  directives: [],
-                  type: connectedModelFields[index].type,
-                  isList: false,
-                  isNullable: field.isNullable,
+              if (connectedModelFields?.length > 0) {
+                connectionInfo.targetNames.forEach((target, index) => {
+                  addFieldToModel(model, {
+                    name: target,
+                    directives: [],
+                    type: connectedModelFields[index].type,
+                    isList: false,
+                    isNullable: field.isNullable,
+                  });
                 });
-              });
+              }
             } else {
               addFieldToModel(model, {
                 name: connectionInfo.targetName,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
This is a follow-up for a [previous PR](https://github.com/aws-amplify/amplify-codegen/pull/570) that fixes the model introspection generation for a model with connected primary key.
- Add e2e test for identified scenario which was fixed in `3.4.2` codegen version.
- Minor refactor to usage of `getPrimaryKeyComponentsFields` method to document the assumptions and add appropriate checks.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.