### PR TITLE
feat: add __typename to selection set

### DIFF
--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -5,7 +5,7 @@ const Ora = require('ora');
 const loadConfig = require('../codegen-config');
 const constants = require('../constants');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
-const { generate } = require('@aws-amplify/graphql-docs-generator')
+const { generate } = require('@aws-amplify/graphql-docs-generator');
 
 async function generateStatements(context, forceDownloadSchema, maxDepth, withoutInit = false, decoupleFrontend = '') {
   try {
@@ -59,6 +59,9 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
         separateFiles: true,
         language,
         maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
+        // default typenameIntrospection to true when not set
+        typenameIntrospection:
+          cfg.amplifyExtension.typenameIntrospection === undefined ? true : !!cfg.amplifyExtension.typenameIntrospection,
       });
       opsGenSpinner.succeed(constants.INFO_MESSAGE_OPS_GEN_SUCCESS + path.relative(path.resolve('.'), opsGenDirectory));
     } finally {

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -71,6 +71,7 @@ describe('command - statements', () => {
     expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
       separateFiles: true,
       language: MOCK_TARGET_LANGUAGE,
+      typenameIntrospection: true,
     });
   });
 
@@ -81,6 +82,7 @@ describe('command - statements', () => {
     expect(generate).toHaveBeenCalledWith(path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA), path.join(MOCK_PROJECT_ROOT, MOCK_STATEMENTS_PATH), {
       separateFiles: true,
       language: 'graphql',
+      typenameIntrospection: true,
     });
   });
 
@@ -92,7 +94,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload
+      forceDownload,
     );
   });
 
@@ -105,7 +107,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload
+      forceDownload,
     );
   });
 

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -24,6 +24,7 @@ query Hero($episode: Episode) {
       }
       friendsConnection {
         totalCount
+        __typename
       }
       appearsIn
       ... on Human {
@@ -35,6 +36,7 @@ query Hero($episode: Episode) {
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -45,6 +47,7 @@ query Hero($episode: Episode) {
       totalCount
       edges {
         cursor
+        __typename
       }
       friends {
         id
@@ -63,7 +66,9 @@ query Hero($episode: Episode) {
         startCursor
         endCursor
         hasNextPage
+        __typename
       }
+      __typename
     }
     appearsIn
     ... on Human {
@@ -75,6 +80,7 @@ query Hero($episode: Episode) {
         name
         length
         coordinates
+        __typename
       }
     }
     ... on Droid {
@@ -87,6 +93,7 @@ query Reviews($episode: Episode!) {
     episode
     stars
     commentary
+    __typename
   }
 }
 query Search($text: String) {
@@ -115,6 +122,7 @@ query Search($text: String) {
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -126,6 +134,7 @@ query Search($text: String) {
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -136,6 +145,7 @@ query Search($text: String) {
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -154,7 +164,9 @@ query Search($text: String) {
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       starships {
@@ -162,6 +174,7 @@ query Search($text: String) {
         name
         length
         coordinates
+        __typename
       }
     }
     ... on Droid {
@@ -185,6 +198,7 @@ query Search($text: String) {
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -196,6 +210,7 @@ query Search($text: String) {
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -206,6 +221,7 @@ query Search($text: String) {
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -224,7 +240,9 @@ query Search($text: String) {
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       primaryFunction
@@ -259,6 +277,7 @@ query Character($id: ID!) {
       }
       friendsConnection {
         totalCount
+        __typename
       }
       appearsIn
       ... on Human {
@@ -270,6 +289,7 @@ query Character($id: ID!) {
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -280,6 +300,7 @@ query Character($id: ID!) {
       totalCount
       edges {
         cursor
+        __typename
       }
       friends {
         id
@@ -298,7 +319,9 @@ query Character($id: ID!) {
         startCursor
         endCursor
         hasNextPage
+        __typename
       }
+      __typename
     }
     appearsIn
     ... on Human {
@@ -310,6 +333,7 @@ query Character($id: ID!) {
         name
         length
         coordinates
+        __typename
       }
     }
     ... on Droid {
@@ -339,6 +363,7 @@ query Droid($id: ID!) {
       }
       friendsConnection {
         totalCount
+        __typename
       }
       appearsIn
       ... on Human {
@@ -350,6 +375,7 @@ query Droid($id: ID!) {
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -360,6 +386,7 @@ query Droid($id: ID!) {
       totalCount
       edges {
         cursor
+        __typename
       }
       friends {
         id
@@ -378,10 +405,13 @@ query Droid($id: ID!) {
         startCursor
         endCursor
         hasNextPage
+        __typename
       }
+      __typename
     }
     appearsIn
     primaryFunction
+    __typename
   }
 }
 query Human($id: ID!) {
@@ -409,6 +439,7 @@ query Human($id: ID!) {
       }
       friendsConnection {
         totalCount
+        __typename
       }
       appearsIn
       ... on Human {
@@ -420,6 +451,7 @@ query Human($id: ID!) {
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -430,6 +462,7 @@ query Human($id: ID!) {
       totalCount
       edges {
         cursor
+        __typename
       }
       friends {
         id
@@ -448,7 +481,9 @@ query Human($id: ID!) {
         startCursor
         endCursor
         hasNextPage
+        __typename
       }
+      __typename
     }
     appearsIn
     starships {
@@ -456,7 +491,9 @@ query Human($id: ID!) {
       name
       length
       coordinates
+      __typename
     }
+    __typename
   }
 }
 query Starship($id: ID!) {
@@ -465,6 +502,7 @@ query Starship($id: ID!) {
     name
     length
     coordinates
+    __typename
   }
 }
 mutation CreateReview($episode: Episode, $review: ReviewInput!) {
@@ -472,6 +510,7 @@ mutation CreateReview($episode: Episode, $review: ReviewInput!) {
     episode
     stars
     commentary
+    __typename
   }
 }
 subscription ReviewAdded($episode: Episode) {
@@ -479,6 +518,7 @@ subscription ReviewAdded($episode: Episode) {
     episode
     stars
     commentary
+    __typename
   }
 }
 "
@@ -511,6 +551,7 @@ export const hero = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -522,6 +563,7 @@ export const hero = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -532,6 +574,7 @@ export const hero = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -550,7 +593,9 @@ export const hero = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -562,6 +607,7 @@ export const hero = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -576,6 +622,7 @@ export const reviews = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -606,6 +653,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -617,6 +665,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -627,6 +676,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -645,7 +695,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         starships {
@@ -653,6 +705,7 @@ export const search = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -676,6 +729,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -687,6 +741,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -697,6 +752,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -715,7 +771,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         primaryFunction
@@ -752,6 +810,7 @@ export const character = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -763,6 +822,7 @@ export const character = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -773,6 +833,7 @@ export const character = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -791,7 +852,9 @@ export const character = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -803,6 +866,7 @@ export const character = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -834,6 +898,7 @@ export const droid = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -845,6 +910,7 @@ export const droid = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -855,6 +921,7 @@ export const droid = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -873,10 +940,13 @@ export const droid = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       primaryFunction
+      __typename
     }
   }
 \`;
@@ -906,6 +976,7 @@ export const human = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -917,6 +988,7 @@ export const human = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -927,6 +999,7 @@ export const human = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -945,7 +1018,9 @@ export const human = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       starships {
@@ -953,7 +1028,9 @@ export const human = /* GraphQL */ \`
         name
         length
         coordinates
+        __typename
       }
+      __typename
     }
   }
 \`;
@@ -964,6 +1041,7 @@ export const starship = /* GraphQL */ \`
       name
       length
       coordinates
+      __typename
     }
   }
 \`;
@@ -973,6 +1051,7 @@ export const createReview = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -982,6 +1061,7 @@ export const reviewAdded = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1016,6 +1096,7 @@ export const hero = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1027,6 +1108,7 @@ export const hero = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1037,6 +1119,7 @@ export const hero = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1055,7 +1138,9 @@ export const hero = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -1067,6 +1152,7 @@ export const hero = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1081,6 +1167,7 @@ export const reviews = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1111,6 +1198,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -1122,6 +1210,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -1132,6 +1221,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -1150,7 +1240,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         starships {
@@ -1158,6 +1250,7 @@ export const search = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1181,6 +1274,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -1192,6 +1286,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -1202,6 +1297,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -1220,7 +1316,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         primaryFunction
@@ -1257,6 +1355,7 @@ export const character = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1268,6 +1367,7 @@ export const character = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1278,6 +1378,7 @@ export const character = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1296,7 +1397,9 @@ export const character = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -1308,6 +1411,7 @@ export const character = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1339,6 +1443,7 @@ export const droid = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1350,6 +1455,7 @@ export const droid = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1360,6 +1466,7 @@ export const droid = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1378,10 +1485,13 @@ export const droid = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       primaryFunction
+      __typename
     }
   }
 \`;
@@ -1411,6 +1521,7 @@ export const human = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1422,6 +1533,7 @@ export const human = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1432,6 +1544,7 @@ export const human = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1450,7 +1563,9 @@ export const human = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       starships {
@@ -1458,7 +1573,9 @@ export const human = /* GraphQL */ \`
         name
         length
         coordinates
+        __typename
       }
+      __typename
     }
   }
 \`;
@@ -1469,6 +1586,7 @@ export const starship = /* GraphQL */ \`
       name
       length
       coordinates
+      __typename
     }
   }
 \`;
@@ -1478,6 +1596,7 @@ export const createReview = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1487,6 +1606,7 @@ export const reviewAdded = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1520,6 +1640,7 @@ export const hero = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1531,6 +1652,7 @@ export const hero = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1541,6 +1663,7 @@ export const hero = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1559,7 +1682,9 @@ export const hero = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -1571,6 +1696,7 @@ export const hero = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1585,6 +1711,7 @@ export const reviews = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1615,6 +1742,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -1626,6 +1754,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -1636,6 +1765,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -1654,7 +1784,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         starships {
@@ -1662,6 +1794,7 @@ export const search = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1685,6 +1818,7 @@ export const search = /* GraphQL */ \`
           }
           friendsConnection {
             totalCount
+            __typename
           }
           appearsIn
           ... on Human {
@@ -1696,6 +1830,7 @@ export const search = /* GraphQL */ \`
               name
               length
               coordinates
+              __typename
             }
           }
           ... on Droid {
@@ -1706,6 +1841,7 @@ export const search = /* GraphQL */ \`
           totalCount
           edges {
             cursor
+            __typename
           }
           friends {
             id
@@ -1724,7 +1860,9 @@ export const search = /* GraphQL */ \`
             startCursor
             endCursor
             hasNextPage
+            __typename
           }
+          __typename
         }
         appearsIn
         primaryFunction
@@ -1761,6 +1899,7 @@ export const character = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1772,6 +1911,7 @@ export const character = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1782,6 +1922,7 @@ export const character = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1800,7 +1941,9 @@ export const character = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       ... on Human {
@@ -1812,6 +1955,7 @@ export const character = /* GraphQL */ \`
           name
           length
           coordinates
+          __typename
         }
       }
       ... on Droid {
@@ -1843,6 +1987,7 @@ export const droid = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1854,6 +1999,7 @@ export const droid = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1864,6 +2010,7 @@ export const droid = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1882,10 +2029,13 @@ export const droid = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       primaryFunction
+      __typename
     }
   }
 \`;
@@ -1915,6 +2065,7 @@ export const human = /* GraphQL */ \`
         }
         friendsConnection {
           totalCount
+          __typename
         }
         appearsIn
         ... on Human {
@@ -1926,6 +2077,7 @@ export const human = /* GraphQL */ \`
             name
             length
             coordinates
+            __typename
           }
         }
         ... on Droid {
@@ -1936,6 +2088,7 @@ export const human = /* GraphQL */ \`
         totalCount
         edges {
           cursor
+          __typename
         }
         friends {
           id
@@ -1954,7 +2107,9 @@ export const human = /* GraphQL */ \`
           startCursor
           endCursor
           hasNextPage
+          __typename
         }
+        __typename
       }
       appearsIn
       starships {
@@ -1962,7 +2117,9 @@ export const human = /* GraphQL */ \`
         name
         length
         coordinates
+        __typename
       }
+      __typename
     }
   }
 \`;
@@ -1973,6 +2130,7 @@ export const starship = /* GraphQL */ \`
       name
       length
       coordinates
+      __typename
     }
   }
 \`;
@@ -1982,6 +2140,7 @@ export const createReview = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -1991,6 +2150,7 @@ export const reviewAdded = /* GraphQL */ \`
       episode
       stars
       commentary
+      __typename
     }
   }
 \`;
@@ -2005,6 +2165,7 @@ query GetUPPERCASE($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListUPPERCASEs(
@@ -2018,8 +2179,10 @@ query ListUPPERCASEs(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query GetLowercase($id: ID!) {
@@ -2028,6 +2191,7 @@ query GetLowercase($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListLowercases(
@@ -2041,8 +2205,10 @@ query ListLowercases(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query GetCamelCase($id: ID!) {
@@ -2051,6 +2217,7 @@ query GetCamelCase($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListCamelCases(
@@ -2064,8 +2231,10 @@ query ListCamelCases(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query GetPascalCase($id: ID!) {
@@ -2074,6 +2243,7 @@ query GetPascalCase($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListPascalCases(
@@ -2087,8 +2257,10 @@ query ListPascalCases(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query GetSnake_case($id: ID!) {
@@ -2097,6 +2269,7 @@ query GetSnake_case($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListSnake_cases(
@@ -2110,8 +2283,10 @@ query ListSnake_cases(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query GetUPPER_SNAKE_CASE($id: ID!) {
@@ -2120,6 +2295,7 @@ query GetUPPER_SNAKE_CASE($id: ID!) {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 query ListUPPER_SNAKE_CASEs(
@@ -2133,8 +2309,10 @@ query ListUPPER_SNAKE_CASEs(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 query QueryByOwner(
@@ -2156,8 +2334,10 @@ query QueryByOwner(
       owner
       createdAt
       updatedAt
+      __typename
     }
     nextToken
+    __typename
   }
 }
 mutation CreateUPPERCASE(
@@ -2169,6 +2349,7 @@ mutation CreateUPPERCASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdateUPPERCASE(
@@ -2180,6 +2361,7 @@ mutation UpdateUPPERCASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeleteUPPERCASE(
@@ -2191,6 +2373,7 @@ mutation DeleteUPPERCASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation CreateLowercase(
@@ -2202,6 +2385,7 @@ mutation CreateLowercase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdateLowercase(
@@ -2213,6 +2397,7 @@ mutation UpdateLowercase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeleteLowercase(
@@ -2224,6 +2409,7 @@ mutation DeleteLowercase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation CreateCamelCase(
@@ -2235,6 +2421,7 @@ mutation CreateCamelCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdateCamelCase(
@@ -2246,6 +2433,7 @@ mutation UpdateCamelCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeleteCamelCase(
@@ -2257,6 +2445,7 @@ mutation DeleteCamelCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation CreatePascalCase(
@@ -2268,6 +2457,7 @@ mutation CreatePascalCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdatePascalCase(
@@ -2279,6 +2469,7 @@ mutation UpdatePascalCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeletePascalCase(
@@ -2290,6 +2481,7 @@ mutation DeletePascalCase(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation CreateSnake_case(
@@ -2301,6 +2493,7 @@ mutation CreateSnake_case(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdateSnake_case(
@@ -2312,6 +2505,7 @@ mutation UpdateSnake_case(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeleteSnake_case(
@@ -2323,6 +2517,7 @@ mutation DeleteSnake_case(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation CreateUPPER_SNAKE_CASE(
@@ -2334,6 +2529,7 @@ mutation CreateUPPER_SNAKE_CASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation UpdateUPPER_SNAKE_CASE(
@@ -2345,6 +2541,7 @@ mutation UpdateUPPER_SNAKE_CASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 mutation DeleteUPPER_SNAKE_CASE(
@@ -2356,6 +2553,7 @@ mutation DeleteUPPER_SNAKE_CASE(
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreateUPPERCASE {
@@ -2364,6 +2562,7 @@ subscription OnCreateUPPERCASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdateUPPERCASE {
@@ -2372,6 +2571,7 @@ subscription OnUpdateUPPERCASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeleteUPPERCASE {
@@ -2380,6 +2580,7 @@ subscription OnDeleteUPPERCASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreateLowercase {
@@ -2388,6 +2589,7 @@ subscription OnCreateLowercase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdateLowercase {
@@ -2396,6 +2598,7 @@ subscription OnUpdateLowercase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeleteLowercase {
@@ -2404,6 +2607,7 @@ subscription OnDeleteLowercase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreateCamelCase {
@@ -2412,6 +2616,7 @@ subscription OnCreateCamelCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdateCamelCase {
@@ -2420,6 +2625,7 @@ subscription OnUpdateCamelCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeleteCamelCase {
@@ -2428,6 +2634,7 @@ subscription OnDeleteCamelCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreatePascalCase {
@@ -2436,6 +2643,7 @@ subscription OnCreatePascalCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdatePascalCase {
@@ -2444,6 +2652,7 @@ subscription OnUpdatePascalCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeletePascalCase {
@@ -2452,6 +2661,7 @@ subscription OnDeletePascalCase {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreateSnake_case {
@@ -2460,6 +2670,7 @@ subscription OnCreateSnake_case {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdateSnake_case {
@@ -2468,6 +2679,7 @@ subscription OnUpdateSnake_case {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeleteSnake_case {
@@ -2476,6 +2688,7 @@ subscription OnDeleteSnake_case {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnCreateUPPER_SNAKE_CASE {
@@ -2484,6 +2697,7 @@ subscription OnCreateUPPER_SNAKE_CASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnUpdateUPPER_SNAKE_CASE {
@@ -2492,6 +2706,7 @@ subscription OnUpdateUPPER_SNAKE_CASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 subscription OnDeleteUPPER_SNAKE_CASE {
@@ -2500,6 +2715,7 @@ subscription OnDeleteUPPER_SNAKE_CASE {
     owner
     createdAt
     updatedAt
+    __typename
   }
 }
 "
@@ -2516,6 +2732,7 @@ export const getUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2531,8 +2748,10 @@ export const listUPPERCASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2543,6 +2762,7 @@ export const getLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2558,8 +2778,10 @@ export const listLowercases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2570,6 +2792,7 @@ export const getCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2585,8 +2808,10 @@ export const listCamelCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2597,6 +2822,7 @@ export const getPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2612,8 +2838,10 @@ export const listPascalCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2624,6 +2852,7 @@ export const getSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2639,8 +2868,10 @@ export const listSnake_cases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2651,6 +2882,7 @@ export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2670,8 +2902,10 @@ export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2695,8 +2929,10 @@ export const queryByOwner = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -2710,6 +2946,7 @@ export const createUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2723,6 +2960,7 @@ export const updateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2736,6 +2974,7 @@ export const deleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2749,6 +2988,7 @@ export const createLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2762,6 +3002,7 @@ export const updateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2775,6 +3016,7 @@ export const deleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2788,6 +3030,7 @@ export const createCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2801,6 +3044,7 @@ export const updateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2814,6 +3058,7 @@ export const deleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2827,6 +3072,7 @@ export const createPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2840,6 +3086,7 @@ export const updatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2853,6 +3100,7 @@ export const deletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2866,6 +3114,7 @@ export const createSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2879,6 +3128,7 @@ export const updateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2892,6 +3142,7 @@ export const deleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2905,6 +3156,7 @@ export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2918,6 +3170,7 @@ export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2931,6 +3184,7 @@ export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2941,6 +3195,7 @@ export const onCreateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2951,6 +3206,7 @@ export const onUpdateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2961,6 +3217,7 @@ export const onDeleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2971,6 +3228,7 @@ export const onCreateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2981,6 +3239,7 @@ export const onUpdateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -2991,6 +3250,7 @@ export const onDeleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3001,6 +3261,7 @@ export const onCreateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3011,6 +3272,7 @@ export const onUpdateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3021,6 +3283,7 @@ export const onDeleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3031,6 +3294,7 @@ export const onCreatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3041,6 +3305,7 @@ export const onUpdatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3051,6 +3316,7 @@ export const onDeletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3061,6 +3327,7 @@ export const onCreateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3071,6 +3338,7 @@ export const onUpdateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3081,6 +3349,7 @@ export const onDeleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3091,6 +3360,7 @@ export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3101,6 +3371,7 @@ export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3111,6 +3382,7 @@ export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3129,6 +3401,7 @@ export const getUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3144,8 +3417,10 @@ export const listUPPERCASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3156,6 +3431,7 @@ export const getLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3171,8 +3447,10 @@ export const listLowercases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3183,6 +3461,7 @@ export const getCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3198,8 +3477,10 @@ export const listCamelCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3210,6 +3491,7 @@ export const getPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3225,8 +3507,10 @@ export const listPascalCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3237,6 +3521,7 @@ export const getSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3252,8 +3537,10 @@ export const listSnake_cases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3264,6 +3551,7 @@ export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3283,8 +3571,10 @@ export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3308,8 +3598,10 @@ export const queryByOwner = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3323,6 +3615,7 @@ export const createUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3336,6 +3629,7 @@ export const updateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3349,6 +3643,7 @@ export const deleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3362,6 +3657,7 @@ export const createLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3375,6 +3671,7 @@ export const updateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3388,6 +3685,7 @@ export const deleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3401,6 +3699,7 @@ export const createCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3414,6 +3713,7 @@ export const updateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3427,6 +3727,7 @@ export const deleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3440,6 +3741,7 @@ export const createPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3453,6 +3755,7 @@ export const updatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3466,6 +3769,7 @@ export const deletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3479,6 +3783,7 @@ export const createSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3492,6 +3797,7 @@ export const updateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3505,6 +3811,7 @@ export const deleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3518,6 +3825,7 @@ export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3531,6 +3839,7 @@ export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3544,6 +3853,7 @@ export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3554,6 +3864,7 @@ export const onCreateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3564,6 +3875,7 @@ export const onUpdateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3574,6 +3886,7 @@ export const onDeleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3584,6 +3897,7 @@ export const onCreateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3594,6 +3908,7 @@ export const onUpdateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3604,6 +3919,7 @@ export const onDeleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3614,6 +3930,7 @@ export const onCreateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3624,6 +3941,7 @@ export const onUpdateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3634,6 +3952,7 @@ export const onDeleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3644,6 +3963,7 @@ export const onCreatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3654,6 +3974,7 @@ export const onUpdatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3664,6 +3985,7 @@ export const onDeletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3674,6 +3996,7 @@ export const onCreateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3684,6 +4007,7 @@ export const onUpdateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3694,6 +4018,7 @@ export const onDeleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3704,6 +4029,7 @@ export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3714,6 +4040,7 @@ export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3724,6 +4051,7 @@ export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3741,6 +4069,7 @@ export const getUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3756,8 +4085,10 @@ export const listUPPERCASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3768,6 +4099,7 @@ export const getLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3783,8 +4115,10 @@ export const listLowercases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3795,6 +4129,7 @@ export const getCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3810,8 +4145,10 @@ export const listCamelCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3822,6 +4159,7 @@ export const getPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3837,8 +4175,10 @@ export const listPascalCases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3849,6 +4189,7 @@ export const getSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3864,8 +4205,10 @@ export const listSnake_cases = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3876,6 +4219,7 @@ export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3895,8 +4239,10 @@ export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3920,8 +4266,10 @@ export const queryByOwner = /* GraphQL */ \`
         owner
         createdAt
         updatedAt
+        __typename
       }
       nextToken
+      __typename
     }
   }
 \`;
@@ -3935,6 +4283,7 @@ export const createUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3948,6 +4297,7 @@ export const updateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3961,6 +4311,7 @@ export const deleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3974,6 +4325,7 @@ export const createLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -3987,6 +4339,7 @@ export const updateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4000,6 +4353,7 @@ export const deleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4013,6 +4367,7 @@ export const createCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4026,6 +4381,7 @@ export const updateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4039,6 +4395,7 @@ export const deleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4052,6 +4409,7 @@ export const createPascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4065,6 +4423,7 @@ export const updatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4078,6 +4437,7 @@ export const deletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4091,6 +4451,7 @@ export const createSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4104,6 +4465,7 @@ export const updateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4117,6 +4479,7 @@ export const deleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4130,6 +4493,7 @@ export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4143,6 +4507,7 @@ export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4156,6 +4521,7 @@ export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4166,6 +4532,7 @@ export const onCreateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4176,6 +4543,7 @@ export const onUpdateUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4186,6 +4554,7 @@ export const onDeleteUPPERCASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4196,6 +4565,7 @@ export const onCreateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4206,6 +4576,7 @@ export const onUpdateLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4216,6 +4587,7 @@ export const onDeleteLowercase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4226,6 +4598,7 @@ export const onCreateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4236,6 +4609,7 @@ export const onUpdateCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4246,6 +4620,7 @@ export const onDeleteCamelCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4256,6 +4631,7 @@ export const onCreatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4266,6 +4642,7 @@ export const onUpdatePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4276,6 +4653,7 @@ export const onDeletePascalCase = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4286,6 +4664,7 @@ export const onCreateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4296,6 +4675,7 @@ export const onUpdateSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4306,6 +4686,7 @@ export const onDeleteSnake_case = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4316,6 +4697,7 @@ export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4326,6 +4708,7 @@ export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;
@@ -4336,6 +4719,7 @@ export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
       owner
       createdAt
       updatedAt
+      __typename
     }
   }
 \`;

--- a/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
@@ -26,7 +26,7 @@ describe('getField', () => {
 
   it('should support simple scalar', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false })).toEqual({
+    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
       name: 'foo',
       fields: [],
       fragments: [],
@@ -37,7 +37,7 @@ describe('getField', () => {
 
   it('it should recursively resolve fields up to max depth', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false })).toEqual({
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
       name: 'nested',
       fields: [
         {
@@ -77,9 +77,39 @@ describe('getField', () => {
     });
   });
 
+  it('it should recorsively resolve fields without typename when typenameIntrospection is disabled', () => {
+    const queries = schema.getQueryType().getFields();
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: false })).toEqual({
+      name: 'nested',
+      fields: [
+        {
+          name: 'level',
+          fields: [],
+          fragments: [],
+          hasBody: false,
+        },
+        {
+          name: 'subObj',
+          fields: [
+            {
+              name: 'level',
+              fields: [],
+              fragments: [],
+              hasBody: false,
+            },
+          ],
+          fragments: [],
+          hasBody: true,
+        },
+      ],
+      fragments: [],
+      hasBody: true,
+    });
+  });
+
   it('should not return anything for complex type when the depth is < 1', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false })).toBeUndefined();
+    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toBeUndefined();
   });
   describe('When type is an Interface', () => {
     beforeEach(() => {
@@ -123,7 +153,10 @@ describe('getField', () => {
     it('interface - should return fragments of all the implementations', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -180,7 +213,10 @@ describe('getField', () => {
     it('union - should return fragments of all the types', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -249,7 +285,10 @@ describe('getField', () => {
     it('aggregateItems property should traverse two additional levels to generate required fields with default depth 2', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 

--- a/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
@@ -55,9 +55,21 @@ describe('getField', () => {
               fragments: [],
               hasBody: false,
             },
+            {
+              name: '__typename',
+              fields: [],
+              fragments: [],
+              hasBody: false,
+            },
           ],
           fragments: [],
           hasBody: true,
+        },
+        {
+          name: '__typename',
+          fields: [],
+          fragments: [],
+          hasBody: false,
         },
       ],
       fragments: [],
@@ -211,7 +223,7 @@ describe('getField', () => {
         buckets: { type: aggregateBucketResultItem },
       },
     });
-    
+
     const aggregateResult = new GraphQLUnionType({
       name: 'SearchableAggregateGenericResult',
       types: [aggregateScalarResult, aggregateBucketResult],

--- a/packages/graphql-docs-generator/src/cli.ts
+++ b/packages/graphql-docs-generator/src/cli.ts
@@ -54,12 +54,21 @@ export function run(argv: Array<String>): void {
         },
         retainCaseStyle: {
           default: true,
-          type: 'boolean'
-        }
+          type: 'boolean',
+        },
+        typenameIntrospection: {
+          default: true,
+          type: 'boolean',
+        },
       },
       async argv => {
-        generate(argv.schema, argv.output, { separateFiles: argv.separateFiles, language: argv.language, maxDepth: argv.maxDepth });
-      }
+        generate(argv.schema, argv.output, {
+          separateFiles: argv.separateFiles,
+          language: argv.language,
+          maxDepth: argv.maxDepth,
+          typenameIntrospection: argv.typenameIntrospection,
+        });
+      },
     )
     .help()
     .version()

--- a/packages/graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/graphql-docs-generator/src/generator/getFields.ts
@@ -22,7 +22,7 @@ export default function getFields(
   field: GraphQLField<any, any>,
   schema: GraphQLSchema,
   depth: number = 2,
-  options: GQLDocsGenOptions
+  options: GQLDocsGenOptions,
 ): GQLTemplateField {
   const fieldType: GQLConcreteType = getType(field.type);
   const renderS3FieldFragment = options.useExternalFragmentForS3Object && isS3Object(fieldType);
@@ -40,6 +40,14 @@ export default function getFields(
       return getFields(subField, schema, adjustDepth(subField, depth), options);
     })
     .filter(f => f);
+  if (isObjectType(fieldType)) {
+    fields.push({
+      name: '__typename',
+      fields: [],
+      fragments: [],
+      hasBody: false,
+    });
+  }
   const fragments: Array<GQLTemplateFragment> = Object.keys(subFragments)
     .map(fragment => getFragment(subFragments[fragment], schema, depth, fields, null, false, options))
     .filter(f => f);
@@ -74,18 +82,14 @@ function adjustDepth(field, depth) {
 }
 
 function isGraphQLAggregateField(field) {
-  if (
-    field &&
-    field.name == 'aggregateItems' &&
-    getBaseType(field.type) == 'SearchableAggregateResult'
-  ) {
+  if (field && field.name == 'aggregateItems' && getBaseType(field.type) == 'SearchableAggregateResult') {
     return true;
   }
   return false;
 }
 
 function getBaseType(type) {
-  if(type && type.ofType) {
+  if (type && type.ofType) {
     return getBaseType(type.ofType);
   }
   return type?.name;

--- a/packages/graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/graphql-docs-generator/src/generator/getFields.ts
@@ -40,6 +40,9 @@ export default function getFields(
       return getFields(subField, schema, adjustDepth(subField, depth), options);
     })
     .filter(f => f);
+
+  // add __typename to selection set.
+  // getFields() does not include __typename because __typename is implicitly included on all object types.
   if (isObjectType(fieldType)) {
     fields.push({
       name: '__typename',

--- a/packages/graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/graphql-docs-generator/src/generator/getFields.ts
@@ -43,7 +43,9 @@ export default function getFields(
 
   // add __typename to selection set.
   // getFields() does not include __typename because __typename is implicitly included on all object types.
-  if (isObjectType(fieldType)) {
+  // https://spec.graphql.org/June2018/#sec-Type-Name-Introspection
+  // do not add to interface types or union types because they are not supported by the transformers
+  if (options.typenameIntrospection && isObjectType(fieldType)) {
     fields.push({
       name: '__typename',
       fields: [],

--- a/packages/graphql-docs-generator/src/generator/types.ts
+++ b/packages/graphql-docs-generator/src/generator/types.ts
@@ -71,5 +71,6 @@ export type GQLAllOperations = {
 };
 
 export type GQLDocsGenOptions = {
-  useExternalFragmentForS3Object: boolean,
+  useExternalFragmentForS3Object: boolean;
+  typenameIntrospection: boolean;
 };

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -18,7 +18,7 @@ const FILE_EXTENSION_MAP = {
 export function generate(
   schemaPath: string,
   outputPath: string,
-  options: { separateFiles: boolean; language: string; maxDepth: number },
+  options: { separateFiles: boolean; language: string; maxDepth: number; typenameIntrospection: boolean },
 ): void {
   const language = options.language || 'graphql';
   const schemaData = loadSchema(schemaPath);
@@ -28,8 +28,10 @@ export function generate(
 
   const maxDepth = options.maxDepth || DEFAULT_MAX_DEPTH;
   const useExternalFragmentForS3Object = options.language === 'graphql';
+  const { typenameIntrospection = true } = options;
   const gqlOperations: GQLAllOperations = generateAllOps(schemaData, maxDepth, {
     useExternalFragmentForS3Object,
+    typenameIntrospection,
   });
   registerPartials();
   registerHelpers();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

**BREAKING CHANGE**

Add `__typename` to selection set of generated queries for object types.

[Typename Introspection](https://spec.graphql.org/June2018/#sec-Type-Name-Introspection) is included in the GraphQL spec and is accessible on the meta field `__typename`. `__typename` is available on object, interface, and union types.

This change adds `__typename` to only object types because we do not generate resolvers for interface and union types. (We could add this anyway for customers not using the transformers).

AppSync is guaranteed to supply `__typename` for all queries not using interface or union types regardless of the resolver implementation. Therefore, this change is only potential breaking for customers meeting the following criteria:
1. using a non-AppSync backend
2. the backend is non-compliant with the GraphQL spec.

Customers will have the option to disable generation of `__typename` with `typenameIntrospection` field in `.graphqlconfig.yml`. The option will default to true when omitted.

```yml
projects:
  typename:
    extensions:
      amplify:
        typenameIntrospection: true
```

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves https://github.com/aws-amplify/amplify-codegen/issues/445

#### Description of how you validated changes

* Unit testing
* `amplify-dev codegen statements` in typescript, ios, and android app and try queries.
    * `__typename` is not accessible on ios and android because the generated classes do no have a `__typename` property, but the inclusion of `__typename` in the query does not cause errors.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.