### PR TITLE
fix: add a type for null safety

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -89,7 +89,7 @@ class Post extends Model {
     return _comments;
   }
   
-  const Post._internal({required this.id, required title, required rating, required status, comments}): _title = title, _rating = rating, _status = status, _comments = comments;
+  const Post._internal({required this.id, required String title, required int rating, required PostStatus status, List<Comment>? comments}): _title = title, _rating = rating, _status = status, _comments = comments;
   
   factory Post({String? id, required String title, required int rating, required PostStatus status, List<Comment>? comments}) {
     return Post._internal(
@@ -142,14 +142,14 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _rating = (json['rating'] as num?)?.toInt(),
       _status = enumFromString<PostStatus>(json['status'], PostStatus.values),
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -257,7 +257,7 @@ class Comment extends Model {
     }
   }
   
-  const Comment._internal({required this.id, required post, required content}): _post = post, _content = content;
+  const Comment._internal({required this.id, required Post post, required String content}): _post = post, _content = content;
   
   factory Comment({String? id, required Post post, required String content}) {
     return Comment._internal(
@@ -303,11 +303,11 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _post = json['post']?['serializedData'] != null
-        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null,
-      _content = json['content'];
+      _content = json['content'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'post': _post?.toJson(), 'content': _content
@@ -451,7 +451,7 @@ class Post extends Model {
     return _comments;
   }
   
-  const Post._internal({required this.id, required title, required rating, required status, comments}): _title = title, _rating = rating, _status = status, _comments = comments;
+  const Post._internal({required this.id, required String title, required int rating, required PostStatus status, List<Comment>? comments}): _title = title, _rating = rating, _status = status, _comments = comments;
   
   factory Post({String? id, required String title, required int rating, required PostStatus status, List<Comment>? comments}) {
     return Post._internal(
@@ -504,14 +504,14 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _rating = (json['rating'] as num?)?.toInt(),
       _status = enumFromString<PostStatus>(json['status'], PostStatus.values),
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -619,7 +619,7 @@ class Comment extends Model {
     }
   }
   
-  const Comment._internal({required this.id, required post, required content}): _post = post, _content = content;
+  const Comment._internal({required this.id, required Post post, required String content}): _post = post, _content = content;
   
   factory Comment({String? id, required Post post, required String content}) {
     return Comment._internal(
@@ -665,11 +665,11 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _post = json['post']?['serializedData'] != null
-        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null,
-      _content = json['content'];
+      _content = json['content'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'post': _post?.toJson(), 'content': _content
@@ -974,7 +974,7 @@ class Address {
     }
   }
   
-  const Address._internal({required line1, line2, required city, required state, required postalCode}): _line1 = line1, _line2 = line2, _city = city, _state = state, _postalCode = postalCode;
+  const Address._internal({required String line1, String? line2, required String city, required String state, required String postalCode}): _line1 = line1, _line2 = line2, _city = city, _state = state, _postalCode = postalCode;
   
   factory Address({required String line1, String? line2, required String city, required String state, required String postalCode}) {
     return Address._internal(
@@ -1028,11 +1028,11 @@ class Address {
   }
   
   Address.fromJson(Map<String, dynamic> json)  
-    : _line1 = json['line1'],
-      _line2 = json['line2'],
-      _city = json['city'],
-      _state = json['state'],
-      _postalCode = json['postalCode'];
+    : _line1 = json['line1'] as String,
+      _line2 = json['line2'] as String?,
+      _city = json['city'] as String,
+      _state = json['state'] as String,
+      _postalCode = json['postalCode'] as String;
   
   Map<String, dynamic> toJson() => {
     'line1': _line1, 'line2': _line2, 'city': _city, 'state': _state, 'postalCode': _postalCode
@@ -1286,7 +1286,7 @@ class Contact {
     return _mailingAddresses;
   }
   
-  const Contact._internal({required contactName, required phone, mailingAddresses}): _contactName = contactName, _phone = phone, _mailingAddresses = mailingAddresses;
+  const Contact._internal({required String contactName, required Phone phone, List<Address>? mailingAddresses}): _contactName = contactName, _phone = phone, _mailingAddresses = mailingAddresses;
   
   factory Contact({required String contactName, required Phone phone, List<Address>? mailingAddresses}) {
     return Contact._internal(
@@ -1332,14 +1332,14 @@ class Contact {
   }
   
   Contact.fromJson(Map<String, dynamic> json)  
-    : _contactName = json['contactName'],
+    : _contactName = json['contactName'] as String,
       _phone = json['phone']?['serializedData'] != null
-        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData']))
+        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData'] as Map))
         : null,
       _mailingAddresses = json['mailingAddresses'] is List
         ? (json['mailingAddresses'] as List)
           .where((e) => e != null)
-          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -1751,7 +1751,7 @@ class Person extends Model {
     return _mailingAddresses;
   }
   
-  const Person._internal({required this.id, required name, required phone, mailingAddresses}): _name = name, _phone = phone, _mailingAddresses = mailingAddresses;
+  const Person._internal({required this.id, required String name, required Phone phone, List<Address>? mailingAddresses}): _name = name, _phone = phone, _mailingAddresses = mailingAddresses;
   
   factory Person({String? id, required String name, required Phone phone, List<Address>? mailingAddresses}) {
     return Person._internal(
@@ -1801,15 +1801,15 @@ class Person extends Model {
   }
   
   Person.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _phone = json['phone']?['serializedData'] != null
-        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData']))
+        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData'] as Map))
         : null,
       _mailingAddresses = json['mailingAddresses'] is List
         ? (json['mailingAddresses'] as List)
           .where((e) => e != null)
-          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -3447,7 +3447,7 @@ class Post extends Model {
     return _tags;
   }
   
-  const Post._internal({required this.id, required title, content, tags}): _title = title, _content = content, _tags = tags;
+  const Post._internal({required this.id, required String title, String? content, List<PostTags>? tags}): _title = title, _content = content, _tags = tags;
   
   factory Post({String? id, required String title, String? content, List<PostTags>? tags}) {
     return Post._internal(
@@ -3496,13 +3496,13 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
-      _content = json['content'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
+      _content = json['content'] as String?,
       _tags = json['tags'] is List
         ? (json['tags'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -3594,7 +3594,7 @@ class Tag extends Model {
     return _posts;
   }
   
-  const Tag._internal({required this.id, required label, posts}): _label = label, _posts = posts;
+  const Tag._internal({required this.id, required String label, List<PostTags>? posts}): _label = label, _posts = posts;
   
   factory Tag({String? id, required String label, List<PostTags>? posts}) {
     return Tag._internal(
@@ -3639,12 +3639,12 @@ class Tag extends Model {
   }
   
   Tag.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _label = json['label'],
+    : id = json['id'] as String,
+      _label = json['label'] as String,
       _posts = json['posts'] is List
         ? (json['posts'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -3738,7 +3738,7 @@ class PostTags extends Model {
     }
   }
   
-  const PostTags._internal({required this.id, required post, required tag}): _post = post, _tag = tag;
+  const PostTags._internal({required this.id, required Post post, required Tag tag}): _post = post, _tag = tag;
   
   factory PostTags({String? id, required Post post, required Tag tag}) {
     return PostTags._internal(
@@ -3784,12 +3784,12 @@ class PostTags extends Model {
   }
   
   PostTags.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _post = json['post']?['serializedData'] != null
-        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null,
       _tag = json['tag']?['serializedData'] != null
-        ? Tag.fromJson(new Map<String, dynamic>.from(json['tag']['serializedData']))
+        ? Tag.fromJson(new Map<String, dynamic>.from(json['tag']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -4343,7 +4343,7 @@ class TodoWithAuth extends Model {
     return _updatedAt;
   }
   
-  const TodoWithAuth._internal({required this.id, required name, createdAt, updatedAt}): _name = name, _createdAt = createdAt, _updatedAt = updatedAt;
+  const TodoWithAuth._internal({required this.id, required String name, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _name = name, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory TodoWithAuth({String? id, required String name}) {
     return TodoWithAuth._internal(
@@ -4387,10 +4387,10 @@ class TodoWithAuth extends Model {
   }
   
   TodoWithAuth.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : id = json['id'] as String,
+      _name = json['name'] as String,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -6902,7 +6902,7 @@ class TestModel extends Model {
   }
   
   TestModel.fromJson(Map<String, dynamic> json)  
-    : id = json['id'];
+    : id = json['id'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id
@@ -6997,7 +6997,7 @@ class Blog extends Model {
     return _posts;
   }
   
-  const Blog._internal({required this.id, required name, posts}): _name = name, _posts = posts;
+  const Blog._internal({required this.id, required String name, List<Post>? posts}): _name = name, _posts = posts;
   
   factory Blog({String? id, required String name, List<Post>? posts}) {
     return Blog._internal(
@@ -7042,12 +7042,12 @@ class Blog extends Model {
   }
   
   Blog.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _posts = json['posts'] is List
         ? (json['posts'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Post.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Post.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -7160,7 +7160,7 @@ class Comment extends Model {
     }
   }
   
-  const Comment._internal({required this.id, post, required content}): _post = post, _content = content;
+  const Comment._internal({required this.id, Post? post, required String content}): _post = post, _content = content;
   
   factory Comment({String? id, Post? post, required String content}) {
     return Comment._internal(
@@ -7206,11 +7206,11 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _post = json['post']?['serializedData'] != null
-        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null,
-      _content = json['content'];
+      _content = json['content'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'post': _post?.toJson(), 'content': _content
@@ -7331,7 +7331,7 @@ class Post extends Model {
     return _comments;
   }
   
-  const Post._internal({required this.id, required title, blog, comments}): _title = title, _blog = blog, _comments = comments;
+  const Post._internal({required this.id, required String title, Blog? blog, List<Comment>? comments}): _title = title, _blog = blog, _comments = comments;
   
   factory Post({String? id, required String title, Blog? blog, List<Comment>? comments}) {
     return Post._internal(
@@ -7380,15 +7380,15 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _blog = json['blog']?['serializedData'] != null
-        ? Blog.fromJson(new Map<String, dynamic>.from(json['blog']['serializedData']))
+        ? Blog.fromJson(new Map<String, dynamic>.from(json['blog']['serializedData'] as Map))
         : null,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -7553,7 +7553,7 @@ class TestModel extends Model {
     return _nullableFloatNullableList;
   }
   
-  const TestModel._internal({required this.id, required floatVal, floatNullableVal, required floatList, floatNullableList, required nullableFloatList, nullableFloatNullableList}): _floatVal = floatVal, _floatNullableVal = floatNullableVal, _floatList = floatList, _floatNullableList = floatNullableList, _nullableFloatList = nullableFloatList, _nullableFloatNullableList = nullableFloatNullableList;
+  const TestModel._internal({required this.id, required double floatVal, double? floatNullableVal, required List<double> floatList, List<double>? floatNullableList, required List<double> nullableFloatList, List<double>? nullableFloatNullableList}): _floatVal = floatVal, _floatNullableVal = floatNullableVal, _floatList = floatList, _floatNullableList = floatNullableList, _nullableFloatList = nullableFloatList, _nullableFloatNullableList = nullableFloatNullableList;
   
   factory TestModel({String? id, required double floatVal, double? floatNullableVal, required List<double> floatList, List<double>? floatNullableList, required List<double> nullableFloatList, List<double>? nullableFloatNullableList}) {
     return TestModel._internal(
@@ -7615,7 +7615,7 @@ class TestModel extends Model {
   }
   
   TestModel.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _floatVal = (json['floatVal'] as num?)?.toDouble(),
       _floatNullableVal = (json['floatNullableVal'] as num?)?.toDouble(),
       _floatList = (json['floatList'] as List?)?.map((e) => (e as num).toDouble()).toList(),
@@ -7856,7 +7856,7 @@ class TestModel extends Model {
     return _nullableIntNullableList;
   }
   
-  const TestModel._internal({required this.id, required floatVal, floatNullableVal, required floatList, floatNullableList, required nullableFloatList, nullableFloatNullableList, required intVal, intNullableVal, required intList, intNullableList, required nullableIntList, nullableIntNullableList}): _floatVal = floatVal, _floatNullableVal = floatNullableVal, _floatList = floatList, _floatNullableList = floatNullableList, _nullableFloatList = nullableFloatList, _nullableFloatNullableList = nullableFloatNullableList, _intVal = intVal, _intNullableVal = intNullableVal, _intList = intList, _intNullableList = intNullableList, _nullableIntList = nullableIntList, _nullableIntNullableList = nullableIntNullableList;
+  const TestModel._internal({required this.id, required double floatVal, double? floatNullableVal, required List<double> floatList, List<double>? floatNullableList, required List<double> nullableFloatList, List<double>? nullableFloatNullableList, required int intVal, int? intNullableVal, required List<int> intList, List<int>? intNullableList, required List<int> nullableIntList, List<int>? nullableIntNullableList}): _floatVal = floatVal, _floatNullableVal = floatNullableVal, _floatList = floatList, _floatNullableList = floatNullableList, _nullableFloatList = nullableFloatList, _nullableFloatNullableList = nullableFloatNullableList, _intVal = intVal, _intNullableVal = intNullableVal, _intList = intList, _intNullableList = intNullableList, _nullableIntList = nullableIntList, _nullableIntNullableList = nullableIntNullableList;
   
   factory TestModel({String? id, required double floatVal, double? floatNullableVal, required List<double> floatList, List<double>? floatNullableList, required List<double> nullableFloatList, List<double>? nullableFloatNullableList, required int intVal, int? intNullableVal, required List<int> intList, List<int>? intNullableList, required List<int> nullableIntList, List<int>? nullableIntNullableList}) {
     return TestModel._internal(
@@ -7942,7 +7942,7 @@ class TestModel extends Model {
   }
   
   TestModel.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
+    : id = json['id'] as String,
       _floatVal = (json['floatVal'] as num?)?.toDouble(),
       _floatNullableVal = (json['floatNullableVal'] as num?)?.toDouble(),
       _floatList = (json['floatList'] as List?)?.map((e) => (e as num).toDouble()).toList(),
@@ -8283,7 +8283,7 @@ class SimpleModel extends Model {
     return _updatedAt;
   }
   
-  const SimpleModel._internal({required this.id, name, createdAt, updatedAt}): _name = name, _createdAt = createdAt, _updatedAt = updatedAt;
+  const SimpleModel._internal({required this.id, String? name, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _name = name, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory SimpleModel({String? id, String? name}) {
     return SimpleModel._internal(
@@ -8327,10 +8327,10 @@ class SimpleModel extends Model {
   }
   
   SimpleModel.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : id = json['id'] as String,
+      _name = json['name'] as String?,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -8454,7 +8454,7 @@ class ModelWithImplicitID extends Model {
     return _updatedAt;
   }
   
-  const ModelWithImplicitID._internal({required this.id, required title, createdAt, updatedAt}): _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithImplicitID._internal({required this.id, required String title, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithImplicitID({String? id, required String title}) {
     return ModelWithImplicitID._internal(
@@ -8498,10 +8498,10 @@ class ModelWithImplicitID extends Model {
   }
   
   ModelWithImplicitID.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : id = json['id'] as String,
+      _title = json['title'] as String,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -8670,7 +8670,7 @@ class ModelWithExplicitID extends Model {
     return _updatedAt;
   }
   
-  const ModelWithExplicitID._internal({required this.id, required title, createdAt, updatedAt}): _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithExplicitID._internal({required this.id, required String title, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithExplicitID({String? id, required String title}) {
     return ModelWithExplicitID._internal(
@@ -8714,10 +8714,10 @@ class ModelWithExplicitID extends Model {
   }
   
   ModelWithExplicitID.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : id = json['id'] as String,
+      _title = json['title'] as String,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -8877,7 +8877,7 @@ class ModelWithExplicitIDAndSDI extends Model {
     return _updatedAt;
   }
   
-  const ModelWithExplicitIDAndSDI._internal({required this.id, parentID, createdAt, updatedAt}): _parentID = parentID, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithExplicitIDAndSDI._internal({required this.id, String? parentID, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _parentID = parentID, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithExplicitIDAndSDI({String? id, String? parentID}) {
     return ModelWithExplicitIDAndSDI._internal(
@@ -8921,10 +8921,10 @@ class ModelWithExplicitIDAndSDI extends Model {
   }
   
   ModelWithExplicitIDAndSDI.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _parentID = json['parentID'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : id = json['id'] as String,
+      _parentID = json['parentID'] as String?,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'parentID': _parentID, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -9122,7 +9122,7 @@ class ModelWithIDPlusSortKeys extends Model {
     return _updatedAt;
   }
   
-  const ModelWithIDPlusSortKeys._internal({required this.id, required title, required rating, createdAt, updatedAt}): _title = title, _rating = rating, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithIDPlusSortKeys._internal({required this.id, required String title, required int rating, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _title = title, _rating = rating, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithIDPlusSortKeys({String? id, required String title, required int rating}) {
     return ModelWithIDPlusSortKeys._internal(
@@ -9170,11 +9170,11 @@ class ModelWithIDPlusSortKeys extends Model {
   }
   
   ModelWithIDPlusSortKeys.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _rating = (json['rating'] as num?)?.toInt(),
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'title': _title, 'rating': _rating, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -9389,7 +9389,7 @@ class ModelWithExplicitlyDefinedPK extends Model {
     return _updatedAt;
   }
   
-  const ModelWithExplicitlyDefinedPK._internal({required modelID, required title, createdAt, updatedAt}): _modelID = modelID, _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithExplicitlyDefinedPK._internal({required String modelID, required String title, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _modelID = modelID, _title = title, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithExplicitlyDefinedPK({required String modelID, required String title}) {
     return ModelWithExplicitlyDefinedPK._internal(
@@ -9433,10 +9433,10 @@ class ModelWithExplicitlyDefinedPK extends Model {
   }
   
   ModelWithExplicitlyDefinedPK.fromJson(Map<String, dynamic> json)  
-    : _modelID = json['modelID'],
-      _title = json['title'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+    : _modelID = json['modelID'] as String,
+      _title = json['title'] as String,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'modelID': _modelID, 'title': _title, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -9651,7 +9651,7 @@ class ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey extends Model {
     return _updatedAt;
   }
   
-  const ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey._internal({required modelID, required title, required rating, createdAt, updatedAt}): _modelID = modelID, _title = title, _rating = rating, _createdAt = createdAt, _updatedAt = updatedAt;
+  const ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey._internal({required String modelID, required String title, required int rating, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _modelID = modelID, _title = title, _rating = rating, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey({required String modelID, required String title, required int rating}) {
     return ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey._internal(
@@ -9699,11 +9699,11 @@ class ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey extends Model {
   }
   
   ModelWithExplicitlyDefinedPKPlusSortKeysAsCompositeKey.fromJson(Map<String, dynamic> json)  
-    : _modelID = json['modelID'],
-      _title = json['title'],
+    : _modelID = json['modelID'] as String,
+      _title = json['title'] as String,
       _rating = (json['rating'] as num?)?.toInt(),
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'modelID': _modelID, 'title': _title, 'rating': _rating, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -9917,7 +9917,7 @@ class Post extends Model {
     return _updatedAt;
   }
   
-  const Post._internal({required this.id, required title, comments, createdAt, updatedAt}): _title = title, _comments = comments, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Post._internal({required this.id, required String title, List<Comment>? comments, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _title = title, _comments = comments, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory Post({String? id, required String title, List<Comment>? comments}) {
     return Post._internal(
@@ -9964,16 +9964,16 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null,
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'title': _title, 'comments': _comments?.map((Comment? e) => e?.toJson()).toList(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -10184,7 +10184,7 @@ class Comment extends Model {
     return _postCommentsTitle;
   }
   
-  const Comment._internal({required this.id, required content, createdAt, updatedAt, postCommentsId, postCommentsTitle}): _content = content, _createdAt = createdAt, _updatedAt = updatedAt, _postCommentsId = postCommentsId, _postCommentsTitle = postCommentsTitle;
+  const Comment._internal({required this.id, required String content, TemporalDateTime? createdAt, TemporalDateTime? updatedAt, String? postCommentsId, String? postCommentsTitle}): _content = content, _createdAt = createdAt, _updatedAt = updatedAt, _postCommentsId = postCommentsId, _postCommentsTitle = postCommentsTitle;
   
   factory Comment({String? id, required String content, String? postCommentsId, String? postCommentsTitle}) {
     return Comment._internal(
@@ -10236,12 +10236,12 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _content = json['content'],
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null,
-      _postCommentsId = json['postCommentsId'],
-      _postCommentsTitle = json['postCommentsTitle'];
+    : id = json['id'] as String,
+      _content = json['content'] as String,
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null,
+      _postCommentsId = json['postCommentsId'] as String?,
+      _postCommentsTitle = json['postCommentsTitle'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'content': _content, 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'postCommentsId': _postCommentsId, 'postCommentsTitle': _postCommentsTitle
@@ -10475,7 +10475,7 @@ class Project extends Model {
     return _projectTeamName;
   }
   
-  const Project._internal({required projectId, required name, team, createdAt, updatedAt, projectTeamTeamId, projectTeamName}): _projectId = projectId, _name = name, _team = team, _createdAt = createdAt, _updatedAt = updatedAt, _projectTeamTeamId = projectTeamTeamId, _projectTeamName = projectTeamName;
+  const Project._internal({required String projectId, required String name, Team? team, TemporalDateTime? createdAt, TemporalDateTime? updatedAt, String? projectTeamTeamId, String? projectTeamName}): _projectId = projectId, _name = name, _team = team, _createdAt = createdAt, _updatedAt = updatedAt, _projectTeamTeamId = projectTeamTeamId, _projectTeamName = projectTeamName;
   
   factory Project({required String projectId, required String name, Team? team, String? projectTeamTeamId, String? projectTeamName}) {
     return Project._internal(
@@ -10530,15 +10530,15 @@ class Project extends Model {
   }
   
   Project.fromJson(Map<String, dynamic> json)  
-    : _projectId = json['projectId'],
-      _name = json['name'],
+    : _projectId = json['projectId'] as String,
+      _name = json['name'] as String,
       _team = json['team']?['serializedData'] != null
-        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData']))
+        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData'] as Map))
         : null,
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null,
-      _projectTeamTeamId = json['projectTeamTeamId'],
-      _projectTeamName = json['projectTeamName'];
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null,
+      _projectTeamTeamId = json['projectTeamTeamId'] as String?,
+      _projectTeamName = json['projectTeamName'] as String?;
   
   Map<String, dynamic> toJson() => {
     'projectId': _projectId, 'name': _name, 'team': _team?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'projectTeamTeamId': _projectTeamTeamId, 'projectTeamName': _projectTeamName
@@ -10776,7 +10776,7 @@ class Team extends Model {
     return _updatedAt;
   }
   
-  const Team._internal({required teamId, required name, project, createdAt, updatedAt}): _teamId = teamId, _name = name, _project = project, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Team._internal({required String teamId, required String name, Project? project, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _teamId = teamId, _name = name, _project = project, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory Team({required String teamId, required String name, Project? project}) {
     return Team._internal(
@@ -10824,13 +10824,13 @@ class Team extends Model {
   }
   
   Team.fromJson(Map<String, dynamic> json)  
-    : _teamId = json['teamId'],
-      _name = json['name'],
+    : _teamId = json['teamId'] as String,
+      _name = json['name'] as String,
       _project = json['project']?['serializedData'] != null
-        ? Project.fromJson(new Map<String, dynamic>.from(json['project']['serializedData']))
+        ? Project.fromJson(new Map<String, dynamic>.from(json['project']['serializedData'] as Map))
         : null,
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'teamId': _teamId, 'name': _name, 'project': _project?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
@@ -11051,7 +11051,7 @@ class CpkOneToOneBidirectionalParent extends Model {
     return _cpkOneToOneBidirectionalParentExplicitChildName;
   }
   
-  const CpkOneToOneBidirectionalParent._internal({required this.id, required name, explicitChild, createdAt, updatedAt, cpkOneToOneBidirectionalParentExplicitChildId, cpkOneToOneBidirectionalParentExplicitChildName}): _name = name, _explicitChild = explicitChild, _createdAt = createdAt, _updatedAt = updatedAt, _cpkOneToOneBidirectionalParentExplicitChildId = cpkOneToOneBidirectionalParentExplicitChildId, _cpkOneToOneBidirectionalParentExplicitChildName = cpkOneToOneBidirectionalParentExplicitChildName;
+  const CpkOneToOneBidirectionalParent._internal({required this.id, required String name, CpkOneToOneBidirectionalChildExplicit? explicitChild, TemporalDateTime? createdAt, TemporalDateTime? updatedAt, String? cpkOneToOneBidirectionalParentExplicitChildId, String? cpkOneToOneBidirectionalParentExplicitChildName}): _name = name, _explicitChild = explicitChild, _createdAt = createdAt, _updatedAt = updatedAt, _cpkOneToOneBidirectionalParentExplicitChildId = cpkOneToOneBidirectionalParentExplicitChildId, _cpkOneToOneBidirectionalParentExplicitChildName = cpkOneToOneBidirectionalParentExplicitChildName;
   
   factory CpkOneToOneBidirectionalParent({String? id, required String name, CpkOneToOneBidirectionalChildExplicit? explicitChild, String? cpkOneToOneBidirectionalParentExplicitChildId, String? cpkOneToOneBidirectionalParentExplicitChildName}) {
     return CpkOneToOneBidirectionalParent._internal(
@@ -11106,15 +11106,15 @@ class CpkOneToOneBidirectionalParent extends Model {
   }
   
   CpkOneToOneBidirectionalParent.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _explicitChild = json['explicitChild']?['serializedData'] != null
-        ? CpkOneToOneBidirectionalChildExplicit.fromJson(new Map<String, dynamic>.from(json['explicitChild']['serializedData']))
+        ? CpkOneToOneBidirectionalChildExplicit.fromJson(new Map<String, dynamic>.from(json['explicitChild']['serializedData'] as Map))
         : null,
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null,
-      _cpkOneToOneBidirectionalParentExplicitChildId = json['cpkOneToOneBidirectionalParentExplicitChildId'],
-      _cpkOneToOneBidirectionalParentExplicitChildName = json['cpkOneToOneBidirectionalParentExplicitChildName'];
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null,
+      _cpkOneToOneBidirectionalParentExplicitChildId = json['cpkOneToOneBidirectionalParentExplicitChildId'] as String?,
+      _cpkOneToOneBidirectionalParentExplicitChildName = json['cpkOneToOneBidirectionalParentExplicitChildName'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'explicitChild': _explicitChild?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'cpkOneToOneBidirectionalParentExplicitChildId': _cpkOneToOneBidirectionalParentExplicitChildId, 'cpkOneToOneBidirectionalParentExplicitChildName': _cpkOneToOneBidirectionalParentExplicitChildName
@@ -11335,7 +11335,7 @@ class CpkOneToOneBidirectionalChildExplicit extends Model {
     return _updatedAt;
   }
   
-  const CpkOneToOneBidirectionalChildExplicit._internal({required this.id, required name, belongsToParent, createdAt, updatedAt}): _name = name, _belongsToParent = belongsToParent, _createdAt = createdAt, _updatedAt = updatedAt;
+  const CpkOneToOneBidirectionalChildExplicit._internal({required this.id, required String name, CpkOneToOneBidirectionalParent? belongsToParent, TemporalDateTime? createdAt, TemporalDateTime? updatedAt}): _name = name, _belongsToParent = belongsToParent, _createdAt = createdAt, _updatedAt = updatedAt;
   
   factory CpkOneToOneBidirectionalChildExplicit({String? id, required String name, CpkOneToOneBidirectionalParent? belongsToParent}) {
     return CpkOneToOneBidirectionalChildExplicit._internal(
@@ -11383,13 +11383,13 @@ class CpkOneToOneBidirectionalChildExplicit extends Model {
   }
   
   CpkOneToOneBidirectionalChildExplicit.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _belongsToParent = json['belongsToParent']?['serializedData'] != null
-        ? CpkOneToOneBidirectionalParent.fromJson(new Map<String, dynamic>.from(json['belongsToParent']['serializedData']))
+        ? CpkOneToOneBidirectionalParent.fromJson(new Map<String, dynamic>.from(json['belongsToParent']['serializedData'] as Map))
         : null,
-      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
+      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt'] as String) : null,
+      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt'] as String) : null;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'belongsToParent': _belongsToParent?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -61,7 +61,7 @@ class Post extends Model {
     return _comments;
   }
   
-  const Post._internal({required this.id, required title, comments}): _title = title, _comments = comments;
+  const Post._internal({required this.id, required String title, List<Comment>? comments}): _title = title, _comments = comments;
   
   factory Post({String? id, required String title, List<Comment>? comments}) {
     return Post._internal(
@@ -106,12 +106,12 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -224,7 +224,7 @@ class Comment extends Model {
     return _post;
   }
   
-  const Comment._internal({required this.id, required content, post}): _content = content, _post = post;
+  const Comment._internal({required this.id, required String content, Post? post}): _content = content, _post = post;
   
   factory Comment({String? id, required String content, Post? post}) {
     return Comment._internal(
@@ -270,10 +270,10 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _content = json['content'],
+    : id = json['id'] as String,
+      _content = json['content'] as String,
       _post = json['post']?['serializedData'] != null
-        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -385,7 +385,7 @@ class Project2 extends Model {
     return _project2TeamId;
   }
   
-  const Project2._internal({required this.id, name, team, project2TeamId}): _name = name, _team = team, _project2TeamId = project2TeamId;
+  const Project2._internal({required this.id, String? name, Team2? team, String? project2TeamId}): _name = name, _team = team, _project2TeamId = project2TeamId;
   
   factory Project2({String? id, String? name, Team2? team, String? project2TeamId}) {
     return Project2._internal(
@@ -434,12 +434,12 @@ class Project2 extends Model {
   }
   
   Project2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String?,
       _team = json['team']?['serializedData'] != null
-        ? Team2.fromJson(new Map<String, dynamic>.from(json['team']['serializedData']))
+        ? Team2.fromJson(new Map<String, dynamic>.from(json['team']['serializedData'] as Map))
         : null,
-      _project2TeamId = json['project2TeamId'];
+      _project2TeamId = json['project2TeamId'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'project2TeamId': _project2TeamId
@@ -557,7 +557,7 @@ class Team2 extends Model {
     return _project;
   }
   
-  const Team2._internal({required this.id, required name, project}): _name = name, _project = project;
+  const Team2._internal({required this.id, required String name, Project2? project}): _name = name, _project = project;
   
   factory Team2({String? id, required String name, Project2? project}) {
     return Team2._internal(
@@ -603,10 +603,10 @@ class Team2 extends Model {
   }
   
   Team2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _project = json['project']?['serializedData'] != null
-        ? Project2.fromJson(new Map<String, dynamic>.from(json['project']['serializedData']))
+        ? Project2.fromJson(new Map<String, dynamic>.from(json['project']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -719,7 +719,7 @@ class Blog7V2 extends Model {
     return _posts;
   }
   
-  const Blog7V2._internal({required this.id, required name, posts}): _name = name, _posts = posts;
+  const Blog7V2._internal({required this.id, required String name, List<Post7V2>? posts}): _name = name, _posts = posts;
   
   factory Blog7V2({String? id, required String name, List<Post7V2>? posts}) {
     return Blog7V2._internal(
@@ -764,12 +764,12 @@ class Blog7V2 extends Model {
   }
   
   Blog7V2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _posts = json['posts'] is List
         ? (json['posts'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Post7V2.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Post7V2.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -888,7 +888,7 @@ class Post7V2 extends Model {
     return _comments;
   }
   
-  const Post7V2._internal({required this.id, required title, blog, comments}): _title = title, _blog = blog, _comments = comments;
+  const Post7V2._internal({required this.id, required String title, Blog7V2? blog, List<Comment7V2>? comments}): _title = title, _blog = blog, _comments = comments;
   
   factory Post7V2({String? id, required String title, Blog7V2? blog, List<Comment7V2>? comments}) {
     return Post7V2._internal(
@@ -937,15 +937,15 @@ class Post7V2 extends Model {
   }
   
   Post7V2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _blog = json['blog']?['serializedData'] != null
-        ? Blog7V2.fromJson(new Map<String, dynamic>.from(json['blog']['serializedData']))
+        ? Blog7V2.fromJson(new Map<String, dynamic>.from(json['blog']['serializedData'] as Map))
         : null,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment7V2.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment7V2.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -1059,7 +1059,7 @@ class Comment7V2 extends Model {
     return _post;
   }
   
-  const Comment7V2._internal({required this.id, content, post}): _content = content, _post = post;
+  const Comment7V2._internal({required this.id, String? content, Post7V2? post}): _content = content, _post = post;
   
   factory Comment7V2({String? id, String? content, Post7V2? post}) {
     return Comment7V2._internal(
@@ -1105,10 +1105,10 @@ class Comment7V2 extends Model {
   }
   
   Comment7V2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _content = json['content'],
+    : id = json['id'] as String,
+      _content = json['content'] as String?,
       _post = json['post']?['serializedData'] != null
-        ? Post7V2.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
+        ? Post7V2.fromJson(new Map<String, dynamic>.from(json['post']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -1216,7 +1216,7 @@ class Project extends Model {
     return _projectTeamId;
   }
   
-  const Project._internal({required this.id, name, team, projectTeamId}): _name = name, _team = team, _projectTeamId = projectTeamId;
+  const Project._internal({required this.id, String? name, Team? team, String? projectTeamId}): _name = name, _team = team, _projectTeamId = projectTeamId;
   
   factory Project({String? id, String? name, Team? team, String? projectTeamId}) {
     return Project._internal(
@@ -1265,12 +1265,12 @@ class Project extends Model {
   }
   
   Project.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String?,
       _team = json['team']?['serializedData'] != null
-        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData']))
+        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData'] as Map))
         : null,
-      _projectTeamId = json['projectTeamId'];
+      _projectTeamId = json['projectTeamId'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
@@ -1388,7 +1388,7 @@ class Team extends Model {
     return _project;
   }
   
-  const Team._internal({required this.id, required name, project}): _name = name, _project = project;
+  const Team._internal({required this.id, required String name, Project? project}): _name = name, _project = project;
   
   factory Team({String? id, required String name, Project? project}) {
     return Team._internal(
@@ -1434,10 +1434,10 @@ class Team extends Model {
   }
   
   Team.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String,
       _project = json['project']?['serializedData'] != null
-        ? Project.fromJson(new Map<String, dynamic>.from(json['project']['serializedData']))
+        ? Project.fromJson(new Map<String, dynamic>.from(json['project']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -1555,7 +1555,7 @@ class Post extends Model {
     return _tags;
   }
   
-  const Post._internal({required this.id, required title, content, tags}): _title = title, _content = content, _tags = tags;
+  const Post._internal({required this.id, required String title, String? content, List<PostTags>? tags}): _title = title, _content = content, _tags = tags;
   
   factory Post({String? id, required String title, String? content, List<PostTags>? tags}) {
     return Post._internal(
@@ -1604,13 +1604,13 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
-      _content = json['content'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
+      _content = json['content'] as String?,
       _tags = json['tags'] is List
         ? (json['tags'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -1731,7 +1731,7 @@ class Tag extends Model {
     return _posts;
   }
   
-  const Tag._internal({required this.id, required label, posts}): _label = label, _posts = posts;
+  const Tag._internal({required this.id, required String label, List<PostTags>? posts}): _label = label, _posts = posts;
   
   factory Tag({String? id, required String label, List<PostTags>? posts}) {
     return Tag._internal(
@@ -1776,12 +1776,12 @@ class Tag extends Model {
   }
   
   Tag.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _label = json['label'],
+    : id = json['id'] as String,
+      _label = json['label'] as String,
       _posts = json['posts'] is List
         ? (json['posts'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => PostTags.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -1879,7 +1879,7 @@ class Todo extends Model {
     return _content;
   }
   
-  const Todo._internal({required this.id, content}): _content = content;
+  const Todo._internal({required this.id, String? content}): _content = content;
   
   factory Todo({String? id, String? content}) {
     return Todo._internal(
@@ -1921,8 +1921,8 @@ class Todo extends Model {
   }
   
   Todo.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _content = json['content'];
+    : id = json['id'] as String,
+      _content = json['content'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'content': _content
@@ -2024,7 +2024,7 @@ class Post2 extends Model {
     return _comments;
   }
   
-  const Post2._internal({required this.id, required title, comments}): _title = title, _comments = comments;
+  const Post2._internal({required this.id, required String title, List<Comment2>? comments}): _title = title, _comments = comments;
   
   factory Post2({String? id, required String title, List<Comment2>? comments}) {
     return Post2._internal(
@@ -2069,12 +2069,12 @@ class Post2 extends Model {
   }
   
   Post2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment2.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment2.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -2195,7 +2195,7 @@ class Comment2 extends Model {
     }
   }
   
-  const Comment2._internal({required this.id, required postID, required content}): _postID = postID, _content = content;
+  const Comment2._internal({required this.id, required String postID, required String content}): _postID = postID, _content = content;
   
   factory Comment2({String? id, required String postID, required String content}) {
     return Comment2._internal(
@@ -2241,9 +2241,9 @@ class Comment2 extends Model {
   }
   
   Comment2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _postID = json['postID'],
-      _content = json['content'];
+    : id = json['id'] as String,
+      _postID = json['postID'] as String,
+      _content = json['content'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'postID': _postID, 'content': _content
@@ -2351,7 +2351,7 @@ class Project2 extends Model {
     return _team;
   }
   
-  const Project2._internal({required this.id, name, teamID, team}): _name = name, _teamID = teamID, _team = team;
+  const Project2._internal({required this.id, String? name, String? teamID, Team2? team}): _name = name, _teamID = teamID, _team = team;
   
   factory Project2({String? id, String? name, String? teamID, Team2? team}) {
     return Project2._internal(
@@ -2400,11 +2400,11 @@ class Project2 extends Model {
   }
   
   Project2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
-      _teamID = json['teamID'],
+    : id = json['id'] as String,
+      _name = json['name'] as String?,
+      _teamID = json['teamID'] as String?,
       _team = json['team']?['serializedData'] != null
-        ? Team2.fromJson(new Map<String, dynamic>.from(json['team']['serializedData']))
+        ? Team2.fromJson(new Map<String, dynamic>.from(json['team']['serializedData'] as Map))
         : null;
   
   Map<String, dynamic> toJson() => {
@@ -2517,7 +2517,7 @@ class Team2 extends Model {
     }
   }
   
-  const Team2._internal({required this.id, required name}): _name = name;
+  const Team2._internal({required this.id, required String name}): _name = name;
   
   factory Team2({String? id, required String name}) {
     return Team2._internal(
@@ -2559,8 +2559,8 @@ class Team2 extends Model {
   }
   
   Team2.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'];
+    : id = json['id'] as String,
+      _name = json['name'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name
@@ -2662,7 +2662,7 @@ class Post extends Model {
     return _comments;
   }
   
-  const Post._internal({required this.id, required title, comments}): _title = title, _comments = comments;
+  const Post._internal({required this.id, required String title, List<Comment>? comments}): _title = title, _comments = comments;
   
   factory Post({String? id, required String title, List<Comment>? comments}) {
     return Post._internal(
@@ -2707,12 +2707,12 @@ class Post extends Model {
   }
   
   Post.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _title = json['title'],
+    : id = json['id'] as String,
+      _title = json['title'] as String,
       _comments = json['comments'] is List
         ? (json['comments'] as List)
           .where((e) => e?['serializedData'] != null)
-          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'])))
+          .map((e) => Comment.fromJson(new Map<String, dynamic>.from(e['serializedData'] as Map)))
           .toList()
         : null;
   
@@ -2824,7 +2824,7 @@ class Comment extends Model {
     return _postCommentsId;
   }
   
-  const Comment._internal({required this.id, required content, postCommentsId}): _content = content, _postCommentsId = postCommentsId;
+  const Comment._internal({required this.id, required String content, String? postCommentsId}): _content = content, _postCommentsId = postCommentsId;
   
   factory Comment({String? id, required String content, String? postCommentsId}) {
     return Comment._internal(
@@ -2870,9 +2870,9 @@ class Comment extends Model {
   }
   
   Comment.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _content = json['content'],
-      _postCommentsId = json['postCommentsId'];
+    : id = json['id'] as String,
+      _content = json['content'] as String,
+      _postCommentsId = json['postCommentsId'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'content': _content, 'postCommentsId': _postCommentsId
@@ -2976,7 +2976,7 @@ class Project extends Model {
     return _projectTeamId;
   }
   
-  const Project._internal({required this.id, name, team, projectTeamId}): _name = name, _team = team, _projectTeamId = projectTeamId;
+  const Project._internal({required this.id, String? name, Team? team, String? projectTeamId}): _name = name, _team = team, _projectTeamId = projectTeamId;
   
   factory Project({String? id, String? name, Team? team, String? projectTeamId}) {
     return Project._internal(
@@ -3025,12 +3025,12 @@ class Project extends Model {
   }
   
   Project.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
+    : id = json['id'] as String,
+      _name = json['name'] as String?,
       _team = json['team']?['serializedData'] != null
-        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData']))
+        ? Team.fromJson(new Map<String, dynamic>.from(json['team']['serializedData'] as Map))
         : null,
-      _projectTeamId = json['projectTeamId'];
+      _projectTeamId = json['projectTeamId'] as String?;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'team': _team?.toJson(), 'projectTeamId': _projectTeamId
@@ -3142,7 +3142,7 @@ class Team extends Model {
     }
   }
   
-  const Team._internal({required this.id, required name}): _name = name;
+  const Team._internal({required this.id, required String name}): _name = name;
   
   factory Team({String? id, required String name}) {
     return Team._internal(
@@ -3184,8 +3184,8 @@ class Team extends Model {
   }
   
   Team.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'];
+    : id = json['id'] as String,
+      _name = json['name'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name
@@ -3299,7 +3299,7 @@ class Customer extends Model {
     }
   }
   
-  const Customer._internal({required this.id, required name, phoneNumber, required accountRepresentativeID}): _name = name, _phoneNumber = phoneNumber, _accountRepresentativeID = accountRepresentativeID;
+  const Customer._internal({required this.id, required String name, String? phoneNumber, required String accountRepresentativeID}): _name = name, _phoneNumber = phoneNumber, _accountRepresentativeID = accountRepresentativeID;
   
   factory Customer({String? id, required String name, String? phoneNumber, required String accountRepresentativeID}) {
     return Customer._internal(
@@ -3349,10 +3349,10 @@ class Customer extends Model {
   }
   
   Customer.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _name = json['name'],
-      _phoneNumber = json['phoneNumber'],
-      _accountRepresentativeID = json['accountRepresentativeID'];
+    : id = json['id'] as String,
+      _name = json['name'] as String,
+      _phoneNumber = json['phoneNumber'] as String?,
+      _accountRepresentativeID = json['accountRepresentativeID'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'name': _name, 'phoneNumber': _phoneNumber, 'accountRepresentativeID': _accountRepresentativeID
@@ -3512,7 +3512,7 @@ class ModelWithPrimaryKey extends Model {
     }
   }
   
-  const ModelWithPrimaryKey._internal({required this.id, required productID, required name, content, required albumID, required categoryID}): _productID = productID, _name = name, _content = content, _albumID = albumID, _categoryID = categoryID;
+  const ModelWithPrimaryKey._internal({required this.id, required String productID, required String name, String? content, required String albumID, required String categoryID}): _productID = productID, _name = name, _content = content, _albumID = albumID, _categoryID = categoryID;
   
   factory ModelWithPrimaryKey({String? id, required String productID, required String name, String? content, required String albumID, required String categoryID}) {
     return ModelWithPrimaryKey._internal(
@@ -3570,12 +3570,12 @@ class ModelWithPrimaryKey extends Model {
   }
   
   ModelWithPrimaryKey.fromJson(Map<String, dynamic> json)  
-    : id = json['id'],
-      _productID = json['productID'],
-      _name = json['name'],
-      _content = json['content'],
-      _albumID = json['albumID'],
-      _categoryID = json['categoryID'];
+    : id = json['id'] as String,
+      _productID = json['productID'] as String,
+      _name = json['name'] as String,
+      _content = json['content'] as String?,
+      _albumID = json['albumID'] as String,
+      _categoryID = json['categoryID'] as String;
   
   Map<String, dynamic> toJson() => {
     'id': id, 'productID': _productID, 'name': _name, 'content': _content, 'albumID': _albumID, 'categoryID': _categoryID

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -565,7 +565,12 @@ export class AppSyncModelDartVisitor<
     //Model._internal
     const args = this.isNullSafety()
       ? `{${model.fields
-          .map(f => `${this.isFieldRequired(f) ? 'required ' : ''}${this.getFieldName(f) === 'id' ? 'this.' : ''}${this.getFieldName(f)}`)
+          .map(
+            f =>
+              `${this.isFieldRequired(f) ? `required ` : ''}${this.getFieldName(f) === 'id' ? 'this.' : this.getNativeType(f)}${
+                this.isFieldRequired(f) ? '' : '?'
+              } ${this.getFieldName(f)}`,
+          )
           .join(', ')}}`
       : `{${model.fields.map(f => `${this.isFieldRequired(f) ? '@required ' : ''}this.${this.getFieldName(f)}`).join(', ')}}`;
     const internalFields = model.fields.filter(f => this.getFieldName(f) !== 'id');
@@ -734,7 +739,7 @@ export class AppSyncModelDartVisitor<
                 this.isNullSafety() ? indent(`.where((e) => e?['serializedData'] != null)`, 2) : undefined,
                 indent(
                   `.map((e) => ${this.getNativeType({ ...field, isList: false })}.fromJson(new Map<String, dynamic>.from(e${
-                    this.isNullSafety() ? `['serializedData']` : ''
+                    this.isNullSafety() ? `['serializedData'] as Map` : ''
                   })))`,
                   2,
                 ),
@@ -748,7 +753,7 @@ export class AppSyncModelDartVisitor<
               `${fieldName} = json['${varName}']${this.isNullSafety() ? `?['serializedData']` : ''} != null`,
               indent(
                 `? ${this.getNativeType(field)}.fromJson(new Map<String, dynamic>.from(json['${varName}']${
-                  this.isNullSafety() ? `['serializedData']` : ''
+                  this.isNullSafety() ? `['serializedData'] as Map` : ''
                 }))`,
               ),
               indent(`: null`),
@@ -808,13 +813,13 @@ export class AppSyncModelDartVisitor<
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullSafetyTypeStr(
                     'List',
                   )})?.map((e) => ${fieldNativeType}.fromString(e)).toList()`
-                : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromString(json['${varName}']) : null`;
+                : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromString(json['${varName}'] as String) : null`;
             case this.scalars['AWSTimestamp']:
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullSafetyTypeStr(
                     'List',
                   )})?.map((e) => ${fieldNativeType}.fromSeconds(e)).toList()`
-                : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromSeconds(json['${varName}']) : null`;
+                : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromSeconds(json['${varName}'] as Int) : null`;
             case this.scalars['Int']:
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullSafetyTypeStr('List')})?.map((e) => (e as num).toInt()).toList()`
@@ -826,7 +831,7 @@ export class AppSyncModelDartVisitor<
             default:
               return field.isList
                 ? `${fieldName} = json['${varName}']?.cast<${this.getNativeType({ ...field, isList: false })}>()`
-                : `${fieldName} = json['${varName}']`;
+                : `${fieldName} = json['${varName}'] as ${this.getNativeType(field)}${this.isFieldRequired(field) ? '' : '?'}`;
           }
         })
         .join(',\n'),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

If you apply null safety, flutter model is created incorrectly. 

Flutter (Channel stable, 3.7.9, on macOS 13.2.1 22D68 darwin-x64, locale ko-KR)
Dart SDK version: 2.19.6 (stable) (Tue Mar 28 13:41:04 2023 +0000) on "macos_x64"


```dart
/*
* Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
*
* Licensed under the Apache License, Version 2.0 (the "License").
* You may not use this file except in compliance with the License.
* A copy of the License is located at
*
*  http://aws.amazon.com/apache2.0
*
* or in the "license" file accompanying this file. This file is distributed
* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
* express or implied. See the License for the specific language governing
* permissions and limitations under the License.
*/

// NOTE: This file is generated and may not follow lint rules defined in your app
// Generated files can be excluded from analysis in analysis_options.yaml
// For more info, see: https://dart.dev/guides/language/analysis-options#excluding-code-from-analysis

// ignore_for_file: public_member_api_docs, annotate_overrides, dead_code, dead_codepublic_member_api_docs, depend_on_referenced_packages, file_names, library_private_types_in_public_api, no_leading_underscores_for_library_prefixes, no_leading_underscores_for_local_identifiers, non_constant_identifier_names, null_check_on_nullable_type_parameter, prefer_adjacent_string_concatenation, prefer_const_constructors, prefer_if_null_operators, prefer_interpolation_to_compose_strings, slash_for_doc_comments, sort_child_properties_last, unnecessary_const, unnecessary_constructor_name, unnecessary_late, unnecessary_new, unnecessary_null_aware_assignments, unnecessary_nullable_for_final_variable_declarations, unnecessary_string_interpolations, use_build_context_synchronously

import 'ModelProvider.dart';
import 'package:amplify_core/amplify_core.dart';
import 'package:flutter/foundation.dart';


/** This is an auto generated class representing the Comment type in your schema. */
@immutable
class Comment extends Model {
  static const classType = const _CommentModelType();
  final String id;
  final String? _content;
  final Post? _post;
  final TemporalDateTime? _createdAt;
  final TemporalDateTime? _updatedAt;

  @override
  getInstanceType() => classType;
  
  @Deprecated('[getId] is being deprecated in favor of custom primary key feature. Use getter [modelIdentifier] to get model identifier.')
  @override
  String getId() => id;
  
  CommentModelIdentifier get modelIdentifier {
      return CommentModelIdentifier(
        id: id
      );
  }
  
  String? get content {
    return _content;
  }
  
  Post? get post {
    return _post;
  }
  
  TemporalDateTime? get createdAt {
    return _createdAt;
  }
  
  TemporalDateTime? get updatedAt {
    return _updatedAt;
  }
  
  const Comment._internal({required this.id, content, post, createdAt, updatedAt}): _content = content, _post = post, _createdAt = createdAt, _updatedAt = updatedAt;
  
  factory Comment({String? id, String? content, Post? post}) {
    return Comment._internal(
      id: id == null ? UUID.getUUID() : id,
      content: content,
      post: post);
  }
  
  bool equals(Object other) {
    return this == other;
  }
  
  @override
  bool operator ==(Object other) {
    if (identical(other, this)) return true;
    return other is Comment &&
      id == other.id &&
      _content == other._content &&
      _post == other._post;
  }
  
  @override
  int get hashCode => toString().hashCode;
  
  @override
  String toString() {
    var buffer = new StringBuffer();
    
    buffer.write("Comment {");
    buffer.write("id=" + "$id" + ", ");
    buffer.write("content=" + "$_content" + ", ");
    buffer.write("post=" + (_post != null ? _post!.toString() : "null") + ", ");
    buffer.write("createdAt=" + (_createdAt != null ? _createdAt!.format() : "null") + ", ");
    buffer.write("updatedAt=" + (_updatedAt != null ? _updatedAt!.format() : "null"));
    buffer.write("}");
    
    return buffer.toString();
  }
  
  Comment copyWith({String? content, Post? post}) {
    return Comment._internal(
      id: id,
      content: content ?? this.content,
      post: post ?? this.post);
  }
  
  Comment.fromJson(Map<String, dynamic> json)  
    : id = json['id'],
      _content = json['content'],
      _post = json['post']?['serializedData'] != null
        ? Post.fromJson(new Map<String, dynamic>.from(json['post']['serializedData']))
        : null,
      _createdAt = json['createdAt'] != null ? TemporalDateTime.fromString(json['createdAt']) : null,
      _updatedAt = json['updatedAt'] != null ? TemporalDateTime.fromString(json['updatedAt']) : null;
  
  Map<String, dynamic> toJson() => {
    'id': id, 'content': _content, 'post': _post?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
  };
  
  Map<String, Object?> toMap() => {
    'id': id, 'content': _content, 'post': _post, 'createdAt': _createdAt, 'updatedAt': _updatedAt
  };

  static final QueryModelIdentifier<CommentModelIdentifier> MODEL_IDENTIFIER = QueryModelIdentifier<CommentModelIdentifier>();
  static final QueryField ID = QueryField(fieldName: "id");
  static final QueryField CONTENT = QueryField(fieldName: "content");
  static final QueryField POST = QueryField(
    fieldName: "post",
    fieldType: ModelFieldType(ModelFieldTypeEnum.model, ofModelName: 'Post'));
  static var schema = Model.defineSchema(define: (ModelSchemaDefinition modelSchemaDefinition) {
    modelSchemaDefinition.name = "Comment";
    modelSchemaDefinition.pluralName = "Comments";
    
    modelSchemaDefinition.authRules = [
      AuthRule(
        authStrategy: AuthStrategy.GROUPS,
        groupClaim: "cognito:groups",
        groups: [ "Admins" ],
        provider: AuthRuleProvider.USERPOOLS,
        operations: [
          ModelOperation.DELETE
        ]),
      AuthRule(
        authStrategy: AuthStrategy.OWNER,
        ownerField: "owner",
        identityClaim: "cognito:username",
        provider: AuthRuleProvider.USERPOOLS,
        operations: [
          ModelOperation.CREATE,
          ModelOperation.UPDATE,
          ModelOperation.DELETE,
          ModelOperation.READ
        ]),
      AuthRule(
        authStrategy: AuthStrategy.PUBLIC,
        operations: [
          ModelOperation.READ
        ])
    ];
    
    modelSchemaDefinition.addField(ModelFieldDefinition.id());
    
    modelSchemaDefinition.addField(ModelFieldDefinition.field(
      key: Comment.CONTENT,
      isRequired: false,
      ofType: ModelFieldType(ModelFieldTypeEnum.string)
    ));
    
    modelSchemaDefinition.addField(ModelFieldDefinition.belongsTo(
      key: Comment.POST,
      isRequired: false,
      targetNames: ['postCommentsId'],
      ofModelName: 'Post'
    ));
    
    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
      fieldName: 'createdAt',
      isRequired: false,
      isReadOnly: true,
      ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)
    ));
    
    modelSchemaDefinition.addField(ModelFieldDefinition.nonQueryField(
      fieldName: 'updatedAt',
      isRequired: false,
      isReadOnly: true,
      ofType: ModelFieldType(ModelFieldTypeEnum.dateTime)
    ));
  });
}

class _CommentModelType extends ModelType<Comment> {
  const _CommentModelType();
  
  @override
  Comment fromJson(Map<String, dynamic> jsonData) {
    return Comment.fromJson(jsonData);
  }
  
  @override
  String modelName() {
    return 'Comment';
  }
}

/**
 * This is an auto generated class representing the model identifier
 * of [Comment] in your schema.
 */
@immutable
class CommentModelIdentifier implements ModelIdentifier<Comment> {
  final String id;

  /** Create an instance of CommentModelIdentifier using [id] the primary key. */
  const CommentModelIdentifier({
    required this.id});
  
  @override
  Map<String, dynamic> serializeAsMap() => (<String, dynamic>{
    'id': id
  });
  
  @override
  List<Map<String, dynamic>> serializeAsList() => serializeAsMap()
    .entries
    .map((entry) => (<String, dynamic>{ entry.key: entry.value }))
    .toList();
  
  @override
  String serializeAsString() => serializeAsMap().values.join('#');
  
  @override
  String toString() => 'CommentModelIdentifier(id: $id)';
  
  @override
  bool operator ==(Object other) {
    if (identical(this, other)) {
      return true;
    }
    
    return other is CommentModelIdentifier &&
      id == other.id;
  }
  
  @override
  int get hashCode =>
    id.hashCode;
}
```

![스크린샷 2023-04-21 오후 10 10 51](https://user-images.githubusercontent.com/1964421/233644612-790df5c1-0bdb-4af5-8d06-1a3200e9a6f8.png)
![스크린샷 2023-04-21 오후 10 11 52](https://user-images.githubusercontent.com/1964421/233644616-21f6546d-64fc-40ae-85e2-54ebca399eb4.png)



#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.