### PR TITLE
fix(codegen): generate default name for index directive

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -132,6 +132,68 @@ describe('processIndex', () => {
     ]);
   });
 
+  it('should generate a default name to @index directive', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {},
+            },
+          ],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherConnection',
+          directives: [
+            {
+              name: 'index',
+              arguments: {},
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'testModelsByConnectionField',
+          fields: ['connectionField'],
+          queryField: undefined,
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'testModelsByAnotherConnection',
+          fields: ['anotherConnection'],
+          queryField: undefined,
+        },
+      },
+    ]);
+  });
+
   it('does nothing if no @index directives in model', () => {
     const model: CodeGenModel = {
       directives: [

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -194,6 +194,72 @@ describe('processIndex', () => {
     ]);
   });
 
+  it('should generate a default name to @index directive with sortkeys', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                sortKeyFields: ['sortField'],
+              },
+            },
+          ],
+        },
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'anotherConnection',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                sortKeyFields: ['sortField1', 'sortField2'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'testModelsByConnectionFieldAndSortField',
+          fields: ['connectionField', 'sortField'],
+          queryField: undefined, 
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'testModelsByAnotherConnectionAndSortField1AndSortField2',
+          fields: ['anotherConnection', 'sortField1', 'sortField2'],
+          queryField: undefined,
+        },
+      },
+    ]);
+  });
+
   it('does nothing if no @index directives in model', () => {
     const model: CodeGenModel = {
       directives: [

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -34,7 +34,7 @@ export const processIndex = (model: CodeGenModel) => {
 /*
  * Accepts a model and field name, and potentially empty list of sortKeyFields to generate a unique index name.
  * e.g. modelName = Employee, fieldName = manager, sortKeyFields = [level]
- * will generate a name like employeeByManagerAndLevel.
+ * will generate a name like employeesByManagerAndLevel.
  * (This naming logic is used to generate a default index name for @index directives that don't have a name argument).
  * Refer https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-index-transformer/src/utils.ts
  */

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -1,5 +1,7 @@
 import { CodeGenDirective, CodeGenModel } from '../visitors/appsync-visitor';
 import { getDirective } from './fieldUtils';
+import pluralize from 'pluralize';
+import { toLower, toUpper } from './stringUtils';
 
 /**
  * Maps @index directives back to how they would be represented with the old @key directive
@@ -17,7 +19,7 @@ export const processIndex = (model: CodeGenModel) => {
   const keyList: CodeGenDirective[] = Object.entries(indexMap).map(([fieldName, directive]) => ({
     name: 'key',
     arguments: {
-      name: directive.arguments.name,
+      name: directive.arguments.name ?? generateDefaultIndexName(model.name, [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? [])),
       queryField: directive.arguments.queryField,
       fields: [fieldName].concat((directive.arguments.sortKeyFields as string[]) ?? []),
     },
@@ -27,4 +29,15 @@ export const processIndex = (model: CodeGenModel) => {
     .map(directive => directive.arguments.name);
   const deDupedKeyList = keyList.filter(key => !existingIndexNames.includes(key.arguments.name));
   model.directives.push(...deDupedKeyList);
+};
+
+/*
+ * Accepts a model and field name, and potentially empty list of sortKeyFields to generate a unique index name.
+ * e.g. modelName = Employee, fieldName = manager, sortKeyFields = [level]
+ * will generate a name like employeeByManagerAndLevel.
+ * 
+ * This naming logic is used to generate a default index name for @index directives that don't have a name argument.
+ */
+export const generateDefaultIndexName = (modelName: string, fieldNames: string[]): string => {
+  return `${toLower(pluralize(modelName))}By${fieldNames.map(toUpper).join('And')}`;
 };

--- a/packages/appsync-modelgen-plugin/src/utils/process-index.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-index.ts
@@ -35,8 +35,8 @@ export const processIndex = (model: CodeGenModel) => {
  * Accepts a model and field name, and potentially empty list of sortKeyFields to generate a unique index name.
  * e.g. modelName = Employee, fieldName = manager, sortKeyFields = [level]
  * will generate a name like employeeByManagerAndLevel.
- * 
- * This naming logic is used to generate a default index name for @index directives that don't have a name argument.
+ * (This naming logic is used to generate a default index name for @index directives that don't have a name argument).
+ * Refer https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-index-transformer/src/utils.ts
  */
 export const generateDefaultIndexName = (modelName: string, fieldNames: string[]): string => {
   return `${toLower(pluralize(modelName))}By${fieldNames.map(toUpper).join('And')}`;

--- a/packages/appsync-modelgen-plugin/src/utils/stringUtils.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/stringUtils.ts
@@ -1,0 +1,7 @@
+export function toUpper(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+export function toLower(word: string): string {
+  return word.charAt(0).toLowerCase() + word.slice(1);
+}


### PR DESCRIPTION
#### Description of changes
Assigns a default name to index directive if source schema doesn't have one.
- This change helps codegen to detect the sortkey fields of PK correctly as codegen considers key directive without a name as PK.

#### Issue #, if available
Fixes https://github.com/aws-amplify/amplify-category-api/issues/1432

#### Description of how you validated changes
- Manual test
- New Unit test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.