### PR TITLE
fix: codegen downgrade to version 3

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-codegen",
-  "version": "4.0.0",
+  "version": "3.4.3",
   "description": "amplify code generator",
   "repository": {
     "type": "git",

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -63,9 +63,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       const generatedOps = generateGraphQLDocuments(schemaData, {
         maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
         useExternalFragmentForS3Object: (language === 'graphql'),
-        // default typenameIntrospection to true when not set
-        typenameIntrospection:
-          cfg.amplifyExtension.typenameIntrospection === undefined ? true : !!cfg.amplifyExtension.typenameIntrospection,
       });
       if(!generatedOps) {
         context.print.warning('No GraphQL statements are generated. Check if the introspection schema has GraphQL operations defined.');

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -97,7 +97,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload,
+      forceDownload
     );
   });
 
@@ -110,7 +110,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload,
+      forceDownload
     );
   });
 

--- a/packages/graphql-docs-generator/API.md
+++ b/packages/graphql-docs-generator/API.md
@@ -15,7 +15,6 @@ export function buildSchema(schema: string): GraphQLSchema;
 export function generateGraphQLDocuments(schema: string, options: {
     maxDepth?: number;
     useExternalFragmentForS3Object?: boolean;
-    typenameIntrospection?: boolean;
 }): GeneratedOperations;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -39,28 +39,38 @@ query Hero
     }
       }
       friendsConnection {
-        totalCount
+        
+    totalCount
+        
       }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
-    friendsConnection {
-      totalCount
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
       edges {
-        cursor
+        
+    cursor
+        
       }
       friends {
         
@@ -80,11 +90,14 @@ query Hero
     }
       }
       pageInfo {
-        startCursor
-        endCursor
-        hasNextPage
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
       }
-    }
+        
+      }
     appearsIn
     
     ...on Human {
@@ -93,10 +106,12 @@ query Hero
     height
     mass
       starships {
-        id
-        name
-        length
-        coordinates
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
     ...on Droid {
@@ -148,70 +163,94 @@ query Search
     height
     mass
       friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
+        
+    id
+    name
+      friends {
+        
+    id
+    name
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
       }
       friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
+        
+    totalCount
+        
+      }
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
+      }
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
+      edges {
+        
+    cursor
+        
+      }
+      friends {
+        
+    id
+    name
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      pageInfo {
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
+      }
+        
       }
     appearsIn
       starships {
-        id
-        name
-        length
-        coordinates
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
     ...on Droid {
@@ -219,63 +258,85 @@ query Search
     id
     name
       friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
+        
+    id
+    name
+      friends {
+        
+    id
+    name
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
       }
       friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
+        
+    totalCount
+        
+      }
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
+      }
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
+      edges {
+        
+    cursor
+        
+      }
+      friends {
+        
+    id
+    name
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+    }
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      pageInfo {
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
+      }
+        
       }
     appearsIn
     primaryFunction
@@ -327,28 +388,38 @@ query Character
     }
       }
       friendsConnection {
-        totalCount
+        
+    totalCount
+        
       }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
-    friendsConnection {
-      totalCount
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
       edges {
-        cursor
+        
+    cursor
+        
       }
       friends {
         
@@ -368,11 +439,14 @@ query Character
     }
       }
       pageInfo {
-        startCursor
-        endCursor
-        hasNextPage
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
       }
-    }
+        
+      }
     appearsIn
     
     ...on Human {
@@ -381,10 +455,12 @@ query Character
     height
     mass
       starships {
-        id
-        name
-        length
-        coordinates
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
     ...on Droid {
@@ -431,28 +507,38 @@ query Droid
     }
       }
       friendsConnection {
-        totalCount
+        
+    totalCount
+        
       }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
-    friendsConnection {
-      totalCount
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
       edges {
-        cursor
+        
+    cursor
+        
       }
       friends {
         
@@ -472,11 +558,14 @@ query Droid
     }
       }
       pageInfo {
-        startCursor
-        endCursor
-        hasNextPage
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
       }
-    }
+        
+      }
     appearsIn
     primaryFunction
     
@@ -523,28 +612,38 @@ query Human
     }
       }
       friendsConnection {
-        totalCount
+        
+    totalCount
+        
       }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
+    appearsIn
+        
+    ...on Human {
+      
+    homePlanet
+    height
+    mass
+      starships {
+        
+    id
+    name
+    length
+    coordinates
+        
       }
     }
-    friendsConnection {
-      totalCount
+    ...on Droid {
+      
+    primaryFunction
+    }
+      }
+      friendsConnection {
+        
+    totalCount
       edges {
-        cursor
+        
+    cursor
+        
       }
       friends {
         
@@ -564,43 +663,49 @@ query Human
     }
       }
       pageInfo {
-        startCursor
-        endCursor
-        hasNextPage
+        
+    startCursor
+    endCursor
+    hasNextPage
+        
       }
-    }
+        
+      }
     appearsIn
-    starships {
-      id
-      name
-      length
-      coordinates
-    }
-  }
-}
-query Starship($id: ID!) {
-  starship(id: $id) {
+      starships {
+        
     id
     name
     length
     coordinates
+        
+      }
+    
   }
 }
-mutation CreateReview($episode: Episode, $review: ReviewInput!) {
-  createReview(episode: $episode, review: $review) {
-    episode
-    stars
-    commentary
+",
+  "starship" => "
+query Starship 
+  (
+      $id:ID!
+  )
+{
+  starship
+  (
+      id:$id
+  )
+ 
+   {
+    
+    id
+    name
+    length
+    coordinates
+    
   }
 }
-subscription ReviewAdded($episode: Episode) {
-  reviewAdded(episode: $episode) {
-    episode
-    stars
-    commentary
-  }
+",
 }
-"
 `;
 
 exports[`GraphQL documents generation tests for introspection schema input should generate GraphQL documents for schema 2`] = `
@@ -655,1519 +760,6 @@ subscription ReviewAdded
 }
 `;
 
-exports[`end 2 end tests should generate statements in JS 1`] = `
-"/* eslint-disable */
-// this is an auto generated file. This will be overwritten
-
-export const hero = /* GraphQL */ \`
-  query Hero($episode: Episode) {
-    hero(episode: $episode) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const reviews = /* GraphQL */ \`
-  query Reviews($episode: Episode!) {
-    reviews(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const search = /* GraphQL */ \`
-  query Search($text: String) {
-    search(text: $text) {
-      ... on Human {
-        id
-        name
-        homePlanet
-        height
-        mass
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        id
-        name
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        primaryFunction
-      }
-      ... on Starship {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const character = /* GraphQL */ \`
-  query Character($id: ID!) {
-    character(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const droid = /* GraphQL */ \`
-  query Droid($id: ID!) {
-    droid(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      primaryFunction
-    }
-  }
-\`;
-export const human = /* GraphQL */ \`
-  query Human($id: ID!) {
-    human(id: $id) {
-      id
-      name
-      homePlanet
-      height
-      mass
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      starships {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const starship = /* GraphQL */ \`
-  query Starship($id: ID!) {
-    starship(id: $id) {
-      id
-      name
-      length
-      coordinates
-    }
-  }
-\`;
-export const createReview = /* GraphQL */ \`
-  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
-    createReview(episode: $episode, review: $review) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const reviewAdded = /* GraphQL */ \`
-  subscription ReviewAdded($episode: Episode) {
-    reviewAdded(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-"
-`;
-
-exports[`end 2 end tests should generate statements in Typescript 1`] = `
-"/* tslint:disable */
-/* eslint-disable */
-// this is an auto generated file. This will be overwritten
-
-export const hero = /* GraphQL */ \`
-  query Hero($episode: Episode) {
-    hero(episode: $episode) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const reviews = /* GraphQL */ \`
-  query Reviews($episode: Episode!) {
-    reviews(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const search = /* GraphQL */ \`
-  query Search($text: String) {
-    search(text: $text) {
-      ... on Human {
-        id
-        name
-        homePlanet
-        height
-        mass
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        id
-        name
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        primaryFunction
-      }
-      ... on Starship {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const character = /* GraphQL */ \`
-  query Character($id: ID!) {
-    character(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const droid = /* GraphQL */ \`
-  query Droid($id: ID!) {
-    droid(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      primaryFunction
-    }
-  }
-\`;
-export const human = /* GraphQL */ \`
-  query Human($id: ID!) {
-    human(id: $id) {
-      id
-      name
-      homePlanet
-      height
-      mass
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      starships {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const starship = /* GraphQL */ \`
-  query Starship($id: ID!) {
-    starship(id: $id) {
-      id
-      name
-      length
-      coordinates
-    }
-  }
-\`;
-export const createReview = /* GraphQL */ \`
-  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
-    createReview(episode: $episode, review: $review) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const reviewAdded = /* GraphQL */ \`
-  subscription ReviewAdded($episode: Episode) {
-    reviewAdded(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-"
-`;
-
-exports[`end 2 end tests should generate statements in flow 1`] = `
-"// @flow
-// this is an auto generated file. This will be overwritten
-
-export const hero = /* GraphQL */ \`
-  query Hero($episode: Episode) {
-    hero(episode: $episode) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const reviews = /* GraphQL */ \`
-  query Reviews($episode: Episode!) {
-    reviews(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const search = /* GraphQL */ \`
-  query Search($text: String) {
-    search(text: $text) {
-      ... on Human {
-        id
-        name
-        homePlanet
-        height
-        mass
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        id
-        name
-        friends {
-          id
-          name
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          friendsConnection {
-            totalCount
-          }
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-            starships {
-              id
-              name
-              length
-              coordinates
-            }
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-          edges {
-            cursor
-          }
-          friends {
-            id
-            name
-            appearsIn
-            ... on Human {
-              homePlanet
-              height
-              mass
-            }
-            ... on Droid {
-              primaryFunction
-            }
-          }
-          pageInfo {
-            startCursor
-            endCursor
-            hasNextPage
-          }
-        }
-        appearsIn
-        primaryFunction
-      }
-      ... on Starship {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const character = /* GraphQL */ \`
-  query Character($id: ID!) {
-    character(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      ... on Human {
-        homePlanet
-        height
-        mass
-        starships {
-          id
-          name
-          length
-          coordinates
-        }
-      }
-      ... on Droid {
-        primaryFunction
-      }
-    }
-  }
-\`;
-export const droid = /* GraphQL */ \`
-  query Droid($id: ID!) {
-    droid(id: $id) {
-      id
-      name
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      primaryFunction
-    }
-  }
-\`;
-export const human = /* GraphQL */ \`
-  query Human($id: ID!) {
-    human(id: $id) {
-      id
-      name
-      homePlanet
-      height
-      mass
-      friends {
-        id
-        name
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        friendsConnection {
-          totalCount
-        }
-        appearsIn
-        ... on Human {
-          homePlanet
-          height
-          mass
-          starships {
-            id
-            name
-            length
-            coordinates
-          }
-        }
-        ... on Droid {
-          primaryFunction
-        }
-      }
-      friendsConnection {
-        totalCount
-        edges {
-          cursor
-        }
-        friends {
-          id
-          name
-          appearsIn
-          ... on Human {
-            homePlanet
-            height
-            mass
-          }
-          ... on Droid {
-            primaryFunction
-          }
-        }
-        pageInfo {
-          startCursor
-          endCursor
-          hasNextPage
-        }
-      }
-      appearsIn
-      starships {
-        id
-        name
-        length
-        coordinates
-      }
-    }
-  }
-\`;
-export const starship = /* GraphQL */ \`
-  query Starship($id: ID!) {
-    starship(id: $id) {
-      id
-      name
-      length
-      coordinates
-    }
-  }
-\`;
-export const createReview = /* GraphQL */ \`
-  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
-    createReview(episode: $episode, review: $review) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-export const reviewAdded = /* GraphQL */ \`
-  subscription ReviewAdded($episode: Episode) {
-    reviewAdded(episode: $episode) {
-      episode
-      stars
-      commentary
-    }
-  }
-\`;
-"
-`;
-
 exports[`end 2 end tests to test if the case style is retained for type names should generate statements 1`] = `
 Map {
   "getUPPERCASE" => "
@@ -2190,18 +782,32 @@ query GetUPPERCASE
     
   }
 }
-query ListUPPERCASEs(
-  $filter: ModelUPPERCASEFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listUPPERCASEs" => "
+query ListUPPERCASEs 
+  (
+      $filter:ModelUPPERCASEFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listUPPERCASEs
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
@@ -2227,18 +833,32 @@ query GetLowercase
     
   }
 }
-query ListLowercases(
-  $filter: ModellowercaseFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listLowercases" => "
+query ListLowercases 
+  (
+      $filter:ModellowercaseFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listLowercases
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
@@ -2264,18 +884,32 @@ query GetCamelCase
     
   }
 }
-query ListCamelCases(
-  $filter: ModelcamelCaseFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listCamelCases" => "
+query ListCamelCases 
+  (
+      $filter:ModelcamelCaseFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listCamelCases
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
@@ -2301,18 +935,32 @@ query GetPascalCase
     
   }
 }
-query ListPascalCases(
-  $filter: ModelPascalCaseFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listPascalCases" => "
+query ListPascalCases 
+  (
+      $filter:ModelPascalCaseFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listPascalCases
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
@@ -2338,18 +986,32 @@ query GetSnake_case
     
   }
 }
-query ListSnake_cases(
-  $filter: Modelsnake_caseFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listSnake_cases" => "
+query ListSnake_cases 
+  (
+      $filter:Modelsnake_caseFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listSnake_cases
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
@@ -2375,391 +1037,72 @@ query GetUPPER_SNAKE_CASE
     
   }
 }
-query ListUPPER_SNAKE_CASEs(
-  $filter: ModelUPPER_SNAKE_CASEFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  listUPPER_SNAKE_CASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "listUPPER_SNAKE_CASEs" => "
+query ListUPPER_SNAKE_CASEs 
+  (
+      $filter:ModelUPPER_SNAKE_CASEFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  listUPPER_SNAKE_CASEs
+  (
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
 }
-query QueryByOwner(
-  $owner: String
-  $sortDirection: ModelSortDirection
-  $filter: ModelUPPERCASEFilterInput
-  $limit: Int
-  $nextToken: String
-) {
-  queryByOwner(
-    owner: $owner
-    sortDirection: $sortDirection
-    filter: $filter
-    limit: $limit
-    nextToken: $nextToken
-  ) {
-    items {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
+",
+  "queryByOwner" => "
+query QueryByOwner 
+  (
+      $owner:String,
+      $sortDirection:ModelSortDirection,
+      $filter:ModelUPPERCASEFilterInput,
+      $limit:Int,
+      $nextToken:String
+  )
+{
+  queryByOwner
+  (
+      owner:$owner,
+      sortDirection:$sortDirection,
+      filter:$filter,
+      limit:$limit,
+      nextToken:$nextToken
+  )
+ 
+   {
+    
+      items {
+        
+    id
+    owner
+    createdAt
+    updatedAt
+        
+      }
     nextToken
     
   }
 }
 ",
 }
-mutation CreateUPPERCASE(
-  $input: CreateUPPERCASEInput!
-  $condition: ModelUPPERCASEConditionInput
-) {
-  createUPPERCASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdateUPPERCASE(
-  $input: UpdateUPPERCASEInput!
-  $condition: ModelUPPERCASEConditionInput
-) {
-  updateUPPERCASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeleteUPPERCASE(
-  $input: DeleteUPPERCASEInput!
-  $condition: ModelUPPERCASEConditionInput
-) {
-  deleteUPPERCASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation CreateLowercase(
-  $input: CreateLowercaseInput!
-  $condition: ModellowercaseConditionInput
-) {
-  createLowercase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdateLowercase(
-  $input: UpdateLowercaseInput!
-  $condition: ModellowercaseConditionInput
-) {
-  updateLowercase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeleteLowercase(
-  $input: DeleteLowercaseInput!
-  $condition: ModellowercaseConditionInput
-) {
-  deleteLowercase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation CreateCamelCase(
-  $input: CreateCamelCaseInput!
-  $condition: ModelcamelCaseConditionInput
-) {
-  createCamelCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdateCamelCase(
-  $input: UpdateCamelCaseInput!
-  $condition: ModelcamelCaseConditionInput
-) {
-  updateCamelCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeleteCamelCase(
-  $input: DeleteCamelCaseInput!
-  $condition: ModelcamelCaseConditionInput
-) {
-  deleteCamelCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation CreatePascalCase(
-  $input: CreatePascalCaseInput!
-  $condition: ModelPascalCaseConditionInput
-) {
-  createPascalCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdatePascalCase(
-  $input: UpdatePascalCaseInput!
-  $condition: ModelPascalCaseConditionInput
-) {
-  updatePascalCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeletePascalCase(
-  $input: DeletePascalCaseInput!
-  $condition: ModelPascalCaseConditionInput
-) {
-  deletePascalCase(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation CreateSnake_case(
-  $input: CreateSnake_caseInput!
-  $condition: Modelsnake_caseConditionInput
-) {
-  createSnake_case(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdateSnake_case(
-  $input: UpdateSnake_caseInput!
-  $condition: Modelsnake_caseConditionInput
-) {
-  updateSnake_case(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeleteSnake_case(
-  $input: DeleteSnake_caseInput!
-  $condition: Modelsnake_caseConditionInput
-) {
-  deleteSnake_case(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation CreateUPPER_SNAKE_CASE(
-  $input: CreateUPPER_SNAKE_CASEInput!
-  $condition: ModelUPPER_SNAKE_CASEConditionInput
-) {
-  createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation UpdateUPPER_SNAKE_CASE(
-  $input: UpdateUPPER_SNAKE_CASEInput!
-  $condition: ModelUPPER_SNAKE_CASEConditionInput
-) {
-  updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-mutation DeleteUPPER_SNAKE_CASE(
-  $input: DeleteUPPER_SNAKE_CASEInput!
-  $condition: ModelUPPER_SNAKE_CASEConditionInput
-) {
-  deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreateUPPERCASE {
-  onCreateUPPERCASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdateUPPERCASE {
-  onUpdateUPPERCASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeleteUPPERCASE {
-  onDeleteUPPERCASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreateLowercase {
-  onCreateLowercase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdateLowercase {
-  onUpdateLowercase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeleteLowercase {
-  onDeleteLowercase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreateCamelCase {
-  onCreateCamelCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdateCamelCase {
-  onUpdateCamelCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeleteCamelCase {
-  onDeleteCamelCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreatePascalCase {
-  onCreatePascalCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdatePascalCase {
-  onUpdatePascalCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeletePascalCase {
-  onDeletePascalCase {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreateSnake_case {
-  onCreateSnake_case {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdateSnake_case {
-  onUpdateSnake_case {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeleteSnake_case {
-  onDeleteSnake_case {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnCreateUPPER_SNAKE_CASE {
-  onCreateUPPER_SNAKE_CASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnUpdateUPPER_SNAKE_CASE {
-  onUpdateUPPER_SNAKE_CASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-subscription OnDeleteUPPER_SNAKE_CASE {
-  onDeleteUPPER_SNAKE_CASE {
-    id
-    owner
-    createdAt
-    updatedAt
-  }
-}
-"
 `;
 
 exports[`end 2 end tests to test if the case style is retained for type names should generate statements 2`] = `
@@ -3454,1841 +1797,4 @@ subscription OnDeleteUPPER_SNAKE_CASE
 }
 ",
 }
-`;
-
-exports[`end 2 end tests to test if the case style is retained for type names should generate statements in JS 1`] = `
-"/* eslint-disable */
-// this is an auto generated file. This will be overwritten
-
-export const getUPPERCASE = /* GraphQL */ \`
-  query GetUPPERCASE($id: ID!) {
-    getUPPERCASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPERCASEs = /* GraphQL */ \`
-  query ListUPPERCASEs(
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getLowercase = /* GraphQL */ \`
-  query GetLowercase($id: ID!) {
-    getLowercase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listLowercases = /* GraphQL */ \`
-  query ListLowercases(
-    $filter: ModellowercaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getCamelCase = /* GraphQL */ \`
-  query GetCamelCase($id: ID!) {
-    getCamelCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listCamelCases = /* GraphQL */ \`
-  query ListCamelCases(
-    $filter: ModelcamelCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getPascalCase = /* GraphQL */ \`
-  query GetPascalCase($id: ID!) {
-    getPascalCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listPascalCases = /* GraphQL */ \`
-  query ListPascalCases(
-    $filter: ModelPascalCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getSnake_case = /* GraphQL */ \`
-  query GetSnake_case($id: ID!) {
-    getSnake_case(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listSnake_cases = /* GraphQL */ \`
-  query ListSnake_cases(
-    $filter: Modelsnake_caseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
-  query GetUPPER_SNAKE_CASE($id: ID!) {
-    getUPPER_SNAKE_CASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
-  query ListUPPER_SNAKE_CASEs(
-    $filter: ModelUPPER_SNAKE_CASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPER_SNAKE_CASEs(
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const queryByOwner = /* GraphQL */ \`
-  query QueryByOwner(
-    $owner: String
-    $sortDirection: ModelSortDirection
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    queryByOwner(
-      owner: $owner
-      sortDirection: $sortDirection
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const createUPPERCASE = /* GraphQL */ \`
-  mutation CreateUPPERCASE(
-    $input: CreateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    createUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPERCASE = /* GraphQL */ \`
-  mutation UpdateUPPERCASE(
-    $input: UpdateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    updateUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPERCASE = /* GraphQL */ \`
-  mutation DeleteUPPERCASE(
-    $input: DeleteUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    deleteUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createLowercase = /* GraphQL */ \`
-  mutation CreateLowercase(
-    $input: CreateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    createLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateLowercase = /* GraphQL */ \`
-  mutation UpdateLowercase(
-    $input: UpdateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    updateLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteLowercase = /* GraphQL */ \`
-  mutation DeleteLowercase(
-    $input: DeleteLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    deleteLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createCamelCase = /* GraphQL */ \`
-  mutation CreateCamelCase(
-    $input: CreateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    createCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateCamelCase = /* GraphQL */ \`
-  mutation UpdateCamelCase(
-    $input: UpdateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    updateCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteCamelCase = /* GraphQL */ \`
-  mutation DeleteCamelCase(
-    $input: DeleteCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    deleteCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createPascalCase = /* GraphQL */ \`
-  mutation CreatePascalCase(
-    $input: CreatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    createPascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updatePascalCase = /* GraphQL */ \`
-  mutation UpdatePascalCase(
-    $input: UpdatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    updatePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deletePascalCase = /* GraphQL */ \`
-  mutation DeletePascalCase(
-    $input: DeletePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    deletePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createSnake_case = /* GraphQL */ \`
-  mutation CreateSnake_case(
-    $input: CreateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    createSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateSnake_case = /* GraphQL */ \`
-  mutation UpdateSnake_case(
-    $input: UpdateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    updateSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteSnake_case = /* GraphQL */ \`
-  mutation DeleteSnake_case(
-    $input: DeleteSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    deleteSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation CreateUPPER_SNAKE_CASE(
-    $input: CreateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation UpdateUPPER_SNAKE_CASE(
-    $input: UpdateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation DeleteUPPER_SNAKE_CASE(
-    $input: DeleteUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPERCASE = /* GraphQL */ \`
-  subscription OnCreateUPPERCASE {
-    onCreateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPERCASE = /* GraphQL */ \`
-  subscription OnUpdateUPPERCASE {
-    onUpdateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPERCASE = /* GraphQL */ \`
-  subscription OnDeleteUPPERCASE {
-    onDeleteUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateLowercase = /* GraphQL */ \`
-  subscription OnCreateLowercase {
-    onCreateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateLowercase = /* GraphQL */ \`
-  subscription OnUpdateLowercase {
-    onUpdateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteLowercase = /* GraphQL */ \`
-  subscription OnDeleteLowercase {
-    onDeleteLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateCamelCase = /* GraphQL */ \`
-  subscription OnCreateCamelCase {
-    onCreateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateCamelCase = /* GraphQL */ \`
-  subscription OnUpdateCamelCase {
-    onUpdateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteCamelCase = /* GraphQL */ \`
-  subscription OnDeleteCamelCase {
-    onDeleteCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreatePascalCase = /* GraphQL */ \`
-  subscription OnCreatePascalCase {
-    onCreatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdatePascalCase = /* GraphQL */ \`
-  subscription OnUpdatePascalCase {
-    onUpdatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeletePascalCase = /* GraphQL */ \`
-  subscription OnDeletePascalCase {
-    onDeletePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateSnake_case = /* GraphQL */ \`
-  subscription OnCreateSnake_case {
-    onCreateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateSnake_case = /* GraphQL */ \`
-  subscription OnUpdateSnake_case {
-    onUpdateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteSnake_case = /* GraphQL */ \`
-  subscription OnDeleteSnake_case {
-    onDeleteSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnCreateUPPER_SNAKE_CASE {
-    onCreateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnUpdateUPPER_SNAKE_CASE {
-    onUpdateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnDeleteUPPER_SNAKE_CASE {
-    onDeleteUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-"
-`;
-
-exports[`end 2 end tests to test if the case style is retained for type names should generate statements in Typescript 1`] = `
-"/* tslint:disable */
-/* eslint-disable */
-// this is an auto generated file. This will be overwritten
-
-export const getUPPERCASE = /* GraphQL */ \`
-  query GetUPPERCASE($id: ID!) {
-    getUPPERCASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPERCASEs = /* GraphQL */ \`
-  query ListUPPERCASEs(
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getLowercase = /* GraphQL */ \`
-  query GetLowercase($id: ID!) {
-    getLowercase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listLowercases = /* GraphQL */ \`
-  query ListLowercases(
-    $filter: ModellowercaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getCamelCase = /* GraphQL */ \`
-  query GetCamelCase($id: ID!) {
-    getCamelCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listCamelCases = /* GraphQL */ \`
-  query ListCamelCases(
-    $filter: ModelcamelCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getPascalCase = /* GraphQL */ \`
-  query GetPascalCase($id: ID!) {
-    getPascalCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listPascalCases = /* GraphQL */ \`
-  query ListPascalCases(
-    $filter: ModelPascalCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getSnake_case = /* GraphQL */ \`
-  query GetSnake_case($id: ID!) {
-    getSnake_case(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listSnake_cases = /* GraphQL */ \`
-  query ListSnake_cases(
-    $filter: Modelsnake_caseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
-  query GetUPPER_SNAKE_CASE($id: ID!) {
-    getUPPER_SNAKE_CASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
-  query ListUPPER_SNAKE_CASEs(
-    $filter: ModelUPPER_SNAKE_CASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPER_SNAKE_CASEs(
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const queryByOwner = /* GraphQL */ \`
-  query QueryByOwner(
-    $owner: String
-    $sortDirection: ModelSortDirection
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    queryByOwner(
-      owner: $owner
-      sortDirection: $sortDirection
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const createUPPERCASE = /* GraphQL */ \`
-  mutation CreateUPPERCASE(
-    $input: CreateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    createUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPERCASE = /* GraphQL */ \`
-  mutation UpdateUPPERCASE(
-    $input: UpdateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    updateUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPERCASE = /* GraphQL */ \`
-  mutation DeleteUPPERCASE(
-    $input: DeleteUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    deleteUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createLowercase = /* GraphQL */ \`
-  mutation CreateLowercase(
-    $input: CreateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    createLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateLowercase = /* GraphQL */ \`
-  mutation UpdateLowercase(
-    $input: UpdateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    updateLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteLowercase = /* GraphQL */ \`
-  mutation DeleteLowercase(
-    $input: DeleteLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    deleteLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createCamelCase = /* GraphQL */ \`
-  mutation CreateCamelCase(
-    $input: CreateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    createCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateCamelCase = /* GraphQL */ \`
-  mutation UpdateCamelCase(
-    $input: UpdateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    updateCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteCamelCase = /* GraphQL */ \`
-  mutation DeleteCamelCase(
-    $input: DeleteCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    deleteCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createPascalCase = /* GraphQL */ \`
-  mutation CreatePascalCase(
-    $input: CreatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    createPascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updatePascalCase = /* GraphQL */ \`
-  mutation UpdatePascalCase(
-    $input: UpdatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    updatePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deletePascalCase = /* GraphQL */ \`
-  mutation DeletePascalCase(
-    $input: DeletePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    deletePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createSnake_case = /* GraphQL */ \`
-  mutation CreateSnake_case(
-    $input: CreateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    createSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateSnake_case = /* GraphQL */ \`
-  mutation UpdateSnake_case(
-    $input: UpdateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    updateSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteSnake_case = /* GraphQL */ \`
-  mutation DeleteSnake_case(
-    $input: DeleteSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    deleteSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation CreateUPPER_SNAKE_CASE(
-    $input: CreateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation UpdateUPPER_SNAKE_CASE(
-    $input: UpdateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation DeleteUPPER_SNAKE_CASE(
-    $input: DeleteUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPERCASE = /* GraphQL */ \`
-  subscription OnCreateUPPERCASE {
-    onCreateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPERCASE = /* GraphQL */ \`
-  subscription OnUpdateUPPERCASE {
-    onUpdateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPERCASE = /* GraphQL */ \`
-  subscription OnDeleteUPPERCASE {
-    onDeleteUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateLowercase = /* GraphQL */ \`
-  subscription OnCreateLowercase {
-    onCreateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateLowercase = /* GraphQL */ \`
-  subscription OnUpdateLowercase {
-    onUpdateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteLowercase = /* GraphQL */ \`
-  subscription OnDeleteLowercase {
-    onDeleteLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateCamelCase = /* GraphQL */ \`
-  subscription OnCreateCamelCase {
-    onCreateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateCamelCase = /* GraphQL */ \`
-  subscription OnUpdateCamelCase {
-    onUpdateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteCamelCase = /* GraphQL */ \`
-  subscription OnDeleteCamelCase {
-    onDeleteCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreatePascalCase = /* GraphQL */ \`
-  subscription OnCreatePascalCase {
-    onCreatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdatePascalCase = /* GraphQL */ \`
-  subscription OnUpdatePascalCase {
-    onUpdatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeletePascalCase = /* GraphQL */ \`
-  subscription OnDeletePascalCase {
-    onDeletePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateSnake_case = /* GraphQL */ \`
-  subscription OnCreateSnake_case {
-    onCreateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateSnake_case = /* GraphQL */ \`
-  subscription OnUpdateSnake_case {
-    onUpdateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteSnake_case = /* GraphQL */ \`
-  subscription OnDeleteSnake_case {
-    onDeleteSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnCreateUPPER_SNAKE_CASE {
-    onCreateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnUpdateUPPER_SNAKE_CASE {
-    onUpdateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnDeleteUPPER_SNAKE_CASE {
-    onDeleteUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-"
-`;
-
-exports[`end 2 end tests to test if the case style is retained for type names should generate statements in flow 1`] = `
-"// @flow
-// this is an auto generated file. This will be overwritten
-
-export const getUPPERCASE = /* GraphQL */ \`
-  query GetUPPERCASE($id: ID!) {
-    getUPPERCASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPERCASEs = /* GraphQL */ \`
-  query ListUPPERCASEs(
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getLowercase = /* GraphQL */ \`
-  query GetLowercase($id: ID!) {
-    getLowercase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listLowercases = /* GraphQL */ \`
-  query ListLowercases(
-    $filter: ModellowercaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getCamelCase = /* GraphQL */ \`
-  query GetCamelCase($id: ID!) {
-    getCamelCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listCamelCases = /* GraphQL */ \`
-  query ListCamelCases(
-    $filter: ModelcamelCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getPascalCase = /* GraphQL */ \`
-  query GetPascalCase($id: ID!) {
-    getPascalCase(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listPascalCases = /* GraphQL */ \`
-  query ListPascalCases(
-    $filter: ModelPascalCaseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getSnake_case = /* GraphQL */ \`
-  query GetSnake_case($id: ID!) {
-    getSnake_case(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listSnake_cases = /* GraphQL */ \`
-  query ListSnake_cases(
-    $filter: Modelsnake_caseFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
-  query GetUPPER_SNAKE_CASE($id: ID!) {
-    getUPPER_SNAKE_CASE(id: $id) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
-  query ListUPPER_SNAKE_CASEs(
-    $filter: ModelUPPER_SNAKE_CASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    listUPPER_SNAKE_CASEs(
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const queryByOwner = /* GraphQL */ \`
-  query QueryByOwner(
-    $owner: String
-    $sortDirection: ModelSortDirection
-    $filter: ModelUPPERCASEFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    queryByOwner(
-      owner: $owner
-      sortDirection: $sortDirection
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        owner
-        createdAt
-        updatedAt
-      }
-      nextToken
-    }
-  }
-\`;
-export const createUPPERCASE = /* GraphQL */ \`
-  mutation CreateUPPERCASE(
-    $input: CreateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    createUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPERCASE = /* GraphQL */ \`
-  mutation UpdateUPPERCASE(
-    $input: UpdateUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    updateUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPERCASE = /* GraphQL */ \`
-  mutation DeleteUPPERCASE(
-    $input: DeleteUPPERCASEInput!
-    $condition: ModelUPPERCASEConditionInput
-  ) {
-    deleteUPPERCASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createLowercase = /* GraphQL */ \`
-  mutation CreateLowercase(
-    $input: CreateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    createLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateLowercase = /* GraphQL */ \`
-  mutation UpdateLowercase(
-    $input: UpdateLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    updateLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteLowercase = /* GraphQL */ \`
-  mutation DeleteLowercase(
-    $input: DeleteLowercaseInput!
-    $condition: ModellowercaseConditionInput
-  ) {
-    deleteLowercase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createCamelCase = /* GraphQL */ \`
-  mutation CreateCamelCase(
-    $input: CreateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    createCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateCamelCase = /* GraphQL */ \`
-  mutation UpdateCamelCase(
-    $input: UpdateCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    updateCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteCamelCase = /* GraphQL */ \`
-  mutation DeleteCamelCase(
-    $input: DeleteCamelCaseInput!
-    $condition: ModelcamelCaseConditionInput
-  ) {
-    deleteCamelCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createPascalCase = /* GraphQL */ \`
-  mutation CreatePascalCase(
-    $input: CreatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    createPascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updatePascalCase = /* GraphQL */ \`
-  mutation UpdatePascalCase(
-    $input: UpdatePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    updatePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deletePascalCase = /* GraphQL */ \`
-  mutation DeletePascalCase(
-    $input: DeletePascalCaseInput!
-    $condition: ModelPascalCaseConditionInput
-  ) {
-    deletePascalCase(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createSnake_case = /* GraphQL */ \`
-  mutation CreateSnake_case(
-    $input: CreateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    createSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateSnake_case = /* GraphQL */ \`
-  mutation UpdateSnake_case(
-    $input: UpdateSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    updateSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteSnake_case = /* GraphQL */ \`
-  mutation DeleteSnake_case(
-    $input: DeleteSnake_caseInput!
-    $condition: Modelsnake_caseConditionInput
-  ) {
-    deleteSnake_case(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation CreateUPPER_SNAKE_CASE(
-    $input: CreateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation UpdateUPPER_SNAKE_CASE(
-    $input: UpdateUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  mutation DeleteUPPER_SNAKE_CASE(
-    $input: DeleteUPPER_SNAKE_CASEInput!
-    $condition: ModelUPPER_SNAKE_CASEConditionInput
-  ) {
-    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPERCASE = /* GraphQL */ \`
-  subscription OnCreateUPPERCASE {
-    onCreateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPERCASE = /* GraphQL */ \`
-  subscription OnUpdateUPPERCASE {
-    onUpdateUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPERCASE = /* GraphQL */ \`
-  subscription OnDeleteUPPERCASE {
-    onDeleteUPPERCASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateLowercase = /* GraphQL */ \`
-  subscription OnCreateLowercase {
-    onCreateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateLowercase = /* GraphQL */ \`
-  subscription OnUpdateLowercase {
-    onUpdateLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteLowercase = /* GraphQL */ \`
-  subscription OnDeleteLowercase {
-    onDeleteLowercase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateCamelCase = /* GraphQL */ \`
-  subscription OnCreateCamelCase {
-    onCreateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateCamelCase = /* GraphQL */ \`
-  subscription OnUpdateCamelCase {
-    onUpdateCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteCamelCase = /* GraphQL */ \`
-  subscription OnDeleteCamelCase {
-    onDeleteCamelCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreatePascalCase = /* GraphQL */ \`
-  subscription OnCreatePascalCase {
-    onCreatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdatePascalCase = /* GraphQL */ \`
-  subscription OnUpdatePascalCase {
-    onUpdatePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeletePascalCase = /* GraphQL */ \`
-  subscription OnDeletePascalCase {
-    onDeletePascalCase {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateSnake_case = /* GraphQL */ \`
-  subscription OnCreateSnake_case {
-    onCreateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateSnake_case = /* GraphQL */ \`
-  subscription OnUpdateSnake_case {
-    onUpdateSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteSnake_case = /* GraphQL */ \`
-  subscription OnDeleteSnake_case {
-    onDeleteSnake_case {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnCreateUPPER_SNAKE_CASE {
-    onCreateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnUpdateUPPER_SNAKE_CASE {
-    onUpdateUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
-  subscription OnDeleteUPPER_SNAKE_CASE {
-    onDeleteUPPER_SNAKE_CASE {
-      id
-      owner
-      createdAt
-      updatedAt
-    }
-  }
-\`;
-"
 `;

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -39,41 +39,28 @@ query Hero
     }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
+        totalCount
       }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
       }
     }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
+    friendsConnection {
+      totalCount
       edges {
-        
-    cursor
-    __typename
-        
+        cursor
       }
       friends {
         
@@ -93,16 +80,11 @@ query Hero
     }
       }
       pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
+        startCursor
+        endCursor
+        hasNextPage
       }
-    __typename
-        
-      }
+    }
     appearsIn
     
     ...on Human {
@@ -111,13 +93,10 @@ query Hero
     height
     mass
       starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+        id
+        name
+        length
+        coordinates
       }
     }
     ...on Droid {
@@ -143,7 +122,6 @@ query Reviews
     episode
     stars
     commentary
-    __typename
     
   }
 }
@@ -170,100 +148,70 @@ query Search
     height
     mass
       friends {
-        
-    id
-    name
-      friends {
-        
-    id
-    name
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
-      }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
-      }
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
-      edges {
-        
-    cursor
-    __typename
-        
-      }
-      friends {
-        
-    id
-    name
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
-      }
-    __typename
-        
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
       }
     appearsIn
       starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+        id
+        name
+        length
+        coordinates
       }
     }
     ...on Droid {
@@ -271,90 +219,63 @@ query Search
     id
     name
       friends {
-        
-    id
-    name
-      friends {
-        
-    id
-    name
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
-      }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
-      }
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
-      edges {
-        
-    cursor
-    __typename
-        
-      }
-      friends {
-        
-    id
-    name
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-    }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
-      }
-    __typename
-        
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
       }
     appearsIn
     primaryFunction
@@ -406,41 +327,28 @@ query Character
     }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
+        totalCount
       }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
       }
     }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
+    friendsConnection {
+      totalCount
       edges {
-        
-    cursor
-    __typename
-        
+        cursor
       }
       friends {
         
@@ -460,16 +368,11 @@ query Character
     }
       }
       pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
+        startCursor
+        endCursor
+        hasNextPage
       }
-    __typename
-        
-      }
+    }
     appearsIn
     
     ...on Human {
@@ -478,13 +381,10 @@ query Character
     height
     mass
       starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+        id
+        name
+        length
+        coordinates
       }
     }
     ...on Droid {
@@ -531,41 +431,28 @@ query Droid
     }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
+        totalCount
       }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
       }
     }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
+    friendsConnection {
+      totalCount
       edges {
-        
-    cursor
-    __typename
-        
+        cursor
       }
       friends {
         
@@ -585,19 +472,13 @@ query Droid
     }
       }
       pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
+        startCursor
+        endCursor
+        hasNextPage
       }
-    __typename
-        
-      }
+    }
     appearsIn
     primaryFunction
-    __typename
     
   }
 }
@@ -642,41 +523,28 @@ query Human
     }
       }
       friendsConnection {
-        
-    totalCount
-    __typename
-        
+        totalCount
       }
-    appearsIn
-        
-    ...on Human {
-      
-    homePlanet
-    height
-    mass
-      starships {
-        
-    id
-    name
-    length
-    coordinates
-    __typename
-        
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
       }
     }
-    ...on Droid {
-      
-    primaryFunction
-    }
-      }
-      friendsConnection {
-        
-    totalCount
+    friendsConnection {
+      totalCount
       edges {
-        
-    cursor
-    __typename
-        
+        cursor
       }
       friends {
         
@@ -696,54 +564,43 @@ query Human
     }
       }
       pageInfo {
-        
-    startCursor
-    endCursor
-    hasNextPage
-    __typename
-        
+        startCursor
+        endCursor
+        hasNextPage
       }
-    __typename
-        
-      }
+    }
     appearsIn
-      starships {
-        
+    starships {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+}
+query Starship($id: ID!) {
+  starship(id: $id) {
     id
     name
     length
     coordinates
-    __typename
-        
-      }
-    __typename
-    
   }
 }
-",
-  "starship" => "
-query Starship 
-  (
-      $id:ID!
-  )
-{
-  starship
-  (
-      id:$id
-  )
- 
-   {
-    
-    id
-    name
-    length
-    coordinates
-    __typename
-    
+mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+  createReview(episode: $episode, review: $review) {
+    episode
+    stars
+    commentary
   }
 }
-",
+subscription ReviewAdded($episode: Episode) {
+  reviewAdded(episode: $episode) {
+    episode
+    stars
+    commentary
+  }
 }
+"
 `;
 
 exports[`GraphQL documents generation tests for introspection schema input should generate GraphQL documents for schema 2`] = `
@@ -766,7 +623,6 @@ mutation CreateReview
     episode
     stars
     commentary
-    __typename
     
   }
 }
@@ -792,12 +648,1524 @@ subscription ReviewAdded
     episode
     stars
     commentary
-    __typename
     
   }
 }
 ",
 }
+`;
+
+exports[`end 2 end tests should generate statements in JS 1`] = `
+"/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const hero = /* GraphQL */ \`
+  query Hero($episode: Episode) {
+    hero(episode: $episode) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const reviews = /* GraphQL */ \`
+  query Reviews($episode: Episode!) {
+    reviews(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const search = /* GraphQL */ \`
+  query Search($text: String) {
+    search(text: $text) {
+      ... on Human {
+        id
+        name
+        homePlanet
+        height
+        mass
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        id
+        name
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        primaryFunction
+      }
+      ... on Starship {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const character = /* GraphQL */ \`
+  query Character($id: ID!) {
+    character(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const droid = /* GraphQL */ \`
+  query Droid($id: ID!) {
+    droid(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+  }
+\`;
+export const human = /* GraphQL */ \`
+  query Human($id: ID!) {
+    human(id: $id) {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const starship = /* GraphQL */ \`
+  query Starship($id: ID!) {
+    starship(id: $id) {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+\`;
+export const createReview = /* GraphQL */ \`
+  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+    createReview(episode: $episode, review: $review) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const reviewAdded = /* GraphQL */ \`
+  subscription ReviewAdded($episode: Episode) {
+    reviewAdded(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests should generate statements in Typescript 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const hero = /* GraphQL */ \`
+  query Hero($episode: Episode) {
+    hero(episode: $episode) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const reviews = /* GraphQL */ \`
+  query Reviews($episode: Episode!) {
+    reviews(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const search = /* GraphQL */ \`
+  query Search($text: String) {
+    search(text: $text) {
+      ... on Human {
+        id
+        name
+        homePlanet
+        height
+        mass
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        id
+        name
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        primaryFunction
+      }
+      ... on Starship {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const character = /* GraphQL */ \`
+  query Character($id: ID!) {
+    character(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const droid = /* GraphQL */ \`
+  query Droid($id: ID!) {
+    droid(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+  }
+\`;
+export const human = /* GraphQL */ \`
+  query Human($id: ID!) {
+    human(id: $id) {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const starship = /* GraphQL */ \`
+  query Starship($id: ID!) {
+    starship(id: $id) {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+\`;
+export const createReview = /* GraphQL */ \`
+  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+    createReview(episode: $episode, review: $review) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const reviewAdded = /* GraphQL */ \`
+  subscription ReviewAdded($episode: Episode) {
+    reviewAdded(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests should generate statements in flow 1`] = `
+"// @flow
+// this is an auto generated file. This will be overwritten
+
+export const hero = /* GraphQL */ \`
+  query Hero($episode: Episode) {
+    hero(episode: $episode) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const reviews = /* GraphQL */ \`
+  query Reviews($episode: Episode!) {
+    reviews(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const search = /* GraphQL */ \`
+  query Search($text: String) {
+    search(text: $text) {
+      ... on Human {
+        id
+        name
+        homePlanet
+        height
+        mass
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        id
+        name
+        friends {
+          id
+          name
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          friendsConnection {
+            totalCount
+          }
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+            starships {
+              id
+              name
+              length
+              coordinates
+            }
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+          edges {
+            cursor
+          }
+          friends {
+            id
+            name
+            appearsIn
+            ... on Human {
+              homePlanet
+              height
+              mass
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+          }
+        }
+        appearsIn
+        primaryFunction
+      }
+      ... on Starship {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const character = /* GraphQL */ \`
+  query Character($id: ID!) {
+    character(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      ... on Human {
+        homePlanet
+        height
+        mass
+        starships {
+          id
+          name
+          length
+          coordinates
+        }
+      }
+      ... on Droid {
+        primaryFunction
+      }
+    }
+  }
+\`;
+export const droid = /* GraphQL */ \`
+  query Droid($id: ID!) {
+    droid(id: $id) {
+      id
+      name
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      primaryFunction
+    }
+  }
+\`;
+export const human = /* GraphQL */ \`
+  query Human($id: ID!) {
+    human(id: $id) {
+      id
+      name
+      homePlanet
+      height
+      mass
+      friends {
+        id
+        name
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        friendsConnection {
+          totalCount
+        }
+        appearsIn
+        ... on Human {
+          homePlanet
+          height
+          mass
+          starships {
+            id
+            name
+            length
+            coordinates
+          }
+        }
+        ... on Droid {
+          primaryFunction
+        }
+      }
+      friendsConnection {
+        totalCount
+        edges {
+          cursor
+        }
+        friends {
+          id
+          name
+          appearsIn
+          ... on Human {
+            homePlanet
+            height
+            mass
+          }
+          ... on Droid {
+            primaryFunction
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+        }
+      }
+      appearsIn
+      starships {
+        id
+        name
+        length
+        coordinates
+      }
+    }
+  }
+\`;
+export const starship = /* GraphQL */ \`
+  query Starship($id: ID!) {
+    starship(id: $id) {
+      id
+      name
+      length
+      coordinates
+    }
+  }
+\`;
+export const createReview = /* GraphQL */ \`
+  mutation CreateReview($episode: Episode, $review: ReviewInput!) {
+    createReview(episode: $episode, review: $review) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+export const reviewAdded = /* GraphQL */ \`
+  subscription ReviewAdded($episode: Episode) {
+    reviewAdded(episode: $episode) {
+      episode
+      stars
+      commentary
+    }
+  }
+\`;
+"
 `;
 
 exports[`end 2 end tests to test if the case style is retained for type names should generate statements 1`] = `
@@ -819,39 +2187,22 @@ query GetUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
-",
-  "listUPPERCASEs" => "
-query ListUPPERCASEs 
-  (
-      $filter:ModelUPPERCASEFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listUPPERCASEs
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
-    id
-    owner
-    createdAt
-    updatedAt
-    __typename
-        
-      }
+query ListUPPERCASEs(
+  $filter: ModelUPPERCASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
     nextToken
-    __typename
     
   }
 }
@@ -873,39 +2224,22 @@ query GetLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
-",
-  "listLowercases" => "
-query ListLowercases 
-  (
-      $filter:ModellowercaseFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listLowercases
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
-    id
-    owner
-    createdAt
-    updatedAt
-    __typename
-        
-      }
+query ListLowercases(
+  $filter: ModellowercaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
     nextToken
-    __typename
     
   }
 }
@@ -927,39 +2261,22 @@ query GetCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
-",
-  "listCamelCases" => "
-query ListCamelCases 
-  (
-      $filter:ModelcamelCaseFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listCamelCases
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
-    id
-    owner
-    createdAt
-    updatedAt
-    __typename
-        
-      }
+query ListCamelCases(
+  $filter: ModelcamelCaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
     nextToken
-    __typename
     
   }
 }
@@ -981,39 +2298,22 @@ query GetPascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
-",
-  "listPascalCases" => "
-query ListPascalCases 
-  (
-      $filter:ModelPascalCaseFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listPascalCases
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
-    id
-    owner
-    createdAt
-    updatedAt
-    __typename
-        
-      }
+query ListPascalCases(
+  $filter: ModelPascalCaseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
     nextToken
-    __typename
     
   }
 }
@@ -1035,39 +2335,22 @@ query GetSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
-",
-  "listSnake_cases" => "
-query ListSnake_cases 
-  (
-      $filter:Modelsnake_caseFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listSnake_cases
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
-    id
-    owner
-    createdAt
-    updatedAt
-    __typename
-        
-      }
+query ListSnake_cases(
+  $filter: Modelsnake_caseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
     nextToken
-    __typename
     
   }
 }
@@ -1089,80 +2372,394 @@ query GetUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
+    
+  }
+}
+query ListUPPER_SNAKE_CASEs(
+  $filter: ModelUPPER_SNAKE_CASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listUPPER_SNAKE_CASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
+    
+  }
+}
+query QueryByOwner(
+  $owner: String
+  $sortDirection: ModelSortDirection
+  $filter: ModelUPPERCASEFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  queryByOwner(
+    owner: $owner
+    sortDirection: $sortDirection
+    filter: $filter
+    limit: $limit
+    nextToken: $nextToken
+  ) {
+    items {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+    nextToken
     
   }
 }
 ",
-  "listUPPER_SNAKE_CASEs" => "
-query ListUPPER_SNAKE_CASEs 
-  (
-      $filter:ModelUPPER_SNAKE_CASEFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  listUPPER_SNAKE_CASEs
-  (
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
+}
+mutation CreateUPPERCASE(
+  $input: CreateUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  createUPPERCASE(input: $input, condition: $condition) {
     id
     owner
     createdAt
     updatedAt
-    __typename
-        
-      }
-    nextToken
-    __typename
-    
   }
 }
-",
-  "queryByOwner" => "
-query QueryByOwner 
-  (
-      $owner:String,
-      $sortDirection:ModelSortDirection,
-      $filter:ModelUPPERCASEFilterInput,
-      $limit:Int,
-      $nextToken:String
-  )
-{
-  queryByOwner
-  (
-      owner:$owner,
-      sortDirection:$sortDirection,
-      filter:$filter,
-      limit:$limit,
-      nextToken:$nextToken
-  )
- 
-   {
-    
-      items {
-        
+mutation UpdateUPPERCASE(
+  $input: UpdateUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  updateUPPERCASE(input: $input, condition: $condition) {
     id
     owner
     createdAt
     updatedAt
-    __typename
-        
-      }
-    nextToken
-    __typename
-    
   }
 }
-",
+mutation DeleteUPPERCASE(
+  $input: DeleteUPPERCASEInput!
+  $condition: ModelUPPERCASEConditionInput
+) {
+  deleteUPPERCASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
 }
+mutation CreateLowercase(
+  $input: CreateLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  createLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateLowercase(
+  $input: UpdateLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  updateLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteLowercase(
+  $input: DeleteLowercaseInput!
+  $condition: ModellowercaseConditionInput
+) {
+  deleteLowercase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateCamelCase(
+  $input: CreateCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  createCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateCamelCase(
+  $input: UpdateCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  updateCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteCamelCase(
+  $input: DeleteCamelCaseInput!
+  $condition: ModelcamelCaseConditionInput
+) {
+  deleteCamelCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreatePascalCase(
+  $input: CreatePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  createPascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdatePascalCase(
+  $input: UpdatePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  updatePascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeletePascalCase(
+  $input: DeletePascalCaseInput!
+  $condition: ModelPascalCaseConditionInput
+) {
+  deletePascalCase(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateSnake_case(
+  $input: CreateSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  createSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateSnake_case(
+  $input: UpdateSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  updateSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteSnake_case(
+  $input: DeleteSnake_caseInput!
+  $condition: Modelsnake_caseConditionInput
+) {
+  deleteSnake_case(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation CreateUPPER_SNAKE_CASE(
+  $input: CreateUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation UpdateUPPER_SNAKE_CASE(
+  $input: UpdateUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+mutation DeleteUPPER_SNAKE_CASE(
+  $input: DeleteUPPER_SNAKE_CASEInput!
+  $condition: ModelUPPER_SNAKE_CASEConditionInput
+) {
+  deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateUPPERCASE {
+  onCreateUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateUPPERCASE {
+  onUpdateUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteUPPERCASE {
+  onDeleteUPPERCASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateLowercase {
+  onCreateLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateLowercase {
+  onUpdateLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteLowercase {
+  onDeleteLowercase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateCamelCase {
+  onCreateCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateCamelCase {
+  onUpdateCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteCamelCase {
+  onDeleteCamelCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreatePascalCase {
+  onCreatePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdatePascalCase {
+  onUpdatePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeletePascalCase {
+  onDeletePascalCase {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateSnake_case {
+  onCreateSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateSnake_case {
+  onUpdateSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteSnake_case {
+  onDeleteSnake_case {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnCreateUPPER_SNAKE_CASE {
+  onCreateUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnUpdateUPPER_SNAKE_CASE {
+  onUpdateUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+subscription OnDeleteUPPER_SNAKE_CASE {
+  onDeleteUPPER_SNAKE_CASE {
+    id
+    owner
+    createdAt
+    updatedAt
+  }
+}
+"
 `;
 
 exports[`end 2 end tests to test if the case style is retained for type names should generate statements 2`] = `
@@ -1186,7 +2783,6 @@ mutation CreateUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1210,7 +2806,6 @@ mutation UpdateUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1234,7 +2829,6 @@ mutation DeleteUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1258,7 +2852,6 @@ mutation CreateLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1282,7 +2875,6 @@ mutation UpdateLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1306,7 +2898,6 @@ mutation DeleteLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1330,7 +2921,6 @@ mutation CreateCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1354,7 +2944,6 @@ mutation UpdateCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1378,7 +2967,6 @@ mutation DeleteCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1402,7 +2990,6 @@ mutation CreatePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1426,7 +3013,6 @@ mutation UpdatePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1450,7 +3036,6 @@ mutation DeletePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1474,7 +3059,6 @@ mutation CreateSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1498,7 +3082,6 @@ mutation UpdateSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1522,7 +3105,6 @@ mutation DeleteSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1546,7 +3128,6 @@ mutation CreateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1570,7 +3151,6 @@ mutation UpdateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1594,7 +3174,6 @@ mutation DeleteUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1615,7 +3194,6 @@ subscription OnCreateUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1631,7 +3209,6 @@ subscription OnUpdateUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1647,7 +3224,6 @@ subscription OnDeleteUPPERCASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1663,7 +3239,6 @@ subscription OnCreateLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1679,7 +3254,6 @@ subscription OnUpdateLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1695,7 +3269,6 @@ subscription OnDeleteLowercase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1711,7 +3284,6 @@ subscription OnCreateCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1727,7 +3299,6 @@ subscription OnUpdateCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1743,7 +3314,6 @@ subscription OnDeleteCamelCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1759,7 +3329,6 @@ subscription OnCreatePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1775,7 +3344,6 @@ subscription OnUpdatePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1791,7 +3359,6 @@ subscription OnDeletePascalCase
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1807,7 +3374,6 @@ subscription OnCreateSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1823,7 +3389,6 @@ subscription OnUpdateSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1839,7 +3404,6 @@ subscription OnDeleteSnake_case
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1855,7 +3419,6 @@ subscription OnCreateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1871,7 +3434,6 @@ subscription OnUpdateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
@@ -1887,10 +3449,1846 @@ subscription OnDeleteUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
-    __typename
     
   }
 }
 ",
 }
+`;
+
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in JS 1`] = `
+"/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in Typescript 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
+`;
+
+exports[`end 2 end tests to test if the case style is retained for type names should generate statements in flow 1`] = `
+"// @flow
+// this is an auto generated file. This will be overwritten
+
+export const getUPPERCASE = /* GraphQL */ \`
+  query GetUPPERCASE($id: ID!) {
+    getUPPERCASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPERCASEs = /* GraphQL */ \`
+  query ListUPPERCASEs(
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPERCASEs(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getLowercase = /* GraphQL */ \`
+  query GetLowercase($id: ID!) {
+    getLowercase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listLowercases = /* GraphQL */ \`
+  query ListLowercases(
+    $filter: ModellowercaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLowercases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getCamelCase = /* GraphQL */ \`
+  query GetCamelCase($id: ID!) {
+    getCamelCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listCamelCases = /* GraphQL */ \`
+  query ListCamelCases(
+    $filter: ModelcamelCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listCamelCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getPascalCase = /* GraphQL */ \`
+  query GetPascalCase($id: ID!) {
+    getPascalCase(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listPascalCases = /* GraphQL */ \`
+  query ListPascalCases(
+    $filter: ModelPascalCaseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPascalCases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getSnake_case = /* GraphQL */ \`
+  query GetSnake_case($id: ID!) {
+    getSnake_case(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listSnake_cases = /* GraphQL */ \`
+  query ListSnake_cases(
+    $filter: Modelsnake_caseFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listSnake_cases(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const getUPPER_SNAKE_CASE = /* GraphQL */ \`
+  query GetUPPER_SNAKE_CASE($id: ID!) {
+    getUPPER_SNAKE_CASE(id: $id) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const listUPPER_SNAKE_CASEs = /* GraphQL */ \`
+  query ListUPPER_SNAKE_CASEs(
+    $filter: ModelUPPER_SNAKE_CASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listUPPER_SNAKE_CASEs(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const queryByOwner = /* GraphQL */ \`
+  query QueryByOwner(
+    $owner: String
+    $sortDirection: ModelSortDirection
+    $filter: ModelUPPERCASEFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    queryByOwner(
+      owner: $owner
+      sortDirection: $sortDirection
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        id
+        owner
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+\`;
+export const createUPPERCASE = /* GraphQL */ \`
+  mutation CreateUPPERCASE(
+    $input: CreateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    createUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPERCASE = /* GraphQL */ \`
+  mutation UpdateUPPERCASE(
+    $input: UpdateUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    updateUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPERCASE = /* GraphQL */ \`
+  mutation DeleteUPPERCASE(
+    $input: DeleteUPPERCASEInput!
+    $condition: ModelUPPERCASEConditionInput
+  ) {
+    deleteUPPERCASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createLowercase = /* GraphQL */ \`
+  mutation CreateLowercase(
+    $input: CreateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    createLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateLowercase = /* GraphQL */ \`
+  mutation UpdateLowercase(
+    $input: UpdateLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    updateLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteLowercase = /* GraphQL */ \`
+  mutation DeleteLowercase(
+    $input: DeleteLowercaseInput!
+    $condition: ModellowercaseConditionInput
+  ) {
+    deleteLowercase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createCamelCase = /* GraphQL */ \`
+  mutation CreateCamelCase(
+    $input: CreateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    createCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateCamelCase = /* GraphQL */ \`
+  mutation UpdateCamelCase(
+    $input: UpdateCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    updateCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteCamelCase = /* GraphQL */ \`
+  mutation DeleteCamelCase(
+    $input: DeleteCamelCaseInput!
+    $condition: ModelcamelCaseConditionInput
+  ) {
+    deleteCamelCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createPascalCase = /* GraphQL */ \`
+  mutation CreatePascalCase(
+    $input: CreatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    createPascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updatePascalCase = /* GraphQL */ \`
+  mutation UpdatePascalCase(
+    $input: UpdatePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    updatePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deletePascalCase = /* GraphQL */ \`
+  mutation DeletePascalCase(
+    $input: DeletePascalCaseInput!
+    $condition: ModelPascalCaseConditionInput
+  ) {
+    deletePascalCase(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createSnake_case = /* GraphQL */ \`
+  mutation CreateSnake_case(
+    $input: CreateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    createSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateSnake_case = /* GraphQL */ \`
+  mutation UpdateSnake_case(
+    $input: UpdateSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    updateSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteSnake_case = /* GraphQL */ \`
+  mutation DeleteSnake_case(
+    $input: DeleteSnake_caseInput!
+    $condition: Modelsnake_caseConditionInput
+  ) {
+    deleteSnake_case(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const createUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation CreateUPPER_SNAKE_CASE(
+    $input: CreateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    createUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const updateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation UpdateUPPER_SNAKE_CASE(
+    $input: UpdateUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    updateUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const deleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  mutation DeleteUPPER_SNAKE_CASE(
+    $input: DeleteUPPER_SNAKE_CASEInput!
+    $condition: ModelUPPER_SNAKE_CASEConditionInput
+  ) {
+    deleteUPPER_SNAKE_CASE(input: $input, condition: $condition) {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPERCASE = /* GraphQL */ \`
+  subscription OnCreateUPPERCASE {
+    onCreateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPERCASE = /* GraphQL */ \`
+  subscription OnUpdateUPPERCASE {
+    onUpdateUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPERCASE = /* GraphQL */ \`
+  subscription OnDeleteUPPERCASE {
+    onDeleteUPPERCASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateLowercase = /* GraphQL */ \`
+  subscription OnCreateLowercase {
+    onCreateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateLowercase = /* GraphQL */ \`
+  subscription OnUpdateLowercase {
+    onUpdateLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteLowercase = /* GraphQL */ \`
+  subscription OnDeleteLowercase {
+    onDeleteLowercase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateCamelCase = /* GraphQL */ \`
+  subscription OnCreateCamelCase {
+    onCreateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateCamelCase = /* GraphQL */ \`
+  subscription OnUpdateCamelCase {
+    onUpdateCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteCamelCase = /* GraphQL */ \`
+  subscription OnDeleteCamelCase {
+    onDeleteCamelCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreatePascalCase = /* GraphQL */ \`
+  subscription OnCreatePascalCase {
+    onCreatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdatePascalCase = /* GraphQL */ \`
+  subscription OnUpdatePascalCase {
+    onUpdatePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeletePascalCase = /* GraphQL */ \`
+  subscription OnDeletePascalCase {
+    onDeletePascalCase {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateSnake_case = /* GraphQL */ \`
+  subscription OnCreateSnake_case {
+    onCreateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateSnake_case = /* GraphQL */ \`
+  subscription OnUpdateSnake_case {
+    onUpdateSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteSnake_case = /* GraphQL */ \`
+  subscription OnDeleteSnake_case {
+    onDeleteSnake_case {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onCreateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnCreateUPPER_SNAKE_CASE {
+    onCreateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onUpdateUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnUpdateUPPER_SNAKE_CASE {
+    onUpdateUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+export const onDeleteUPPER_SNAKE_CASE = /* GraphQL */ \`
+  subscription OnDeleteUPPER_SNAKE_CASE {
+    onDeleteUPPER_SNAKE_CASE {
+      id
+      owner
+      createdAt
+      updatedAt
+    }
+  }
+\`;
+"
 `;

--- a/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
@@ -26,7 +26,7 @@ describe('getField', () => {
 
   it('should support simple scalar', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
+    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false })).toEqual({
       name: 'foo',
       fields: [],
       fragments: [],
@@ -37,49 +37,7 @@ describe('getField', () => {
 
   it('it should recursively resolve fields up to max depth', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
-      name: 'nested',
-      fields: [
-        {
-          name: 'level',
-          fields: [],
-          fragments: [],
-          hasBody: false,
-        },
-        {
-          name: 'subObj',
-          fields: [
-            {
-              name: 'level',
-              fields: [],
-              fragments: [],
-              hasBody: false,
-            },
-            {
-              name: '__typename',
-              fields: [],
-              fragments: [],
-              hasBody: false,
-            },
-          ],
-          fragments: [],
-          hasBody: true,
-        },
-        {
-          name: '__typename',
-          fields: [],
-          fragments: [],
-          hasBody: false,
-        },
-      ],
-      fragments: [],
-      hasBody: true,
-    });
-  });
-
-  it('it should recorsively resolve fields without typename when typenameIntrospection is disabled', () => {
-    const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: false })).toEqual({
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false })).toEqual({
       name: 'nested',
       fields: [
         {
@@ -109,7 +67,7 @@ describe('getField', () => {
 
   it('should not return anything for complex type when the depth is < 1', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toBeUndefined();
+    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false })).toBeUndefined();
   });
   describe('When type is an Interface', () => {
     beforeEach(() => {
@@ -153,10 +111,7 @@ describe('getField', () => {
     it('interface - should return fragments of all the implementations', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, {
-        useExternalFragmentForS3Object: false,
-        typenameIntrospection: true,
-      });
+      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, { useExternalFragmentForS3Object: false });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -213,10 +168,7 @@ describe('getField', () => {
     it('union - should return fragments of all the types', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, {
-        useExternalFragmentForS3Object: false,
-        typenameIntrospection: true,
-      });
+      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, { useExternalFragmentForS3Object: false });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -259,7 +211,7 @@ describe('getField', () => {
         buckets: { type: aggregateBucketResultItem },
       },
     });
-
+    
     const aggregateResult = new GraphQLUnionType({
       name: 'SearchableAggregateGenericResult',
       types: [aggregateScalarResult, aggregateBucketResult],
@@ -285,10 +237,7 @@ describe('getField', () => {
     it('aggregateItems property should traverse two additional levels to generate required fields with default depth 2', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, {
-        useExternalFragmentForS3Object: false,
-        typenameIntrospection: true,
-      });
+      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, { useExternalFragmentForS3Object: false });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 

--- a/packages/graphql-docs-generator/src/cli.ts
+++ b/packages/graphql-docs-generator/src/cli.ts
@@ -31,14 +31,10 @@ export function run(argv: Array<String>): void {
           default: 2,
           normalize: true,
           type: 'number',
-        },
-        typenameIntrospection: {
-          default: true,
-          type: 'boolean',
-        },
+        }
       },
       async argv => {
-        generateGraphQLDocuments(argv.schema, { maxDepth: argv.maxDepth, typenameIntrospection: argv.typenameIntrospection });
+        generateGraphQLDocuments(argv.schema, { maxDepth: argv.maxDepth });
       }
     )
     .help()

--- a/packages/graphql-docs-generator/src/generator/getFields.ts
+++ b/packages/graphql-docs-generator/src/generator/getFields.ts
@@ -22,7 +22,7 @@ export default function getFields(
   field: GraphQLField<any, any>,
   schema: GraphQLSchema,
   depth: number = 2,
-  options: GQLDocsGenOptions,
+  options: GQLDocsGenOptions
 ): GQLTemplateField {
   const fieldType: GQLConcreteType = getType(field.type);
   const renderS3FieldFragment = options.useExternalFragmentForS3Object && isS3Object(fieldType);
@@ -40,19 +40,6 @@ export default function getFields(
       return getFields(subField, schema, adjustDepth(subField, depth), options);
     })
     .filter(f => f);
-
-  // add __typename to selection set.
-  // getFields() does not include __typename because __typename is implicitly included on all object types.
-  // https://spec.graphql.org/June2018/#sec-Type-Name-Introspection
-  // do not add to interface types or union types because they are not supported by the transformers
-  if (options.typenameIntrospection && isObjectType(fieldType)) {
-    fields.push({
-      name: '__typename',
-      fields: [],
-      fragments: [],
-      hasBody: false,
-    });
-  }
   const fragments: Array<GQLTemplateFragment> = Object.keys(subFragments)
     .map(fragment => getFragment(subFragments[fragment], schema, depth, fields, null, false, options))
     .filter(f => f);
@@ -87,14 +74,18 @@ function adjustDepth(field, depth) {
 }
 
 function isGraphQLAggregateField(field) {
-  if (field && field.name == 'aggregateItems' && getBaseType(field.type) == 'SearchableAggregateResult') {
+  if (
+    field &&
+    field.name == 'aggregateItems' &&
+    getBaseType(field.type) == 'SearchableAggregateResult'
+  ) {
     return true;
   }
   return false;
 }
 
 function getBaseType(type) {
-  if (type && type.ofType) {
+  if(type && type.ofType) {
     return getBaseType(type.ofType);
   }
   return type?.name;

--- a/packages/graphql-docs-generator/src/generator/types.ts
+++ b/packages/graphql-docs-generator/src/generator/types.ts
@@ -72,8 +72,7 @@ export type GQLAllOperations = {
 };
 
 export type GQLDocsGenOptions = {
-  useExternalFragmentForS3Object: boolean;
-  typenameIntrospection: boolean;
+  useExternalFragmentForS3Object: boolean,
 };
 
 export enum SchemaType {

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -6,12 +6,11 @@ export { buildSchema } from './generator/utils/loading';
 
 export function generateGraphQLDocuments(
   schema: string,
-  options: { maxDepth?: number, useExternalFragmentForS3Object?: boolean; typenameIntrospection?: boolean },
+  options: { maxDepth?: number, useExternalFragmentForS3Object?: boolean; },
 ): GeneratedOperations {
   const opts = {
     maxDepth: 2,
     useExternalFragmentForS3Object: true,
-    typenameIntrospection: true,
     ...options,
   };
 

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -19,7 +19,6 @@ export function generateGraphQLDocuments(
 
   const gqlOperations: GQLAllOperations = generateAllOps(extendedSchema, opts.maxDepth, {
     useExternalFragmentForS3Object: opts.useExternalFragmentForS3Object,
-    typenameIntrospection: opts.typenameIntrospection
   });
   registerPartials();
   registerHelpers();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

- Revert the `__typename` change in doc generator
- Downgrade amplify codegen to version 3 to avoid version mismatch error from JS datastore

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.