### PR TITLE
Release Amplify Codegen at major version 4

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-codegen",
-  "version": "3.4.4",
+  "version": "4.0.0",
   "description": "amplify code generator",
   "repository": {
     "type": "git",

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -63,6 +63,9 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       const generatedOps = generateGraphQLDocuments(schemaData, {
         maxDepth: maxDepth || cfg.amplifyExtension.maxDepth,
         useExternalFragmentForS3Object: (language === 'graphql'),
+        // default typenameIntrospection to true when not set
+        typenameIntrospection:
+          cfg.amplifyExtension.typenameIntrospection === undefined ? true : !!cfg.amplifyExtension.typenameIntrospection,
       });
       if(!generatedOps) {
         context.print.warning('No GraphQL statements are generated. Check if the introspection schema has GraphQL operations defined.');

--- a/packages/amplify-codegen/tests/commands/statements.test.js
+++ b/packages/amplify-codegen/tests/commands/statements.test.js
@@ -97,7 +97,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload
+      forceDownload,
     );
   });
 
@@ -110,7 +110,7 @@ describe('command - statements', () => {
       path.join(MOCK_PROJECT_ROOT, MOCK_SCHEMA),
       MOCK_APIS[0],
       MOCK_REGION,
-      forceDownload
+      forceDownload,
     );
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -142,7 +142,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"6b1bad408fb4d771f3219e585d3db29b\\"
 };"
 `;
@@ -271,7 +271,7 @@ exports[`Metadata visitor for custom PK support HasMany without corresponding be
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"cb4c9a5805faf864220f95ebc3e346de\\"
 };"
 `;
@@ -424,7 +424,7 @@ exports[`Metadata visitor for custom PK support generates with belongsTo 1`] = `
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"8b37aacc0491d9d130e918d8ee88197c\\"
 };"
 `;
@@ -579,8 +579,1256 @@ exports[`Metadata visitor for custom PK support generates with explicit index 1`
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"b4f818e9f626f398b3ce56e741314a5b\\"
+};"
+`;
+
+exports[`Metadata visitor for custom PK support relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in js 1`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"customPostId\\": {
+                    \\"name\\": \\"customPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customPostId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"customCommentId\\": {
+                    \\"name\\": \\"customCommentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsCustomPostId\\": {
+                    \\"name\\": \\"postCommentsCustomPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customCommentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+};"
+`;
+
+exports[`Metadata visitor for custom PK support relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in ts 1`] = `
+"import { Schema } from \\"@aws-amplify/datastore\\";
+
+export const schema: Schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"customPostId\\": {
+                    \\"name\\": \\"customPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customPostId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"customCommentId\\": {
+                    \\"name\\": \\"customCommentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postCommentsCustomPostId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsCustomPostId\\": {
+                    \\"name\\": \\"postCommentsCustomPostId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"customCommentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"post\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"post\\": {
+                    \\"name\\": \\"post\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"Post1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"BELONGS_TO\\",
+                        \\"targetNames\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
+};"
+`;
+
+exports[`Metadata visitor for custom PK support relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in js 1`] = `
+"export const schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"gsi-Post.comments\\",
+                        \\"fields\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
+};"
+`;
+
+exports[`Metadata visitor for custom PK support relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in ts 1`] = `
+"import { Schema } from \\"@aws-amplify/datastore\\";
+
+export const schema: Schema = {
+    \\"models\\": {
+        \\"Post\\": {
+            \\"name\\": \\"Post\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Posts\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment\\": {
+            \\"name\\": \\"Comment\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"postCommentsId\\": {
+                    \\"name\\": \\"postCommentsId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postCommentsTitle\\": {
+                    \\"name\\": \\"postCommentsTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comments\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"id\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"gsi-Post.comments\\",
+                        \\"fields\\": [
+                            \\"postCommentsId\\",
+                            \\"postCommentsTitle\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Post1\\": {
+            \\"name\\": \\"Post1\\",
+            \\"fields\\": {
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"title\\": {
+                    \\"name\\": \\"title\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"comments\\": {
+                    \\"name\\": \\"comments\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"model\\": \\"Comment1\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": true,
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_MANY\\",
+                        \\"associatedWith\\": [
+                            \\"postId\\"
+                        ]
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Post1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"title\\"
+                        ]
+                    }
+                }
+            ]
+        },
+        \\"Comment1\\": {
+            \\"name\\": \\"Comment1\\",
+            \\"fields\\": {
+                \\"commentId\\": {
+                    \\"name\\": \\"commentId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"postId\\": {
+                    \\"name\\": \\"postId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"postTitle\\": {
+                    \\"name\\": \\"postTitle\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Comment1s\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"fields\\": [
+                            \\"commentId\\",
+                            \\"content\\"
+                        ]
+                    }
+                },
+                {
+                    \\"type\\": \\"key\\",
+                    \\"properties\\": {
+                        \\"name\\": \\"byPost\\",
+                        \\"fields\\": [
+                            \\"postId\\",
+                            \\"postTitle\\"
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {},
+    \\"codegenVersion\\": \\"3.4.4\\",
+    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
 };"
 `;
 
@@ -758,7 +2006,7 @@ exports[`Metadata visitor for custom PK support relation metadata for hasOne/bel
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"e44592ddc9b6514a18674da5baacfe68\\"
 };"
 `;
@@ -939,1260 +2187,12 @@ export const schema: Schema = {
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"e44592ddc9b6514a18674da5baacfe68\\"
 };"
 `;
 
-exports[`relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in js 1`] = `
-"export const schema = {
-    \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
-            \\"fields\\": {
-                \\"customPostId\\": {
-                    \\"name\\": \\"customPostId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"customPostId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
-            \\"fields\\": {
-                \\"customCommentId\\": {
-                    \\"name\\": \\"customCommentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"postCommentsCustomPostId\\": {
-                    \\"name\\": \\"postCommentsCustomPostId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"customCommentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"post\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    \\"enums\\": {},
-    \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
-};"
-`;
-
-exports[`relation metadata for hasMany & belongsTo when custom PK is enabled should generate correct metadata in ts 1`] = `
-"import { Schema } from \\"@aws-amplify/datastore\\";
-
-export const schema: Schema = {
-    \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
-            \\"fields\\": {
-                \\"customPostId\\": {
-                    \\"name\\": \\"customPostId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"customPostId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
-            \\"fields\\": {
-                \\"customCommentId\\": {
-                    \\"name\\": \\"customCommentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postCommentsCustomPostId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"postCommentsCustomPostId\\": {
-                    \\"name\\": \\"postCommentsCustomPostId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"customCommentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"post\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"post\\": {
-                    \\"name\\": \\"post\\",
-                    \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"model\\": \\"Post1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"association\\": {
-                        \\"connectionType\\": \\"BELONGS_TO\\",
-                        \\"targetNames\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    \\"enums\\": {},
-    \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"cb8f120e36ffc33e0b01e0874ba14f7a\\"
-};"
-`;
-
-exports[`relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in js 1`] = `
-"export const schema = {
-    \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"postCommentsId\\": {
-                    \\"name\\": \\"postCommentsId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"gsi-Post.comments\\",
-                        \\"fields\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postId\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    \\"enums\\": {},
-    \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
-};"
-`;
-
-exports[`relation metadata for hasMany uni when custom PK is enabled should generate correct metadata in ts 1`] = `
-"import { Schema } from \\"@aws-amplify/datastore\\";
-
-export const schema: Schema = {
-    \\"models\\": {
-        \\"Post\\": {
-            \\"name\\": \\"Post\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Posts\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment\\": {
-            \\"name\\": \\"Comment\\",
-            \\"fields\\": {
-                \\"id\\": {
-                    \\"name\\": \\"id\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"postCommentsId\\": {
-                    \\"name\\": \\"postCommentsId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postCommentsTitle\\": {
-                    \\"name\\": \\"postCommentsTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comments\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"id\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"gsi-Post.comments\\",
-                        \\"fields\\": [
-                            \\"postCommentsId\\",
-                            \\"postCommentsTitle\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Post1\\": {
-            \\"name\\": \\"Post1\\",
-            \\"fields\\": {
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"title\\": {
-                    \\"name\\": \\"title\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"comments\\": {
-                    \\"name\\": \\"comments\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"model\\": \\"Comment1\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": true,
-                    \\"association\\": {
-                        \\"connectionType\\": \\"HAS_MANY\\",
-                        \\"associatedWith\\": [
-                            \\"postId\\"
-                        ]
-                    }
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Post1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"title\\"
-                        ]
-                    }
-                }
-            ]
-        },
-        \\"Comment1\\": {
-            \\"name\\": \\"Comment1\\",
-            \\"fields\\": {
-                \\"commentId\\": {
-                    \\"name\\": \\"commentId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"content\\": {
-                    \\"name\\": \\"content\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"postId\\": {
-                    \\"name\\": \\"postId\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"ID\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"postTitle\\": {
-                    \\"name\\": \\"postTitle\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                },
-                \\"createdAt\\": {
-                    \\"name\\": \\"createdAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                },
-                \\"updatedAt\\": {
-                    \\"name\\": \\"updatedAt\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDateTime\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": [],
-                    \\"isReadOnly\\": true
-                }
-            },
-            \\"syncable\\": true,
-            \\"pluralName\\": \\"Comment1s\\",
-            \\"attributes\\": [
-                {
-                    \\"type\\": \\"model\\",
-                    \\"properties\\": {}
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"fields\\": [
-                            \\"commentId\\",
-                            \\"content\\"
-                        ]
-                    }
-                },
-                {
-                    \\"type\\": \\"key\\",
-                    \\"properties\\": {
-                        \\"name\\": \\"byPost\\",
-                        \\"fields\\": [
-                            \\"postId\\",
-                            \\"postTitle\\"
-                        ]
-                    }
-                }
-            ]
-        }
-    },
-    \\"enums\\": {},
-    \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
-    \\"version\\": \\"aa7ec83a3846aece824a211c5304dd88\\"
-};"
-`;
-
-exports[`relation metadata for manyToMany when custom PK is enabled should generate correct metadata in js 1`] = `
+exports[`Metadata visitor for custom PK support relation metadata for manyToMany when custom PK is enabled should generate correct metadata in js 1`] = `
 "export const schema = {
     \\"models\\": {
         \\"Post\\": {
@@ -2457,12 +2457,12 @@ exports[`relation metadata for manyToMany when custom PK is enabled should gener
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"7c85f0b3f2df2a63cd6e1c28593a5381\\"
 };"
 `;
 
-exports[`relation metadata for manyToMany when custom PK is enabled should generate correct metadata in ts 1`] = `
+exports[`Metadata visitor for custom PK support relation metadata for manyToMany when custom PK is enabled should generate correct metadata in ts 1`] = `
 "import { Schema } from \\"@aws-amplify/datastore\\";
 
 export const schema: Schema = {
@@ -2729,7 +2729,7 @@ export const schema: Schema = {
     },
     \\"enums\\": {},
     \\"nonModels\\": {},
-    \\"codegenVersion\\": \\"1.0.0\\",
+    \\"codegenVersion\\": \\"3.4.4\\",
     \\"version\\": \\"7c85f0b3f2df2a63cd6e1c28593a5381\\"
 };"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-json-metadata-visitor.test.ts
@@ -290,7 +290,7 @@ describe('Metadata visitor', () => {
 
         expect(metadata).toMatchInlineSnapshot(`
           Object {
-            "codegenVersion": "1.0.0",
+            "codegenVersion": "3.4.4",
             "enums": Object {
               "SimpleEnum": Object {
                 "name": "SimpleEnum",
@@ -474,7 +474,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
@@ -568,7 +568,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
@@ -728,7 +728,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
@@ -853,7 +853,7 @@ describe('Metadata visitor', () => {
                     }
                 }
             },
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"5eb36909e822fd40c657cc69b22c919a\\"
         };"
       `);
@@ -974,7 +974,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
         };"
       `);
@@ -1080,7 +1080,7 @@ describe('Metadata visitor for auth process in field level', () => {
             },
             \\"enums\\": {},
             \\"nonModels\\": {},
-            \\"codegenVersion\\": \\"1.0.0\\",
+            \\"codegenVersion\\": \\"3.4.4\\",
             \\"version\\": \\"0fffb966ea9b8954eb89d00d74d474ac\\"
         };"
       `);
@@ -1221,7 +1221,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"codegenVersion\\": \\"1.0.0\\",
+          \\"codegenVersion\\": \\"3.4.4\\",
           \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
@@ -1344,7 +1344,7 @@ describe('Metadata visitor has one relation', () => {
           },
           \\"enums\\": {},
           \\"nonModels\\": {},
-          \\"codegenVersion\\": \\"1.0.0\\",
+          \\"codegenVersion\\": \\"3.4.4\\",
           \\"version\\": \\"27c53665371915d89e2b47bb22ec29af\\"
       };"
     `);
@@ -1441,7 +1441,6 @@ describe('Metadata visitor for custom PK support', () => {
       getVisitor(schema, 'javascript', { respectPrimaryKeyAttributesOnConnectionField: true, transformerVersion: 2 }).generate(),
     ).toMatchSnapshot();
   });
-});
   describe('relation metadata for hasMany uni when custom PK is enabled', () => {
     const schema = /* GraphQL */ `
       type Post @model {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -160,7 +160,10 @@ export class AppSyncJSONVisitor<
       models: {},
       enums: {},
       nonModels: {},
-      codegenVersion: this._parsedConfig.codegenVersion || 'unknown',
+      // This is hard-coded for the schema version purpose instead of codegen version
+      // To avoid the failure of validation method checkCodegenSchema in JS Datastore
+      // The hard code is starting from amplify codegen major version 4
+      codegenVersion: '3.4.4',
       version: this.computeVersion(),
     };
 

--- a/packages/graphql-docs-generator/API.md
+++ b/packages/graphql-docs-generator/API.md
@@ -15,6 +15,7 @@ export function buildSchema(schema: string): GraphQLSchema;
 export function generateGraphQLDocuments(schema: string, options: {
     maxDepth?: number;
     useExternalFragmentForS3Object?: boolean;
+    typenameIntrospection?: boolean;
 }): GeneratedOperations;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
+++ b/packages/graphql-docs-generator/__integration__/__snapshots__/e2e.test.ts.snap
@@ -41,6 +41,7 @@ query Hero
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -56,6 +57,7 @@ query Hero
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -70,6 +72,7 @@ query Hero
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -94,8 +97,10 @@ query Hero
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
@@ -111,6 +116,7 @@ query Hero
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -137,6 +143,7 @@ query Reviews
     episode
     stars
     commentary
+    __typename
     
   }
 }
@@ -186,6 +193,7 @@ query Search
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -201,6 +209,7 @@ query Search
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -215,6 +224,7 @@ query Search
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -239,8 +249,10 @@ query Search
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
@@ -250,6 +262,7 @@ query Search
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -281,6 +294,7 @@ query Search
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -296,6 +310,7 @@ query Search
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -310,6 +325,7 @@ query Search
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -334,8 +350,10 @@ query Search
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
@@ -390,6 +408,7 @@ query Character
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -405,6 +424,7 @@ query Character
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -419,6 +439,7 @@ query Character
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -443,8 +464,10 @@ query Character
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
@@ -460,6 +483,7 @@ query Character
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -509,6 +533,7 @@ query Droid
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -524,6 +549,7 @@ query Droid
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -538,6 +564,7 @@ query Droid
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -562,12 +589,15 @@ query Droid
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
     primaryFunction
+    __typename
     
   }
 }
@@ -614,6 +644,7 @@ query Human
       friendsConnection {
         
     totalCount
+    __typename
         
       }
     appearsIn
@@ -629,6 +660,7 @@ query Human
     name
     length
     coordinates
+    __typename
         
       }
     }
@@ -643,6 +675,7 @@ query Human
       edges {
         
     cursor
+    __typename
         
       }
       friends {
@@ -667,8 +700,10 @@ query Human
     startCursor
     endCursor
     hasNextPage
+    __typename
         
       }
+    __typename
         
       }
     appearsIn
@@ -678,8 +713,10 @@ query Human
     name
     length
     coordinates
+    __typename
         
       }
+    __typename
     
   }
 }
@@ -701,6 +738,7 @@ query Starship
     name
     length
     coordinates
+    __typename
     
   }
 }
@@ -728,6 +766,7 @@ mutation CreateReview
     episode
     stars
     commentary
+    __typename
     
   }
 }
@@ -753,6 +792,7 @@ subscription ReviewAdded
     episode
     stars
     commentary
+    __typename
     
   }
 }
@@ -779,6 +819,7 @@ query GetUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -806,9 +847,11 @@ query ListUPPERCASEs
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -830,6 +873,7 @@ query GetLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -857,9 +901,11 @@ query ListLowercases
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -881,6 +927,7 @@ query GetCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -908,9 +955,11 @@ query ListCamelCases
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -932,6 +981,7 @@ query GetPascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -959,9 +1009,11 @@ query ListPascalCases
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -983,6 +1035,7 @@ query GetSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1010,9 +1063,11 @@ query ListSnake_cases
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -1034,6 +1089,7 @@ query GetUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1061,9 +1117,11 @@ query ListUPPER_SNAKE_CASEs
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -1095,9 +1153,11 @@ query QueryByOwner
     owner
     createdAt
     updatedAt
+    __typename
         
       }
     nextToken
+    __typename
     
   }
 }
@@ -1126,6 +1186,7 @@ mutation CreateUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1149,6 +1210,7 @@ mutation UpdateUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1172,6 +1234,7 @@ mutation DeleteUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1195,6 +1258,7 @@ mutation CreateLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1218,6 +1282,7 @@ mutation UpdateLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1241,6 +1306,7 @@ mutation DeleteLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1264,6 +1330,7 @@ mutation CreateCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1287,6 +1354,7 @@ mutation UpdateCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1310,6 +1378,7 @@ mutation DeleteCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1333,6 +1402,7 @@ mutation CreatePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1356,6 +1426,7 @@ mutation UpdatePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1379,6 +1450,7 @@ mutation DeletePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1402,6 +1474,7 @@ mutation CreateSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1425,6 +1498,7 @@ mutation UpdateSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1448,6 +1522,7 @@ mutation DeleteSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1471,6 +1546,7 @@ mutation CreateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1494,6 +1570,7 @@ mutation UpdateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1517,6 +1594,7 @@ mutation DeleteUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1537,6 +1615,7 @@ subscription OnCreateUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1552,6 +1631,7 @@ subscription OnUpdateUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1567,6 +1647,7 @@ subscription OnDeleteUPPERCASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1582,6 +1663,7 @@ subscription OnCreateLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1597,6 +1679,7 @@ subscription OnUpdateLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1612,6 +1695,7 @@ subscription OnDeleteLowercase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1627,6 +1711,7 @@ subscription OnCreateCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1642,6 +1727,7 @@ subscription OnUpdateCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1657,6 +1743,7 @@ subscription OnDeleteCamelCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1672,6 +1759,7 @@ subscription OnCreatePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1687,6 +1775,7 @@ subscription OnUpdatePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1702,6 +1791,7 @@ subscription OnDeletePascalCase
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1717,6 +1807,7 @@ subscription OnCreateSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1732,6 +1823,7 @@ subscription OnUpdateSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1747,6 +1839,7 @@ subscription OnDeleteSnake_case
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1762,6 +1855,7 @@ subscription OnCreateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1777,6 +1871,7 @@ subscription OnUpdateUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }
@@ -1792,6 +1887,7 @@ subscription OnDeleteUPPER_SNAKE_CASE
     owner
     createdAt
     updatedAt
+    __typename
     
   }
 }

--- a/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
+++ b/packages/graphql-docs-generator/__tests__/generator/getFields.test.ts
@@ -26,7 +26,7 @@ describe('getField', () => {
 
   it('should support simple scalar', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false })).toEqual({
+    expect(getFields(queries.foo, schema, 3, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
       name: 'foo',
       fields: [],
       fragments: [],
@@ -37,7 +37,49 @@ describe('getField', () => {
 
   it('it should recursively resolve fields up to max depth', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false })).toEqual({
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toEqual({
+      name: 'nested',
+      fields: [
+        {
+          name: 'level',
+          fields: [],
+          fragments: [],
+          hasBody: false,
+        },
+        {
+          name: 'subObj',
+          fields: [
+            {
+              name: 'level',
+              fields: [],
+              fragments: [],
+              hasBody: false,
+            },
+            {
+              name: '__typename',
+              fields: [],
+              fragments: [],
+              hasBody: false,
+            },
+          ],
+          fragments: [],
+          hasBody: true,
+        },
+        {
+          name: '__typename',
+          fields: [],
+          fragments: [],
+          hasBody: false,
+        },
+      ],
+      fragments: [],
+      hasBody: true,
+    });
+  });
+
+  it('it should recorsively resolve fields without typename when typenameIntrospection is disabled', () => {
+    const queries = schema.getQueryType().getFields();
+    expect(getFields(queries.nested, schema, 2, { useExternalFragmentForS3Object: false, typenameIntrospection: false })).toEqual({
       name: 'nested',
       fields: [
         {
@@ -67,7 +109,7 @@ describe('getField', () => {
 
   it('should not return anything for complex type when the depth is < 1', () => {
     const queries = schema.getQueryType().getFields();
-    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false })).toBeUndefined();
+    expect(getFields(queries.nested, schema, 0, { useExternalFragmentForS3Object: false, typenameIntrospection: true })).toBeUndefined();
   });
   describe('When type is an Interface', () => {
     beforeEach(() => {
@@ -111,7 +153,10 @@ describe('getField', () => {
     it('interface - should return fragments of all the implementations', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().shapeInterface, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -168,7 +213,10 @@ describe('getField', () => {
     it('union - should return fragments of all the types', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().shapeResult, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 
@@ -211,7 +259,7 @@ describe('getField', () => {
         buckets: { type: aggregateBucketResultItem },
       },
     });
-    
+
     const aggregateResult = new GraphQLUnionType({
       name: 'SearchableAggregateGenericResult',
       types: [aggregateScalarResult, aggregateBucketResult],
@@ -237,7 +285,10 @@ describe('getField', () => {
     it('aggregateItems property should traverse two additional levels to generate required fields with default depth 2', () => {
       const maxDepth = 2;
       const getPossibleTypeSpy = jest.spyOn(schema, 'getPossibleTypes');
-      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, { useExternalFragmentForS3Object: false });
+      getFields(schema.getQueryType().getFields().aggregateItems, schema, maxDepth, {
+        useExternalFragmentForS3Object: false,
+        typenameIntrospection: true,
+      });
       expect(getPossibleTypeSpy).toHaveBeenCalled();
       expect(getFragment).toHaveBeenCalled();
 

--- a/packages/graphql-docs-generator/src/cli.ts
+++ b/packages/graphql-docs-generator/src/cli.ts
@@ -31,10 +31,14 @@ export function run(argv: Array<String>): void {
           default: 2,
           normalize: true,
           type: 'number',
-        }
+        },
+        typenameIntrospection: {
+          default: true,
+          type: 'boolean',
+        },
       },
       async argv => {
-        generateGraphQLDocuments(argv.schema, { maxDepth: argv.maxDepth });
+        generateGraphQLDocuments(argv.schema, { maxDepth: argv.maxDepth, typenameIntrospection: argv.typenameIntrospection });
       }
     )
     .help()

--- a/packages/graphql-docs-generator/src/generator/types.ts
+++ b/packages/graphql-docs-generator/src/generator/types.ts
@@ -72,7 +72,8 @@ export type GQLAllOperations = {
 };
 
 export type GQLDocsGenOptions = {
-  useExternalFragmentForS3Object: boolean,
+  useExternalFragmentForS3Object: boolean;
+  typenameIntrospection: boolean;
 };
 
 export enum SchemaType {

--- a/packages/graphql-docs-generator/src/index.ts
+++ b/packages/graphql-docs-generator/src/index.ts
@@ -6,11 +6,12 @@ export { buildSchema } from './generator/utils/loading';
 
 export function generateGraphQLDocuments(
   schema: string,
-  options: { maxDepth?: number, useExternalFragmentForS3Object?: boolean; },
+  options: { maxDepth?: number, useExternalFragmentForS3Object?: boolean; typenameIntrospection?: boolean },
 ): GeneratedOperations {
   const opts = {
     maxDepth: 2,
     useExternalFragmentForS3Object: true,
+    typenameIntrospection: true,
     ...options,
   };
 
@@ -18,6 +19,7 @@ export function generateGraphQLDocuments(
 
   const gqlOperations: GQLAllOperations = generateAllOps(extendedSchema, opts.maxDepth, {
     useExternalFragmentForS3Object: opts.useExternalFragmentForS3Object,
+    typenameIntrospection: opts.typenameIntrospection
   });
   registerPartials();
   registerHelpers();


### PR DESCRIPTION
* Revert "fix: codegen downgrade to version 3 (#589)"

This reverts commit c1f9f36979691dfba3dd3db1c4a516aeeb29c41e.

* fix: use hard code codegen version in schema.js

* fix lint

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.