### PR TITLE
chore: fix e2e tests related to flutter pubspec file

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/init/amplifyPull.ts
+++ b/packages/amplify-codegen-e2e-core/src/init/amplifyPull.ts
@@ -116,8 +116,7 @@ function initializeFrontend(chain: ExecutionContext, config: AmplifyFrontendConf
   switch (config.frontendType) {
     case AmplifyFrontend.android:
       chain
-        .send('j')
-        .sendCarriageReturn()
+        .sendLine('android')
         .wait('Where is your Res directory')
         .sendCarriageReturn()
       return;

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -34,7 +34,8 @@
     "graphql-tag": "^2.10.1",
     "lodash": "^4.17.19",
     "uuid": "^3.4.0",
-    "yargs": "^15.1.0"
+    "yargs": "^15.1.0",
+    "js-yaml": "^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.0",

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
@@ -116,6 +116,10 @@ describe('Amplify pull in sandbox app with codegen tests', () => {
     it(`should pull sandbox, download schema and generate models without deleting user files in ${config.frontendType} project`, async () => {
       //generate pre existing user file
       const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);
+      // Flutter projects need min dart version to be met for modelgen to succeed.
+      if (config?.frontendType === AmplifyFrontend.flutter) {
+        createPubspecLockFile(projectRoot);
+      };
       //pull sandbox app
       await amplifyPullSandbox(projectRoot, {
         appType: config.frontendType,

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/pull-codegen.test.ts
@@ -17,12 +17,14 @@ import {
   getAdminApp,
   amplifyPullSandbox,
   getProjectSchema,
+  AmplifyFrontend,
 } from '@aws-amplify/amplify-codegen-e2e-core';
 import { existsSync } from 'fs';
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';
 import { JSONUtilities } from '@aws-amplify/amplify-cli-core';
 import { SandboxApp } from '../types/SandboxApp';
+import { createPubspecLockFile } from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';
 const envName = 'pulltest';
@@ -72,6 +74,10 @@ describe('Amplify pull in amplify app with codegen tests', () => {
       it(`should generate models and do not delete user files by amplify pull in an empty folder of ${config.frontendType} app`, async () => {
         //generate pre existing user file
         const userSourceCodePath = generateSourceCode(emptyProjectRoot, config.srcDir);
+        // Flutter projects need min dart version to be met for modelgen to succeed.
+        if (config?.frontendType === AmplifyFrontend.flutter) {
+          createPubspecLockFile(emptyProjectRoot);
+        };
         //amplify pull in a new project
         await amplifyPull(emptyProjectRoot, { emptyDir: true, appId, frontendConfig: config });
         expect(existsSync(userSourceCodePath)).toBe(true);

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -4,11 +4,13 @@ import {
     updateApiSchema,
     createRandomName,
     generateModels,
-    AmplifyFrontendConfig
+    AmplifyFrontendConfig,
+    AmplifyFrontend
 } from '@aws-amplify/amplify-codegen-e2e-core';
-import { existsSync } from "fs";
+import { existsSync, writeFileSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir, generateSourceCode } from '../utils';
+const yaml = require('js-yaml');
 
 export async function testCodegenModels(config: AmplifyFrontendConfig, projectRoot: string, schema: string, outputDir?: string) {
     const name = createRandomName();
@@ -28,9 +30,28 @@ export async function testCodegenModels(config: AmplifyFrontendConfig, projectRo
 
     // pre-existing file should still exist
     expect(existsSync(userSourceCodePath)).toBe(true);
+
+    // For flutter frontend, we need to have a pubspec lock file with supported dart version
+    if (config?.frontendType === AmplifyFrontend.flutter) {
+        createPubspecLockFile(projectRoot);
+    }
     // datastore models are generated at correct location
     const dirToCheck = outputDir
         ? path.join(projectRoot, outputDir)
         : path.join(projectRoot, config.modelgenDir);
     expect(isNotEmptyDir(dirToCheck)).toBe(true);
 }
+
+export const createPubspecLockFile = (projectRoot: string) => {
+    const lockFile = {
+        packages: {
+          amplify_flutter: {
+            version: '2.0.0'
+          },
+        },
+    };
+    const pubspecPath = path.join(projectRoot, 'pubspec.lock');
+    if (!existsSync(pubspecPath)) {
+        writeFileSync(pubspecPath, yaml.dump(lockFile));
+    }
+};

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/datastore-modelgen.ts
@@ -25,16 +25,17 @@ export async function testCodegenModels(config: AmplifyFrontendConfig, projectRo
     //generate pre existing user file
     const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);
 
+    // For flutter frontend, we need to have a pubspec lock file with supported dart version
+    if (config?.frontendType === AmplifyFrontend.flutter) {
+        createPubspecLockFile(projectRoot);
+    }
+
     //generate models
     await expect(generateModels(projectRoot, outputDir)).resolves.not.toThrow();
 
     // pre-existing file should still exist
     expect(existsSync(userSourceCodePath)).toBe(true);
 
-    // For flutter frontend, we need to have a pubspec lock file with supported dart version
-    if (config?.frontendType === AmplifyFrontend.flutter) {
-        createPubspecLockFile(projectRoot);
-    }
     // datastore models are generated at correct location
     const dirToCheck = outputDir
         ? path.join(projectRoot, outputDir)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Flutter apps require a `pubspec.lock` file in their project before running modelgen as it is supported for only dart versions above `0.6.0`. This change adds that step. https://github.com/aws-amplify/amplify-codegen/pull/576

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Full e2e now pass as seen from the checks


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.