### PR TITLE
Fix add codegen from a non-amplify application

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -31,11 +31,7 @@ export function generateStatementsAndTypes(cwd: string) : Promise<void> {
 // CLI workflow to add codegen to Amplify project
 export function addCodegen(cwd: string, settings: any = {}): Promise<void> {
   return new Promise((resolve, reject) => {
-    const cmdOptions = ['codegen', 'add'];
-    if (settings.withoutInit) {
-      cmdOptions.push('--apiId', 'mockapiid');
-    }
-    const chain = spawn(getCLIPath(), cmdOptions, { cwd, stripColors: true });
+    const chain = spawn(getCLIPath(), ['codegen', 'add'], { cwd, stripColors: true });
     if (settings.isAPINotAdded) {
       chain.wait("There are no GraphQL APIs available.");
       chain.wait("Add by running $amplify api add");
@@ -45,13 +41,6 @@ export function addCodegen(cwd: string, settings: any = {}): Promise<void> {
     }
     else {
       if (settings.frontendType === AmplifyFrontend.javascript) {
-        if (settings.withoutInit) {
-          chain
-          .wait("Choose the type of app that you're building")
-          .sendCarriageReturn()
-          .wait('What javascript framework are you using')
-          .sendCarriageReturn()
-        }
         chain.wait('Choose the code generation language target').sendCarriageReturn();
       }
       chain

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -45,6 +45,13 @@ export function addCodegen(cwd: string, settings: any = {}): Promise<void> {
     }
     else {
       if (settings.frontendType === AmplifyFrontend.javascript) {
+        if (settings.withoutInit) {
+          chain
+          .wait("Choose the type of app that you're building")
+          .sendCarriageReturn()
+          .wait('What javascript framework are you using')
+          .sendCarriageReturn()
+        }
         chain.wait('Choose the code generation language target').sendCarriageReturn();
       }
       chain

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -174,10 +174,6 @@ export function addCodegenNonAmplifyJS(cwd: string): Promise<void> {
       .wait('Do you want to generate/update all possible GraphQL operations')
       .sendLine('y')
       .wait('Enter maximum statement depth [increase from default if your schema is deeply')
-      .sendCarriageReturn()
-      .wait('Enter the file name for the generated code')
-      .sendCarriageReturn()
-      .wait('Do you want to generate code for your newly created GraphQL API')
       .sendCarriageReturn();
 
     chain.run((err: Error) => {

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -158,3 +158,35 @@ export function generateModelIntrospection(cwd: string, settings: { outputDir?: 
   });
 }
 
+// CLI workflow to add codegen to non-Amplify JS project
+export function addCodegenNonAmplifyJS(cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cmdOptions = ['codegen', 'add', '--apiId', 'mockapiid'];
+    const chain = spawn(getCLIPath(), cmdOptions, { cwd, stripColors: true });
+    chain
+      .wait("Choose the type of app that you're building")
+      .sendCarriageReturn()
+      .wait('What javascript framework are you using')
+      .sendCarriageReturn()
+      .wait('Choose the code generation language target').sendCarriageReturn()
+      .wait('Enter the file name pattern of graphql queries, mutations and subscriptions')
+      .sendCarriageReturn()
+      .wait('Do you want to generate/update all possible GraphQL operations')
+      .sendLine('y')
+      .wait('Enter maximum statement depth [increase from default if your schema is deeply')
+      .sendCarriageReturn()
+      .wait('Enter the file name for the generated code')
+      .sendCarriageReturn()
+      .wait('Do you want to generate code for your newly created GraphQL API')
+      .sendCarriageReturn();
+
+    chain.run((err: Error) => {
+      if (!err) {
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
+

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -31,7 +31,11 @@ export function generateStatementsAndTypes(cwd: string) : Promise<void> {
 // CLI workflow to add codegen to Amplify project
 export function addCodegen(cwd: string, settings: any = {}): Promise<void> {
   return new Promise((resolve, reject) => {
-    const chain = spawn(getCLIPath(), ['codegen', 'add'], { cwd, stripColors: true });
+    const cmdOptions = ['codegen', 'add'];
+    if (settings.withoutInit) {
+      cmdOptions.push('--apiId', 'mockapiid');
+    }
+    const chain = spawn(getCLIPath(), cmdOptions, { cwd, stripColors: true });
     if (settings.isAPINotAdded) {
       chain.wait("There are no GraphQL APIs available.");
       chain.wait("Add by running $amplify api add");

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
@@ -5,7 +5,8 @@ import {
     DEFAULT_JS_CONFIG,
     createRandomName,
     addApiWithoutSchema,
-    updateApiSchema
+    updateApiSchema,
+    addCodegenNonAmplifyJS
 } from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync, writeFileSync } from "fs";
 import path from 'path';
@@ -95,8 +96,7 @@ describe('codegen add tests - JS', () => {
         writeFileSync(schemaPath, testSchema);
 
         // add codegen without init
-        const settings = { withoutInit: true, ...config };
-        await expect(addCodegen(projectRoot, settings)).resolves.not.toThrow();
+        await expect(addCodegenNonAmplifyJS(projectRoot)).resolves.not.toThrow();
 
         // pre-existing file should still exist
         expect(existsSync(userSourceCodePath)).toBe(true);

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
@@ -7,7 +7,7 @@ import {
     addApiWithoutSchema,
     updateApiSchema
 } from "@aws-amplify/amplify-codegen-e2e-core";
-import { existsSync } from "fs";
+import { existsSync, writeFileSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';
 import { deleteAmplifyProject, testAddCodegen, testSetupBeforeAddCodegen, 
@@ -71,5 +71,38 @@ describe('codegen add tests - JS', () => {
 
     it(`Adding codegen works as expected`, async () => {
         await testAddCodegen(config, projectRoot, schema);
+    });
+
+    it(`Adding codegen outside of Amplify project`, async () => {
+        // init project and add API category
+        const testSchema = `
+        type Query {
+            echo: String
+        }
+
+        type Mutation {
+            mymutation: String
+        }
+
+        type Subscription {
+            mysub: String
+        }          
+        `;
+
+        // Setup the non-amplify project with schema and pre-existing files
+        const userSourceCodePath = testSetupBeforeAddCodegen(projectRoot, config);
+        const schemaPath = path.join(projectRoot, 'schema.graphql');
+        writeFileSync(schemaPath, testSchema);
+
+        // add codegen without init
+        const settings = { withoutInit: true, ...config };
+        await expect(addCodegen(projectRoot, settings)).resolves.not.toThrow();
+
+        // pre-existing file should still exist
+        expect(existsSync(userSourceCodePath)).toBe(true);
+        // GraphQL statements are generated
+        expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
+        // graphql configuration should be added
+        expect(existsSync(getGraphQLConfigFilePath(projectRoot))).toBe(true);
     });
 });

--- a/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
+++ b/packages/amplify-codegen/src/codegen-config/AmplifyCodeGenConfig.js
@@ -7,18 +7,13 @@ const fs =  require('fs-extra');
 class AmplifyCodeGenConfig {
   static configFileName = '.graphqlconfig.yml';
 
-  constructor(projectPath, withoutInit = false) {
+  constructor(projectPath) {
     try {
       this.gqlConfig = graphQLConfig.getGraphQLConfig();
       this.fixOldConfig();
     } catch (e) {
       if (e instanceof graphQLConfig.ConfigNotFoundError) {
-        let projectRoot;
-        if (!withoutInit) {
-          projectRoot = projectPath || process.cwd();
-        } else {
-          projectRoot = process.cwd();
-        }
+        const projectRoot = projectPath || process.cwd();
         const configPath = join(projectRoot, '.graphqlconfig.yml');
         if(fs.existsSync(configPath)) {
           this.gqlConfig = graphQLConfig.getGraphQLConfig(projectRoot);

--- a/packages/amplify-codegen/src/codegen-config/index.js
+++ b/packages/amplify-codegen/src/codegen-config/index.js
@@ -6,8 +6,8 @@ let config = null;
 
 function loadConfig(context, withoutInit = false) {
   if (!config) {
-    const projectPath = context.amplify.getEnvInfo().projectPath;
-    config = new AmplifyCodeGenConfig(projectPath, withoutInit);
+    const projectPath = withoutInit ? undefined : context.amplify.getEnvInfo().projectPath;
+    config = new AmplifyCodeGenConfig(projectPath);
   }
   return config;
 }

--- a/packages/amplify-codegen/tests/codegen-config/index.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/index.test.js
@@ -13,7 +13,7 @@ const MOCK_CONTEXT = {
 describe('codegen-config', () => {
   it('is singleton', () => {
     loadConfig(MOCK_CONTEXT);
-    expect(AmplifyCodeGenConfig).toHaveBeenCalledWith(MOCK_PROJECT_ROOT, false);
+    expect(AmplifyCodeGenConfig).toHaveBeenCalledWith(MOCK_PROJECT_ROOT);
     loadConfig(MOCK_CONTEXT);
     expect(AmplifyCodeGenConfig).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Check if the project is initialized with Amplify before calling the `getEnvInfo` on the shared Amplify context.
This fixes the issue with running `add codegen --apiId <appsync-api-id>` command. The `apiId` input is optional.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Validated in non-amplify and amplify initialized JS applications.
Added e2e test


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.