### PR TITLE
chore: add unit test coverage thresholds

### DIFF
--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -44,6 +44,13 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 56,
+        "functions": 68,
+        "lines": 73
+      }
+    },
     "testURL": "http://localhost",
     "testRegex": "((\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [

--- a/packages/appsync-modelgen-plugin/package.json
+++ b/packages/appsync-modelgen-plugin/package.json
@@ -62,6 +62,13 @@
     "collectCoverageFrom": [
       "src/**/*.ts"
     ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "testRegex": "(src/__tests__/.*.test.ts)$",
     "globals": {
       "ts-jest": {

--- a/packages/graphql-docs-generator/package.json
+++ b/packages/graphql-docs-generator/package.json
@@ -53,6 +53,13 @@
     "collectCoverageFrom": [
       "src/**/*.ts"
     ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 64,
+        "functions": 71,
+        "lines": 80
+      }
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/packages/graphql-types-generator/package.json
+++ b/packages/graphql-types-generator/package.json
@@ -73,6 +73,13 @@
       "<rootDir>/src/polyfills.js"
     ],
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 79,
+        "functions": 80,
+        "lines": 80
+      }
+    },
     "testURL": "http://localhost",
     "setupFilesAfterEnv": [
       "<rootDir>/test/test-utils/matchers.ts"


### PR DESCRIPTION
#### Description of changes
Add unit test coverage thresholds (currently set to `min(curr_val, 80)`) to prevent reduction in unit test coverage.

Info on the coverage configuration can be found here https://jestjs.io/docs/27.x/configuration#coveragethreshold-object

Line coverage refers to what % of lines are covered in the given package (in average across all files, since we're using global)
Branch coverage refers to what % of code paths are covered in the given package (in average across all files, since we're using global)
Function coverage refers to what % of functions are covered in the given package (in average across all files, since we're using global)

#### Issue #, if available
N/A

#### Description of how you validated changes
Ran unit tests.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.