### PR TITLE
fix: Swift - Generate schema for non-models containing models correctly

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1290,3 +1290,45 @@ extension ModelPath where ModelType == task {
     }
 }"
 `;
+
+exports[`AppSyncSwiftVisitor Should render non-models containing models correctly 1`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Task: Embeddable {
+  var id: String?
+  var title: String
+  var todo: Todo?
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Should render non-models containing models correctly 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Task {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case todo
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let task = Task.keys
+    
+    model.pluralName = \\"Tasks\\"
+    
+    model.fields(
+      .id(),
+      .field(task.title, is: .required, ofType: .string),
+      .field(task.todo, is: .optional, ofType: .model(type: Todo.self))
+    )
+    }
+}"
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -591,6 +591,28 @@ describe('AppSyncSwiftVisitor', () => {
     expect(generatedTaskMetadata).toMatchSnapshot();
   });
 
+  it('Should render non-models containing models correctly', () => {
+    const schema = /* GraphQL */ `
+      type Todo @model {
+        id: ID!
+        title: String!
+      }
+
+      type Task {
+        id: ID
+        title: String!
+        todo: Todo
+      }
+    `;
+
+      const taskVisitor = getVisitor(schema, 'Task');
+      expect(taskVisitor.generate()).toMatchSnapshot();
+
+      const taskMetadataVisitor = getVisitor(schema, 'Task', CodeGenGenerateEnum.metadata);
+      const generatedTaskMetadata = taskMetadataVisitor.generate();
+      expect(generatedTaskMetadata).toMatchSnapshot();
+  });
+
   describe('connection', () => {
     describe('One to Many connection', () => {
       const schema = /* GraphQL */ `

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -650,7 +650,7 @@ export class AppSyncSwiftVisitor<
       if (isEnumType) {
         ofType = `.enum(type: ${typeName})`;
       } else if (isModelType) {
-        ofType = `.model(${typeName})`;
+        ofType = `.model(type: ${typeName})`;
       } else if (isNonModelType) {
         ofType = `.embedded(type: ${typeName})`;
       } else {


### PR DESCRIPTION
#### Description of changes
If a schema contains non-models types that contain models, they're not generated correctly in Swift, because of a missing label, and the code doesn't compile.
That scenario can happen if you have a custom resolver that returns a model along with other things.

#### Issue #, if available
-N/A-

#### Description of how you validated changes
- Added test
- Generated models locally

#### Checklist
- [X] PR description included
- [X] `yarn test` passes
- [X] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [X] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.