### PR TITLE
fix: use pinned api category version until CDK bump is complete

### DIFF
--- a/.circleci/config.base.yml
+++ b/.circleci/config.base.yml
@@ -59,6 +59,7 @@ install_cli_with_local_codegen: &install_cli
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
     npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/amplify-category-api@5.4.1
     amplify -v
     npm list --global --depth=1
     unsetNpmRegistryUrl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ install_cli_with_local_codegen: &ref_3
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
     npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/amplify-category-api@5.4.1
     amplify -v
     npm list --global --depth=1
     unsetNpmRegistryUrl

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -162,6 +162,7 @@ function _installCLIFromLocalRegistry {
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
     npm install -g @aws-amplify/cli-internal
+    npm install -g @aws-amplify/amplify-category-api@5.4.1
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'
     unsetNpmRegistryUrl


### PR DESCRIPTION
#### Description of changes
Currently a subset of e2e tests are failing due to the in-flight migration from CDK 2.68.0 to 2.80.0 in CLI. This is because CLI has a caret dep on the API category packages (which we probably shouldn't do) so when installing CLI-internal we're getting the latest minor version of API cateogyr, that has the newer references to CDK 2.80, but cli-internal does not. For reasons that are not yet super clear, mixing cdk versions across the CLI causes issues, and while that's not ideal, it's not the issue we're solving here, we just want a consistent state of the world for codegen e2e testing.

This is blocking verification of dependabot fixes,etc.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests https://app.circleci.com/pipelines/github/aws-amplify/amplify-codegen/3595/workflows/e697bd1f-b25e-4874-bbc4-ea05bf67606f

#### Checklist
- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.