### PR TITLE
feat: API.swift compatibility with AWSAPIPlugin

### DIFF
--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -10,12 +10,6 @@ batch:
       buildspec: .codebuild/build_linux.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-    - identifier: build_windows
-      buildspec: .codebuild/build_windows.yml
-      env:
-        type: WINDOWS_SERVER_2019_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        image: $WINDOWS_IMAGE_2019
     - identifier: test
       buildspec: .codebuild/test.yml
       env:

--- a/packages/graphql-types-generator/src/swift/appSyncCompatibilityTypes.ts
+++ b/packages/graphql-types-generator/src/swift/appSyncCompatibilityTypes.ts
@@ -48,7 +48,7 @@ public extension GraphQLMapConvertible {
 
 public typealias GraphQLID = String
 
-public protocol GraphQLOperation: AnyObject {
+public protocol APISwiftGraphQLOperation: AnyObject {
   
   static var operationString: String { get }
   static var requestString: String { get }
@@ -59,7 +59,7 @@ public protocol GraphQLOperation: AnyObject {
   associatedtype Data: GraphQLSelectionSet
 }
 
-public extension GraphQLOperation {
+public extension APISwiftGraphQLOperation {
   static var requestString: String {
     return operationString
   }
@@ -73,11 +73,11 @@ public extension GraphQLOperation {
   }
 }
 
-public protocol GraphQLQuery: GraphQLOperation {}
+public protocol GraphQLQuery: APISwiftGraphQLOperation {}
 
-public protocol GraphQLMutation: GraphQLOperation {}
+public protocol GraphQLMutation: APISwiftGraphQLOperation {}
 
-public protocol GraphQLSubscription: GraphQLOperation {}
+public protocol GraphQLSubscription: APISwiftGraphQLOperation {}
 
 public protocol GraphQLFragment: GraphQLSelectionSet {
   static var possibleTypes: [String] { get }

--- a/packages/graphql-types-generator/src/swift/appSyncCompatibilityTypes.ts
+++ b/packages/graphql-types-generator/src/swift/appSyncCompatibilityTypes.ts
@@ -1,0 +1,419 @@
+// Blank lines at the beginning are intentional
+export const appSyncCompatibilityTypesCode = `
+import Foundation
+
+public protocol GraphQLInputValue {
+}
+
+public struct GraphQLVariable {
+  let name: String
+  
+  public init(_ name: String) {
+    self.name = name
+  }
+}
+
+extension GraphQLVariable: GraphQLInputValue {
+}
+
+extension JSONEncodable {
+  public func evaluate(with variables: [String: JSONEncodable]?) throws -> Any {
+    return jsonValue
+  }
+}
+
+public typealias GraphQLMap = [String: JSONEncodable?]
+
+extension Dictionary where Key == String, Value == JSONEncodable? {
+  public var withNilValuesRemoved: Dictionary<String, JSONEncodable> {
+    var filtered = Dictionary<String, JSONEncodable>(minimumCapacity: count)
+    for (key, value) in self {
+      if value != nil {
+        filtered[key] = value
+      }
+    }
+    return filtered
+  }
+}
+
+public protocol GraphQLMapConvertible: JSONEncodable {
+  var graphQLMap: GraphQLMap { get }
+}
+
+public extension GraphQLMapConvertible {
+  var jsonValue: Any {
+    return graphQLMap.withNilValuesRemoved.jsonValue
+  }
+}
+
+public typealias GraphQLID = String
+
+public protocol GraphQLOperation: AnyObject {
+  
+  static var operationString: String { get }
+  static var requestString: String { get }
+  static var operationIdentifier: String? { get }
+  
+  var variables: GraphQLMap? { get }
+  
+  associatedtype Data: GraphQLSelectionSet
+}
+
+public extension GraphQLOperation {
+  static var requestString: String {
+    return operationString
+  }
+
+  static var operationIdentifier: String? {
+    return nil
+  }
+
+  var variables: GraphQLMap? {
+    return nil
+  }
+}
+
+public protocol GraphQLQuery: GraphQLOperation {}
+
+public protocol GraphQLMutation: GraphQLOperation {}
+
+public protocol GraphQLSubscription: GraphQLOperation {}
+
+public protocol GraphQLFragment: GraphQLSelectionSet {
+  static var possibleTypes: [String] { get }
+}
+
+public typealias Snapshot = [String: Any?]
+
+public protocol GraphQLSelectionSet: Decodable {
+  static var selections: [GraphQLSelection] { get }
+  
+  var snapshot: Snapshot { get }
+  init(snapshot: Snapshot)
+}
+
+extension GraphQLSelectionSet {
+    public init(from decoder: Decoder) throws {
+        if let jsonObject = try? APISwiftJSONValue(from: decoder) {
+            let encoder = JSONEncoder()
+            let jsonData = try encoder.encode(jsonObject)
+            let decodedDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
+            let optionalDictionary = decodedDictionary.mapValues { $0 as Any? }
+
+            self.init(snapshot: optionalDictionary)
+        } else {
+            self.init(snapshot: [:])
+        }
+    }
+}
+
+enum APISwiftJSONValue: Codable {
+    case array([APISwiftJSONValue])
+    case boolean(Bool)
+    case number(Double)
+    case object([String: APISwiftJSONValue])
+    case string(String)
+    case null
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let value = try? container.decode([String: APISwiftJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([APISwiftJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            self = .null
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        switch self {
+        case .array(let value):
+            try container.encode(value)
+        case .boolean(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+public protocol GraphQLSelection {
+}
+
+public struct GraphQLField: GraphQLSelection {
+  let name: String
+  let alias: String?
+  let arguments: [String: GraphQLInputValue]?
+  
+  var responseKey: String {
+    return alias ?? name
+  }
+  
+  let type: GraphQLOutputType
+  
+  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
+    self.name = name
+    self.alias = alias
+    
+    self.arguments = arguments
+    
+    self.type = type
+  }
+}
+
+public indirect enum GraphQLOutputType {
+  case scalar(JSONDecodable.Type)
+  case object([GraphQLSelection])
+  case nonNull(GraphQLOutputType)
+  case list(GraphQLOutputType)
+  
+  var namedType: GraphQLOutputType {
+    switch self {
+    case .nonNull(let innerType), .list(let innerType):
+      return innerType.namedType
+    case .scalar, .object:
+      return self
+    }
+  }
+}
+
+public struct GraphQLBooleanCondition: GraphQLSelection {
+  let variableName: String
+  let inverted: Bool
+  let selections: [GraphQLSelection]
+  
+  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
+    self.variableName = variableName
+    self.inverted = inverted;
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLTypeCondition: GraphQLSelection {
+  let possibleTypes: [String]
+  let selections: [GraphQLSelection]
+  
+  public init(possibleTypes: [String], selections: [GraphQLSelection]) {
+    self.possibleTypes = possibleTypes
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLFragmentSpread: GraphQLSelection {
+  let fragment: GraphQLFragment.Type
+  
+  public init(_ fragment: GraphQLFragment.Type) {
+    self.fragment = fragment
+  }
+}
+
+public struct GraphQLTypeCase: GraphQLSelection {
+  let variants: [String: [GraphQLSelection]]
+  let \`default\`: [GraphQLSelection]
+  
+  public init(variants: [String: [GraphQLSelection]], default: [GraphQLSelection]) {
+    self.variants = variants
+    self.default = \`default\`;
+  }
+}
+
+public typealias JSONObject = [String: Any]
+
+public protocol JSONDecodable {
+  init(jsonValue value: Any) throws
+}
+
+public protocol JSONEncodable: GraphQLInputValue {
+  var jsonValue: Any { get }
+}
+
+public enum JSONDecodingError: Error, LocalizedError {
+  case missingValue
+  case nullValue
+  case wrongType
+  case couldNotConvert(value: Any, to: Any.Type)
+  
+  public var errorDescription: String? {
+    switch self {
+    case .missingValue:
+      return "Missing value"
+    case .nullValue:
+      return "Unexpected null value"
+    case .wrongType:
+      return "Wrong type"
+    case .couldNotConvert(let value, let expectedType):
+      return "Could not convert \\"\\(value)\\" to \\(expectedType)"
+    }
+  }
+}
+
+extension String: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
+    }
+    self = string
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Int: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
+    }
+    self = number.intValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Float: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
+    }
+    self = number.floatValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Double: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
+    }
+    self = number.doubleValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Bool: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let bool = value as? Bool else {
+        throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
+    }
+    self = bool
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension RawRepresentable where RawValue: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    let rawValue = try RawValue(jsonValue: value)
+    if let tempSelf = Self(rawValue: rawValue) {
+      self = tempSelf
+    } else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
+    }
+  }
+}
+
+extension RawRepresentable where RawValue: JSONEncodable {
+  public var jsonValue: Any {
+    return rawValue.jsonValue
+  }
+}
+
+extension Optional where Wrapped: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    if value is NSNull {
+      self = .none
+    } else {
+      self = .some(try Wrapped(jsonValue: value))
+    }
+  }
+}
+
+extension Optional: JSONEncodable {
+  public var jsonValue: Any {
+    switch self {
+    case .none:
+      return NSNull()
+    case .some(let wrapped as JSONEncodable):
+      return wrapped.jsonValue
+    default:
+      fatalError("Optional is only JSONEncodable if Wrapped is")
+    }
+  }
+}
+
+extension Dictionary: JSONEncodable {
+  public var jsonValue: Any {
+    return jsonObject
+  }
+  
+  public var jsonObject: JSONObject {
+    var jsonObject = JSONObject(minimumCapacity: count)
+    for (key, value) in self {
+      if case let (key as String, value as JSONEncodable) = (key, value) {
+        jsonObject[key] = value.jsonValue
+      } else {
+        fatalError("Dictionary is only JSONEncodable if Value is (and if Key is String)")
+      }
+    }
+    return jsonObject
+  }
+}
+
+extension Array: JSONEncodable {
+  public var jsonValue: Any {
+    return map() { element -> (Any) in
+      if case let element as JSONEncodable = element {
+        return element.jsonValue
+      } else {
+        fatalError("Array is only JSONEncodable if Element is")
+      }
+    }
+  }
+}
+
+extension URL: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
+    }
+    self.init(string: string)!
+  }
+
+  public var jsonValue: Any {
+    return self.absoluteString
+  }
+}
+
+extension Dictionary {
+  static func += (lhs: inout Dictionary, rhs: Dictionary) {
+    lhs.merge(rhs) { (_, new) in new }
+  }
+}
+`;

--- a/packages/graphql-types-generator/src/swift/codeGeneration.ts
+++ b/packages/graphql-types-generator/src/swift/codeGeneration.ts
@@ -18,6 +18,7 @@ import { join, wrap } from '../utilities/printing';
 import { SwiftGenerator, Property, escapeIdentifierIfNeeded, Struct } from './language';
 import { Helpers } from './helpers';
 import { s3WrapperCode } from './s3Wrapper';
+import { appSyncCompatibilityTypesCode } from './appSyncCompatibilityTypes';
 import { isList } from '../utilities/graphql';
 
 import { typeCaseForSelectionSet, TypeCase, Variant } from '../compiler/visitors/typeCase';
@@ -120,7 +121,11 @@ export class SwiftAPIGenerator extends SwiftGenerator<CompilerContext> {
   fileHeader() {
     this.printOnNewline('//  This file was automatically generated and should not be edited.');
     this.printNewline();
+    this.printOnNewline('#if canImport(AWSAPIPlugin)');
+    this.print(appSyncCompatibilityTypesCode);
+    this.printOnNewline('#elseif canImport(AWSAppSync)');
     this.printOnNewline('import AWSAppSync');
+    this.printOnNewline('#endif');
   }
 
   classDeclarationForOperation(operation: Operation) {

--- a/packages/graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/packages/graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -675,7 +675,7 @@ public extension GraphQLMapConvertible {
 
 public typealias GraphQLID = String
 
-public protocol GraphQLOperation: AnyObject {
+public protocol APISwiftGraphQLOperation: AnyObject {
   
   static var operationString: String { get }
   static var requestString: String { get }
@@ -686,7 +686,7 @@ public protocol GraphQLOperation: AnyObject {
   associatedtype Data: GraphQLSelectionSet
 }
 
-public extension GraphQLOperation {
+public extension APISwiftGraphQLOperation {
   static var requestString: String {
     return operationString
   }
@@ -700,11 +700,11 @@ public extension GraphQLOperation {
   }
 }
 
-public protocol GraphQLQuery: GraphQLOperation {}
+public protocol GraphQLQuery: APISwiftGraphQLOperation {}
 
-public protocol GraphQLMutation: GraphQLOperation {}
+public protocol GraphQLMutation: APISwiftGraphQLOperation {}
 
-public protocol GraphQLSubscription: GraphQLOperation {}
+public protocol GraphQLSubscription: APISwiftGraphQLOperation {}
 
 public protocol GraphQLFragment: GraphQLSelectionSet {
   static var possibleTypes: [String] { get }

--- a/packages/graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
+++ b/packages/graphql-types-generator/test/swift/__snapshots__/codeGeneration.ts.snap
@@ -623,6 +623,432 @@ exports[`Swift code generation #classDeclarationForOperation() should generate a
 }"
 `;
 
+exports[`Swift code generation #fileHeader should generate a file header 1`] = `
+"//  This file was automatically generated and should not be edited.
+
+#if canImport(AWSAPIPlugin)
+import Foundation
+
+public protocol GraphQLInputValue {
+}
+
+public struct GraphQLVariable {
+  let name: String
+  
+  public init(_ name: String) {
+    self.name = name
+  }
+}
+
+extension GraphQLVariable: GraphQLInputValue {
+}
+
+extension JSONEncodable {
+  public func evaluate(with variables: [String: JSONEncodable]?) throws -> Any {
+    return jsonValue
+  }
+}
+
+public typealias GraphQLMap = [String: JSONEncodable?]
+
+extension Dictionary where Key == String, Value == JSONEncodable? {
+  public var withNilValuesRemoved: Dictionary<String, JSONEncodable> {
+    var filtered = Dictionary<String, JSONEncodable>(minimumCapacity: count)
+    for (key, value) in self {
+      if value != nil {
+        filtered[key] = value
+      }
+    }
+    return filtered
+  }
+}
+
+public protocol GraphQLMapConvertible: JSONEncodable {
+  var graphQLMap: GraphQLMap { get }
+}
+
+public extension GraphQLMapConvertible {
+  var jsonValue: Any {
+    return graphQLMap.withNilValuesRemoved.jsonValue
+  }
+}
+
+public typealias GraphQLID = String
+
+public protocol GraphQLOperation: AnyObject {
+  
+  static var operationString: String { get }
+  static var requestString: String { get }
+  static var operationIdentifier: String? { get }
+  
+  var variables: GraphQLMap? { get }
+  
+  associatedtype Data: GraphQLSelectionSet
+}
+
+public extension GraphQLOperation {
+  static var requestString: String {
+    return operationString
+  }
+
+  static var operationIdentifier: String? {
+    return nil
+  }
+
+  var variables: GraphQLMap? {
+    return nil
+  }
+}
+
+public protocol GraphQLQuery: GraphQLOperation {}
+
+public protocol GraphQLMutation: GraphQLOperation {}
+
+public protocol GraphQLSubscription: GraphQLOperation {}
+
+public protocol GraphQLFragment: GraphQLSelectionSet {
+  static var possibleTypes: [String] { get }
+}
+
+public typealias Snapshot = [String: Any?]
+
+public protocol GraphQLSelectionSet: Decodable {
+  static var selections: [GraphQLSelection] { get }
+  
+  var snapshot: Snapshot { get }
+  init(snapshot: Snapshot)
+}
+
+extension GraphQLSelectionSet {
+    public init(from decoder: Decoder) throws {
+        if let jsonObject = try? APISwiftJSONValue(from: decoder) {
+            let encoder = JSONEncoder()
+            let jsonData = try encoder.encode(jsonObject)
+            let decodedDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
+            let optionalDictionary = decodedDictionary.mapValues { $0 as Any? }
+
+            self.init(snapshot: optionalDictionary)
+        } else {
+            self.init(snapshot: [:])
+        }
+    }
+}
+
+enum APISwiftJSONValue: Codable {
+    case array([APISwiftJSONValue])
+    case boolean(Bool)
+    case number(Double)
+    case object([String: APISwiftJSONValue])
+    case string(String)
+    case null
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let value = try? container.decode([String: APISwiftJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([APISwiftJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            self = .null
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        switch self {
+        case .array(let value):
+            try container.encode(value)
+        case .boolean(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+public protocol GraphQLSelection {
+}
+
+public struct GraphQLField: GraphQLSelection {
+  let name: String
+  let alias: String?
+  let arguments: [String: GraphQLInputValue]?
+  
+  var responseKey: String {
+    return alias ?? name
+  }
+  
+  let type: GraphQLOutputType
+  
+  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
+    self.name = name
+    self.alias = alias
+    
+    self.arguments = arguments
+    
+    self.type = type
+  }
+}
+
+public indirect enum GraphQLOutputType {
+  case scalar(JSONDecodable.Type)
+  case object([GraphQLSelection])
+  case nonNull(GraphQLOutputType)
+  case list(GraphQLOutputType)
+  
+  var namedType: GraphQLOutputType {
+    switch self {
+    case .nonNull(let innerType), .list(let innerType):
+      return innerType.namedType
+    case .scalar, .object:
+      return self
+    }
+  }
+}
+
+public struct GraphQLBooleanCondition: GraphQLSelection {
+  let variableName: String
+  let inverted: Bool
+  let selections: [GraphQLSelection]
+  
+  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
+    self.variableName = variableName
+    self.inverted = inverted;
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLTypeCondition: GraphQLSelection {
+  let possibleTypes: [String]
+  let selections: [GraphQLSelection]
+  
+  public init(possibleTypes: [String], selections: [GraphQLSelection]) {
+    self.possibleTypes = possibleTypes
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLFragmentSpread: GraphQLSelection {
+  let fragment: GraphQLFragment.Type
+  
+  public init(_ fragment: GraphQLFragment.Type) {
+    self.fragment = fragment
+  }
+}
+
+public struct GraphQLTypeCase: GraphQLSelection {
+  let variants: [String: [GraphQLSelection]]
+  let \`default\`: [GraphQLSelection]
+  
+  public init(variants: [String: [GraphQLSelection]], default: [GraphQLSelection]) {
+    self.variants = variants
+    self.default = \`default\`;
+  }
+}
+
+public typealias JSONObject = [String: Any]
+
+public protocol JSONDecodable {
+  init(jsonValue value: Any) throws
+}
+
+public protocol JSONEncodable: GraphQLInputValue {
+  var jsonValue: Any { get }
+}
+
+public enum JSONDecodingError: Error, LocalizedError {
+  case missingValue
+  case nullValue
+  case wrongType
+  case couldNotConvert(value: Any, to: Any.Type)
+  
+  public var errorDescription: String? {
+    switch self {
+    case .missingValue:
+      return \\"Missing value\\"
+    case .nullValue:
+      return \\"Unexpected null value\\"
+    case .wrongType:
+      return \\"Wrong type\\"
+    case .couldNotConvert(let value, let expectedType):
+      return \\"Could not convert \\\\\\"\\\\(value)\\\\\\" to \\\\(expectedType)\\"
+    }
+  }
+}
+
+extension String: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
+    }
+    self = string
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Int: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
+    }
+    self = number.intValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Float: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
+    }
+    self = number.floatValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Double: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
+    }
+    self = number.doubleValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Bool: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let bool = value as? Bool else {
+        throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
+    }
+    self = bool
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension RawRepresentable where RawValue: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    let rawValue = try RawValue(jsonValue: value)
+    if let tempSelf = Self(rawValue: rawValue) {
+      self = tempSelf
+    } else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
+    }
+  }
+}
+
+extension RawRepresentable where RawValue: JSONEncodable {
+  public var jsonValue: Any {
+    return rawValue.jsonValue
+  }
+}
+
+extension Optional where Wrapped: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    if value is NSNull {
+      self = .none
+    } else {
+      self = .some(try Wrapped(jsonValue: value))
+    }
+  }
+}
+
+extension Optional: JSONEncodable {
+  public var jsonValue: Any {
+    switch self {
+    case .none:
+      return NSNull()
+    case .some(let wrapped as JSONEncodable):
+      return wrapped.jsonValue
+    default:
+      fatalError(\\"Optional is only JSONEncodable if Wrapped is\\")
+    }
+  }
+}
+
+extension Dictionary: JSONEncodable {
+  public var jsonValue: Any {
+    return jsonObject
+  }
+  
+  public var jsonObject: JSONObject {
+    var jsonObject = JSONObject(minimumCapacity: count)
+    for (key, value) in self {
+      if case let (key as String, value as JSONEncodable) = (key, value) {
+        jsonObject[key] = value.jsonValue
+      } else {
+        fatalError(\\"Dictionary is only JSONEncodable if Value is (and if Key is String)\\")
+      }
+    }
+    return jsonObject
+  }
+}
+
+extension Array: JSONEncodable {
+  public var jsonValue: Any {
+    return map() { element -> (Any) in
+      if case let element as JSONEncodable = element {
+        return element.jsonValue
+      } else {
+        fatalError(\\"Array is only JSONEncodable if Element is\\")
+      }
+    }
+  }
+}
+
+extension URL: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
+    }
+    self.init(string: string)!
+  }
+
+  public var jsonValue: Any {
+    return self.absoluteString
+  }
+}
+
+extension Dictionary {
+  static func += (lhs: inout Dictionary, rhs: Dictionary) {
+    lhs.merge(rhs) { (_, new) in new }
+  }
+}
+
+#elseif canImport(AWSAppSync)
+import AWSAppSync
+#endif"
+`;
+
 exports[`Swift code generation #initializerDeclarationForProperties() should generate initializer for a property 1`] = `
 "public init(episode: Episode) {
   self.episode = episode

--- a/packages/graphql-types-generator/test/swift/codeGeneration.ts
+++ b/packages/graphql-types-generator/test/swift/codeGeneration.ts
@@ -21,6 +21,14 @@ describe('Swift code generation', () => {
     return context;
   }
 
+  describe('#fileHeader', () => {
+    it('should generate a file header', () => {
+      generator.fileHeader();
+
+      expect(generator.output).toMatchSnapshot();
+    });
+  });
+
   describe('#classDeclarationForOperation()', () => {
     it(`should generate a class declaration for a query with variables`, () => {
       const { operations } = compile(`


### PR DESCRIPTION
#### Description of changes
Currently developers that have an AppSync backend that was not provisioned with Amplify CLI can still generate the **API.swift** file from the introspection schema. This file has a hard dependency on [iOS AppSync SDK client.](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/). The top of API.swift contains `imports AWSAppSync`.

This file is pretty useful as it contains all the different operations available and  components to successfully make a request, but cannot be used with Amplify's APIPlugin. This PR makes the API.swift file compatible with Amplify AWSAPIPlugin, removing the dependency on AppSync SDK.
1. If can import AWSAPIPlugin, declare the types required to compile API.swift in-line. The required types were extracted out of AWSAppSync SDK codebase. Additionally, the Data types were made decodable, to allow them to be passed to Amplify.GraphQLRequest as the type to decode to.
2. Fallback to importing AWSAppSync. This is to allow backwards compatibility with existing app clients. Developers may continue to their existing workflow in updating their schema, and regenerate the API.swift file, while not having to change their code to use AWSAPIPlugin.

We considered that if the developer has AppSync SDK and Amplify already in the same app, and **API.swift** was compilng due to AppSync SDK. The developer is most likely using AppSync SDK to interact with the backend, while the rest of Amplify (excluding AWSAPIPlugin) for the remaining plugins. If they did not add AWSAPIPlugin, there's no impact and they can upgrade to use AWSAPIPlugin when they are ready to.

if AWSAPIPlugin was added, it may have been
1. Added accidentally and unused, developer may have to remove the AWSPIPlugin so it continues to compile with AWSAppSync import, or upgrade to AWSAPIPlugin call pattern in their code.
2. The developer is using AWSAPIPlugin's REST APIs and AWSAppSync SDK. We believe the number of customers in this use case is near zero. Because we think this is an edge case, the path to unblock the customer is that they will have to upgrade to use AWSAPIPlugin, or modify the API.swift to reverse the changes to import AWSAppSync instead.
3. The developer is using AWSAPIPlugin's GraphQL requests already, and included AppSync SDK to compile the API.swift successfully. The developer can now remove AppSync SDK as it is an unused dependency. 

The upgrade guide is meant for both existing customers to move to AWSAPIPlugin and new customers that have built AppSync backends without using the Amplify's provisioning, see upgrade guide PR for more details: https://github.com/aws-amplify/docs/pull/5649

#### Issue #, if available

#### Description of how you validated changes

Local testing:
```
nvm use v14 && yarn clean && rm -rf node_modules && yarn && yarn build && yarn test
```

`amplify-dev` testing
```
nvm use 16.14.0 && yarn setup-dev
```


We validate the new API.swift file compiles and works during runtime by the integration tests in the following PRs:
- https://github.com/aws-amplify/amplify-swift/pull/3098

### Tagged release

`@aws-amplify/cli@12.2.1-swift-codegen.0`

example of CLI required changes to create CLI tagged release: https://github.com/aws-amplify/amplify-cli/commit/3e4d27a8620e51d322ea572da05a265bf6aab470

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.