### PR TITLE
chore: increase timeout for github workflow run

### DIFF
--- a/.codebuild/scripts/run-ios-modelgen-e2e-test.sh
+++ b/.codebuild/scripts/run-ios-modelgen-e2e-test.sh
@@ -52,11 +52,11 @@ main() {
     latest_run_id=$(get_latest_run_id)
     echo "Latest run ID: $latest_run_id"
     run_status=$(get_run_status "$latest_run_id")
-    timeout=$((SECONDS + 600))  # 600 seconds = 10 minutes
+    timeout=$((SECONDS + 1200))  # 1200 seconds = 20 minutes
 
     # Continuously check for status until completion
     while [[ "$run_status" != "completed"  && "$SECONDS" -lt "$timeout" ]]; do
-        echo "Test run status: $latest_status"
+        echo "Test run status: $run_status"
         sleep 10 # Wait before checking again
         run_status=$(get_run_status "$latest_run_id")
     done

--- a/.github/workflows/build-swift-modelgen.yml
+++ b/.github/workflows/build-swift-modelgen.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   Build-Swift-Modelgen:
-    name: Analyze
+    name: Build
     runs-on: macos-13-xl
     permissions:
       actions: read


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Increase timeout for polling the status of Github workflow that compiles the generated Swift models.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
[The latest run](https://github.com/aws-amplify/amplify-codegen/actions/runs/5581585863) was successful but took ~13 mins to complete.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.