### PR TITLE
chore: fix FF not initialized error

### DIFF
--- a/.codebuild/release_workflow.yml
+++ b/.codebuild/release_workflow.yml
@@ -30,4 +30,4 @@ batch:
       buildspec: .codebuild/deploy.yml
       depend-on:
         - test
-        - build-windows
+        - build_windows

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-amplify/amplify-cli-core": "^4.0.6",
+    "@aws-amplify/amplify-cli-core": "^4.0.4",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
     "@commitlint/config-lerna-scopes": "^17.0.2",
@@ -113,6 +113,7 @@
     "execa": "^5.1.1"
   },
   "resolutions": {
+    "@aws-amplify/amplify-cli-core": "4.0.4",
     "minimist": "^1.2.6",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,39 +40,20 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-"@aws-amplify/amplify-cli-core@^4.0.6":
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-core/-/amplify-cli-core-4.1.0.tgz#d851ce760271a767c72d93862ab24493f1effc4d"
-  integrity sha512-m9EiXMkgVMGDjAd71784NbYx4dWmu1SeFmkanx40X+nx1Bg8koYIUEAuUuTQkFFYpyBy/wwooJudatNTv1V25g==
+"@aws-amplify/amplify-cli-core@4.0.4", "@aws-amplify/amplify-cli-core@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-core/-/amplify-cli-core-4.0.4.tgz#6c00c3e847a39c2627e6f62375863d655ed5eedc"
+  integrity sha512-LwHV9e1Q+wSddYr9rHl1TXU9DBRePy3C6ewCMqdRAY0ys2qp6loyyZbU+eppHBTubpxE+/nrc42Im2uii//MzQ==
   dependencies:
-    "@aws-amplify/amplify-cli-logger" "1.3.3"
-    "@aws-amplify/amplify-prompts" "2.8.0"
-    "@aws-amplify/graphql-transformer-interfaces" "^2.2.1"
-    "@yarnpkg/lockfile" "^1.1.0"
-    ajv "^6.12.6"
-    aws-cdk-lib "~2.68.0"
-    chalk "^4.1.1"
-    ci-info "^2.0.0"
-    cli-table3 "^0.6.0"
-    cloudform-types "^4.2.0"
-    colors "1.4.0"
-    dotenv "^8.2.0"
-    ejs "^3.1.7"
-    execa "^5.1.1"
-    fs-extra "^8.1.0"
-    globby "^11.0.3"
-    hjson "^3.2.1"
-    inquirer "^7.3.3"
-    js-yaml "^4.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.7"
-    open "^8.4.0"
-    ora "^4.0.3"
-    proxy-agent "^5.0.0"
-    semver "^7.3.5"
-    typescript-json-schema "~0.52.0"
-    which "^2.0.2"
-    yaml "^2.2.2"
+    amplify-cli-core "4.0.4"
+
+"@aws-amplify/amplify-cli-logger@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-logger/-/amplify-cli-logger-1.3.2.tgz#802667e38276361b78d138a770f6e9f1a009d3a3"
+  integrity sha512-dQ7Dwh2MNIjhnqx+c48aDjsrsTMU391n23sF5fRyxoC+tmxvaMbz3N3g6XeciwNb1OB5zMBI5zCAjbm94k1S+A==
+  dependencies:
+    winston "^3.3.3"
+    winston-daily-rotate-file "^4.5.0"
 
 "@aws-amplify/amplify-cli-logger@1.3.3":
   version "1.3.3"
@@ -82,10 +63,27 @@
     winston "^3.3.3"
     winston-daily-rotate-file "^4.5.0"
 
+"@aws-amplify/amplify-cli-shared-interfaces@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-shared-interfaces/-/amplify-cli-shared-interfaces-1.2.2.tgz#e717ef421379837519ed6cba42226874574fe505"
+  integrity sha512-iZZAhfPUBRZr5b4S5YnpN98oYQfZSMMxo0J/fpDQ7mh3CFOGdWcg6vIU3M9tqGZWUNYi3P0MkzreOgDE+9yJ6A==
+
 "@aws-amplify/amplify-cli-shared-interfaces@1.2.3":
   version "1.2.3"
   resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-shared-interfaces/-/amplify-cli-shared-interfaces-1.2.3.tgz#01afc1508e11faadeb5d45298e8b5c486dc272b0"
   integrity sha512-c/c82OMAFZvgjkfeMFE/h1ycqC7218IfeVNLN7rVGMS98hRs810zRXvFc1w8uI+zwUiDV8+bzAuzODqt5aC9iA==
+
+"@aws-amplify/amplify-function-plugin-interface@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-function-plugin-interface/-/amplify-function-plugin-interface-1.11.0.tgz#f09bbfdd16677c35e8455a9cb7b0cb658f58a7bc"
+  integrity sha512-X0Ywl6zBd54XOiWDGakaoCKogTtU7wR+s+8egmQuBMYJK/kW+apvyPGI7wdXGommwXYs1Hs1vr61V+h/+Rbfig==
+
+"@aws-amplify/amplify-prompts@2.6.8":
+  version "2.6.8"
+  resolved "https://registry.npmjs.org/@aws-amplify/amplify-prompts/-/amplify-prompts-2.6.8.tgz#9f5975ffa76d4ea3187b053f39c0d99e96d0d342"
+  integrity sha512-s3xtMgVOWlxyIPPTXF1s1BD/4r7jTEO1vsPEc//HrlB3hPJdZ6cKrDb3cXsbkGUJnrmU6UwEmManwNozrmKzWg==
+  dependencies:
+    amplify-prompts "2.6.8"
 
 "@aws-amplify/amplify-prompts@2.8.0":
   version "2.8.0"
@@ -226,10 +224,17 @@
     object-hash "^3.0.0"
     ts-dedent "^2.0.0"
 
-"@aws-amplify/graphql-transformer-interfaces@2.2.4", "@aws-amplify/graphql-transformer-interfaces@^2.2.1":
+"@aws-amplify/graphql-transformer-interfaces@2.2.4":
   version "2.2.4"
   resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-2.2.4.tgz#b609a15bb184f681ca0cf1bb1a036402d18a6fce"
   integrity sha512-gURfrKm2dFirw6CYLFYL4WagKqeBJw7R7B5q8+bLdQPkoDugaCijojlXmcctBo0Vxx948LeyhMYJ/jzoNgbW9Q==
+  dependencies:
+    graphql "^15.5.0"
+
+"@aws-amplify/graphql-transformer-interfaces@^2.1.1", "@aws-amplify/graphql-transformer-interfaces@^2.2.2":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-2.3.0.tgz#fee01fbbcb0572201e1e3553503db9f706fc01dd"
+  integrity sha512-GC3zsT3RGK7XPdt/sLDOS69lY0vcob7ozoAuBtLotA9CrmuxHuSAWwYr3diqyt5Jn0z6c64DGjbiLD3XD00kyg==
   dependencies:
     graphql "^15.5.0"
 
@@ -5756,6 +5761,11 @@
   resolved "https://registry.npmjs.org/@types/inflected/-/inflected-1.1.29.tgz#8ef717dcf618d84584f506108ea85cd852f6d3ab"
   integrity sha512-csq2i12fylUrVWQ15ZMnVV3IV/KJ6zti/bn/n1FSHgZfIw1OGZV2OaJLdpGb0e1SRwdg92yalOS3Wftuw59rFA==
 
+"@types/ini@^1.3.31":
+  version "1.3.31"
+  resolved "https://registry.npmjs.org/@types/ini/-/ini-1.3.31.tgz#c78541a187bd88d5c73e990711c9d85214800d1b"
+  integrity sha512-8ecxxaG4AlVEM1k9+BsziMw8UsX0qy3jYI1ad/71RrDZ+rdL6aZB0wLfAuflQiDhkD5o4yJ0uPK3OSUic3fG0w==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -6215,10 +6225,53 @@ amazon-cognito-identity-js@6.3.1:
     isomorphic-unfetch "^3.0.0"
     js-cookie "^2.2.1"
 
+amplify-cli-core@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/amplify-cli-core/-/amplify-cli-core-4.0.4.tgz#02fef5a69753814d1c85b04ba1c9eafea7eea010"
+  integrity sha512-gnbBNcbuB9CisbVn1PfXjc38EyhywtqA3UgYPUPBx+u/zgJU48npAi5VHJUxY+d+PPFnQW5UPgnHAZAp5OA8Eg==
+  dependencies:
+    "@aws-amplify/amplify-cli-logger" "1.3.2"
+    "@aws-amplify/amplify-prompts" "2.6.8"
+    "@aws-amplify/graphql-transformer-interfaces" "^2.1.1"
+    "@yarnpkg/lockfile" "^1.1.0"
+    ajv "^6.12.6"
+    aws-cdk-lib "~2.68.0"
+    chalk "^4.1.1"
+    ci-info "^2.0.0"
+    cli-table3 "^0.6.0"
+    cloudform-types "^4.2.0"
+    colors "1.4.0"
+    dotenv "^8.2.0"
+    ejs "^3.1.7"
+    execa "^5.1.1"
+    fs-extra "^8.1.0"
+    globby "^11.0.3"
+    hjson "^3.2.1"
+    inquirer "^7.3.3"
+    js-yaml "^4.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    open "^8.4.0"
+    ora "^4.0.3"
+    proxy-agent "^5.0.0"
+    semver "^7.3.5"
+    typescript-json-schema "~0.52.0"
+    which "^2.0.2"
+    yaml "^2.2.1"
+
 amplify-headless-interface@^1.13.1:
   version "1.17.4"
   resolved "https://registry.npmjs.org/amplify-headless-interface/-/amplify-headless-interface-1.17.4.tgz#4daaa11d045655f4a726cb0bbcf790eef17986fe"
   integrity sha512-GinREwQl5Y5Zx0WcZ1YEXr4H9IJLLPdTZK6mfosTppSGj1rVMCt86ES7j9Xqb/q1naXymqCiOD4FzrN3IHPCvg==
+
+amplify-prompts@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.npmjs.org/amplify-prompts/-/amplify-prompts-2.6.8.tgz#4eeee956eee7393b4bf932005f872a4681a568a3"
+  integrity sha512-piWttrnUwswHpVb6LPUlrAg3O24jaOJvLxzNBXu4VxkmB5ASKdHBIp2+EnujiGT3QkRDhkdLARw+MFuXfjnolA==
+  dependencies:
+    "@aws-amplify/amplify-cli-shared-interfaces" "1.2.2"
+    chalk "^4.1.1"
+    enquirer "^2.3.6"
 
 ansi-colors@^4.1.1:
   version "4.1.3"
@@ -7251,7 +7304,7 @@ ci-info@^2.0.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.8.0:
   version "3.8.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
@@ -9788,6 +9841,11 @@ ini@^1.3.2, ini@^1.3.4:
   version "1.3.8"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ini@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz#c76ec81007875bc44d544ff7a11a55d12294102d"
+  integrity sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==
 
 init-package-json@^3.0.2:
   version "3.0.2"
@@ -14882,7 +14940,7 @@ yaml@1.10.2, yaml@^1.10.0:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.2.2:
+yaml@^2.2.1, yaml@^2.2.2:
   version "2.3.1"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The API plugin depends on `4.0.4` of CLI core without a `^` today https://github.com/aws-amplify/amplify-category-api/blob/28a89d960eaf3be3b729af567c83442e374e2443/packages/amplify-category-api/package.json#L71. While the Codegen resolves to latest. This is causing the API related CLI commands to fail using the dev binary.

Also includes a typo correction in a buildpsec file.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.