### PR TITLE
Add maxDepth parameter fetching via Codegen Config getter API

### DIFF
--- a/packages/amplify-codegen/src/codegen-config/index.js
+++ b/packages/amplify-codegen/src/codegen-config/index.js
@@ -43,6 +43,7 @@ function getCodegenConfig(projectPath) {
     : path.dirname(path.dirname(includeFiles));
 
   const { generatedFileName } = cfg.amplifyExtension || {};
+  const { maxDepth } = cfg.amplifyExtension || {};
 
   return {
     getGeneratedQueriesPath: function() {
@@ -62,6 +63,12 @@ function getCodegenConfig(projectPath) {
         return;
       }
       return path.normalize(generatedFileName);
+    },
+    getQueryMaxDepth: function() {
+      if (!maxDepth || !Number(maxDepth)) {
+        return;
+      }
+      return Number(maxDepth);
     }
   }
 }

--- a/packages/amplify-codegen/tests/codegen-config/getCodegenConfig.test.js
+++ b/packages/amplify-codegen/tests/codegen-config/getCodegenConfig.test.js
@@ -57,6 +57,13 @@ describe('get codegen configuration', () => {
     expect(getConfigReturn.getGeneratedFragmentsPath()).toEqual(path.join('src', 'graphql', 'fragments'));
   });
 
+  it('returns correct maxDepth as a Number', () => {
+    fs.existsSync = jest.fn().mockReturnValue(true);
+    graphQLConfig.getGraphQLConfig = jest.fn().mockReturnValue(MOCK_CODEGEN_CONFIG);
+    const getConfigReturn = getCodegenConfig(MOCK_PROJECT_ROOT);
+    expect(getConfigReturn.getQueryMaxDepth()).toEqual(4);
+  });
+
   it('uses the includes property if the generated documents path does not exist', () => {
     const configWithoutDocumentsPath = { ...MOCK_CODEGEN_CONFIG };
     delete configWithoutDocumentsPath.config.extensions.amplify.docsFilePath;
@@ -92,5 +99,14 @@ describe('get codegen configuration', () => {
     graphQLConfig.getGraphQLConfig = jest.fn().mockReturnValue(configWithoutTypes);
     const getConfigReturn = getCodegenConfig(MOCK_PROJECT_ROOT);
     expect(getConfigReturn.getGeneratedTypesPath()).toBeUndefined();
+  });
+
+  it('returns undefined if maxDepth does not exist', () => {
+    const configWithoutMaxDepth = { ...MOCK_CODEGEN_CONFIG };
+    delete configWithoutMaxDepth.config.extensions.amplify.maxDepth;
+    fs.existsSync = jest.fn().mockReturnValue(true);
+    graphQLConfig.getGraphQLConfig = jest.fn().mockReturnValue(configWithoutMaxDepth);
+    const getConfigReturn = getCodegenConfig(MOCK_PROJECT_ROOT);
+    expect(getConfigReturn.getQueryMaxDepth()).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The new API either returns a valid `maxDepth` config parameter which is set via `amplify codegen add` by the customers.
Or it returns `undefined` if any customers manually made changes to the `graphqlconfig.yml` file to remove it. This case will be handled in Studio UI by prompting customers to re-configure their codegen via `amplify codegen update` or `amplify codegen configure`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.