### PR TITLE
fix: post publish sync between main and release

### DIFF
--- a/.codebuild/scripts/publish.sh
+++ b/.codebuild/scripts/publish.sh
@@ -4,8 +4,11 @@ if [ -z "$BRANCH_NAME" ]; then
   echo "BRANCH_NAME is missing"
   exit 1
 else
+  # These are more of an extra caution to make sure we have latest commits
+  git checkout main
+  git pull origin main
   git checkout $BRANCH_NAME
-  git pull
+  git pull origin $BRANCH_NAME
   git fetch --all
   yarn install
   git restore .

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amplify-codegen",
   "version": "4.1.7",
-  "description": "Amplify Code generator",
+  "description": "Amplify Code Generator",
   "repository": {
     "type": "git",
     "url": "https://github.com/aws-amplify/amplify-codegen.git",

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -319,7 +319,6 @@ function runE2eTest {
 
 function _deploy {
   echo "Deploy"
-  loadCacheFromBuildJob
   echo "Authenticate with NPM"
   PUBLISH_TOKEN=$(echo "$NPM_PUBLISH_TOKEN" | jq -r '.token')
   echo "//registry.npmjs.org/:_authToken=$PUBLISH_TOKEN" > ~/.npmrc


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The codebuild job starts with HEAD at a detached commit from the `release` branch, which is observed in the SSH session. Another thing is that there is no default tracking branches for the cloned repo in the container.
Adding explicit `pull` from origin for `main` and `release` to be sure we're using latest code and the history is all fetched.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.