### PR TITLE
chore: use ada auth for viewing e2e artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "cloud-e2e": "source scripts/cloud-utils.sh && cloudE2E",
     "cloud-e2e-beta": "source scripts/cloud-utils.sh && cloudE2EBeta",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .codebuild/e2e_workflow.yml",
-    "view-test-artifacts": "yarn ts-node ./scripts/view-test-artifacts.ts",
-    "cloud-e2e-debug": "source scripts/cloud-utils.sh && cloudE2EDebug"
+    "view-test-artifacts": "yarn authenticate-e2e-profile && yarn ts-node ./scripts/view-test-artifacts.ts",
+    "cloud-e2e-debug": "source scripts/cloud-utils.sh && cloudE2EDebug",
+    "authenticate-e2e-profile": "source scripts/cloud-utils.sh && authenticateWithE2EProfile"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-codegen/issues"

--- a/scripts/cloud-utils.sh
+++ b/scripts/cloud-utils.sh
@@ -134,3 +134,9 @@ function generatedDebugSpecForFailedTests {
   fi
   echo $failed_tests | xargs yarn ts-node ./scripts/split-e2e-tests.ts --debug
 }
+
+function authenticateWithE2EProfile {
+    E2E_ROLE_NAME=CodebuildDeveloper
+    E2E_PROFILE_NAME=AmplifyAPIE2EProd
+    authenticate $E2E_ACCOUNT_PROD $E2E_ROLE_NAME $E2E_PROFILE_NAME
+}

--- a/scripts/view-test-artifacts.ts
+++ b/scripts/view-test-artifacts.ts
@@ -1,9 +1,5 @@
 /**
  * Usage: `yarn view-test-artifacts <buildBatchId>`
- *
- * N.B. It is important to have your local environment configured for the correct codebuild account before running the script.
- * This script caches resources, but in the case the local resource state is out of sync, you may need to wipe the asset directory
- * that is printed when the script begins.
  */
 
 import * as process from 'process';
@@ -11,12 +7,15 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs-extra';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { CodeBuild, S3 } from 'aws-sdk';
+import { CodeBuild, S3, SharedIniFileCredentials } from 'aws-sdk';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { SingleBar, Presets } from 'cli-progress';
 import * as execa from 'execa';
 
-const s3 = new S3();
+const E2E_PROFILE_NAME = 'AmplifyAPIE2EProd';
+const credentials = new SharedIniFileCredentials({ profile: E2E_PROFILE_NAME });
+const s3 = new S3({ credentials });
+const codeBuild = new CodeBuild({ credentials, region: 'us-east-1' });
 const progressBar = new SingleBar({}, Presets.shades_classic);
 
 type BuildStatus = 'FAILED' | 'FAULT' | 'IN_PROGRESS' | 'STOPPED' | 'SUCCEEDED' | 'TIMED_OUT';
@@ -82,7 +81,6 @@ const generateIndexFile = (directory: string, artifacts: TestArtifact[]): void =
  * @param batchId the batch to look up.
  */
 const retrieveArtifactsForBatch = async (batchId: string): Promise<TestArtifact[]> => {
-  const codeBuild = new CodeBuild({ region: 'us-east-1' });
   const { buildBatches } = await codeBuild.batchGetBuildBatches({ ids: [batchId] }).promise();
   return (buildBatches || [])
     .flatMap((batch) =>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Use the ada CLI authentication to view the E2E test artifacts. This keeps it more uniform with other scripts we have.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.