### PR TITLE
fix: download introspection schema when apiId is passed

### DIFF
--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -125,7 +125,7 @@ async function add(context, apiId = null, region = 'us-east-1') {
       schema = getSDLSchemaLocation(apiDetails.name);
     }
   } else if (apiDetails) {
-    schema = await downloadIntrospectionSchemaWithProgress(context, apiDetails.id, 'schema.json', region);
+    schema = await downloadIntrospectionSchemaWithProgress(context, apiDetails.id, path.join(process.cwd(), 'schema.json'), region);
   } else {
     schema = schemaPath;
   }

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -85,7 +85,7 @@ async function add(context, apiId = null, region = 'us-east-1') {
     }
     [apiDetails] = availableAppSyncApis;
     apiDetails.isLocal = true;
-  } else {
+  } else if (apiId) {
     let shouldRetry = true;
     while (shouldRetry) {
       const apiDetailSpinner = new Ora();
@@ -108,6 +108,7 @@ async function add(context, apiId = null, region = 'us-east-1') {
       }
     }
   }
+  // else no appsync API, but has schema.graphql or schema.json
 
   if (!withoutInit && !apiDetails) {
     return;

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -38,9 +38,9 @@ async function add(context, apiId = null, region = 'us-east-1') {
   }
 
   const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
-  if (withoutInit && !schemaPath) {
+  if (withoutInit && !(apiId || schemaPath)) {
     throw Error(
-      `Please download schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
+      `Provide an AppSync API ID with --apiId or manually download schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
     );
   }
   // Grab the frontend
@@ -78,32 +78,32 @@ async function add(context, apiId = null, region = 'us-east-1') {
     throw new Error(constants.ERROR_CODEGEN_SUPPORT_MAX_ONE_API);
   }
   let apiDetails;
-  if (!withoutInit) {
-    if (!apiId) {
-      const availableAppSyncApis = getAppSyncAPIDetails(context); // published and un-published
-      if (availableAppSyncApis.length === 0) {
-        throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
-      }
-      [apiDetails] = availableAppSyncApis;
-      apiDetails.isLocal = true;
-    } else {
-      let shouldRetry = true;
-      while (shouldRetry) {
-        const apiDetailSpinner = new Ora();
-        try {
-          apiDetailSpinner.start('Getting API details');
-          apiDetails = await getAppSyncAPIInfo(context, apiId, region);
-          apiDetailSpinner.succeed();
+  if (!withoutInit && !apiId) {
+    const availableAppSyncApis = getAppSyncAPIDetails(context); // published and un-published
+    if (availableAppSyncApis.length === 0) {
+      throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
+    }
+    [apiDetails] = availableAppSyncApis;
+    apiDetails.isLocal = true;
+  } else {
+    let shouldRetry = true;
+    while (shouldRetry) {
+      const apiDetailSpinner = new Ora();
+      try {
+        apiDetailSpinner.start('Getting API details');
+        apiDetails = await getAppSyncAPIInfo(context, apiId, region);
+        if (!withoutInit) {
           await updateAmplifyMeta(context, apiDetails);
-          break;
-        } catch (e) {
-          apiDetailSpinner.fail();
-          if (e instanceof AmplifyCodeGenAPINotFoundError) {
-            context.print.info(`AppSync API was not found in region ${region}`);
-            ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
-          } else {
-            throw e;
-          }
+        }
+        apiDetailSpinner.succeed();
+        break;
+      } catch (e) {
+        apiDetailSpinner.fail();
+        if (e instanceof AmplifyCodeGenAPINotFoundError) {
+          context.print.info(`AppSync API was not found in region ${region}`);
+          ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
+        } else {
+          throw e;
         }
       }
     }
@@ -123,6 +123,8 @@ async function add(context, apiId = null, region = 'us-east-1') {
     } else {
       schema = getSDLSchemaLocation(apiDetails.name);
     }
+  } else if (apiDetails) {
+    schema = await downloadIntrospectionSchemaWithProgress(context, apiDetails.id, 'schema.json', region);
   } else {
     schema = schemaPath;
   }

--- a/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
@@ -16,7 +16,11 @@ async function downloadIntrospectionSchema(context, apiId, downloadLocation, reg
       const introspectionDir = dirname(downloadLocation);
       fs.ensureDirSync(introspectionDir);
       fs.writeFileSync(downloadLocation, schema, 'utf8');
-      return relative(amplify.getEnvInfo().projectPath, downloadLocation);
+      try {
+        return relative(amplify.getEnvInfo().projectPath, downloadLocation);
+      } catch {
+        return downloadLocation;
+      }
     } catch (ex) {
       if (ex.code === 'NotFoundException') {
         throw new AmplifyCodeGenAPINotFoundError(constants.ERROR_APPSYNC_API_NOT_FOUND);

--- a/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`command - add without init should download introspection schema when api id 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": "MOCK_API_ID",
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "react",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-east-1",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.json",
+}
+`;
+
 exports[`command - add without init should read frontend and framework from options 1`] = `
 Object {
   "amplifyExtension": Object {
@@ -7,6 +25,24 @@ Object {
     "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
     "docsFilePath": "MOCK_DOCS_FILE_PATH",
     "framework": "vue",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-east-1",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.json",
+}
+`;
+
+exports[`command - add without init should use existing schema if no api id 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": null,
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "react",
     "frontend": "javascript",
     "generatedFileName": "API.TS",
     "region": "us-east-1",
@@ -32,6 +68,6 @@ Object {
   "excludes": "MOCK_EXCLUDE",
   "includes": "MOCK_INCLUDE",
   "projectName": "Codegen Project",
-  "schema": "/user/foo/project/schema.graphql",
+  "schema": "/user/foo/project/schema.json",
 }
 `;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* download introspection schema when apiId is passed

```
amplify codegen add --apiId <api-id> --region <region>
```

When `--apiId` is set, the CLI will attempt to download the introspection schema to `./schema.json`. When no `--region` is supplied `us-east-1` is used. If the api cannot be found the CLI will prompt the customer to try a different region.

```
✖ Getting API details
AppSync API was not found in region us-east-1
? Do you want to choose a different region Yes
? Choose AWS Region (Use arrow keys)
❯ US East (N. Virginia) 
  US East (Ohio) 
  US West (N. California) 
  US West (Oregon) 
  EU (Stockholm) 
  EU (Milan) 
  EU (Ireland) 
(Move up and down to reveal more choices)
```

An additional change (https://github.com/aws-amplify/amplify-codegen/pull/689) is needed after this PR. The customer can end in a broken state if:
1. `amplify codegen add --apiId <api-id>`
2. `rm -rf schema.json`
3. `amplify codegen`

There is no way the customer can use the codegen CLI to download the introspection schema. 

```
$ amplify-dev codegen types
⠋ Generating🛑 ENOENT: no such file or directory, open '/Users/dppilche/amplify/apps/testnoamplify/schema.json'

Resolution: Please report this issue at https://github.com/aws-amplify/amplify-cli/issues and include the project identifier from: 'amplify diagnose --send-report'
Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/
⠹ Generating^Aborted!
```

```
$ amplify-dev codegen statements 
Cannot find GraphQL schema file: /Users/dppilche/amplify/apps/testnoamplify/schema.json
```

```
$ amplify codegen 
Please download the schema.graphql or schema.json and place in /Users/dppilche/amplify/apps/testnoamplify before adding codegen when not in an amplify project
```

Each of these commands need to initialize a download when outside an amplify project if `apiId` is set in `.graphqconfig.yml`.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit testing
* E2E tests to come in later PR

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.