### PR TITLE
feat: use default directive definitions if outside amplify project

### DIFF
--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -5,6 +5,7 @@ const glob = require('glob-all');
 const { FeatureFlags, pathManager } = require('@aws-amplify/amplify-cli-core');
 const { generateModels: generateModelsHelper } = require('@aws-amplify/graphql-generator');
 const { validateAmplifyFlutterMinSupportedVersion } = require('../utils/validateAmplifyFlutterMinSupportedVersion');
+const defaultDirectiveDefinitions = require('../utils/defaultDirectiveDefinitions');
 
 const platformToLanguageMap = {
   android: 'java',
@@ -85,9 +86,14 @@ async function generateModels(context, generateOptions = null) {
   const backendPath = await context.amplify.pathManager.getBackendDirPath();
   const apiResourcePath = path.join(backendPath, 'api', apiResource.resourceName);
 
-  const directiveDefinitions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getTransformerDirectives', {
-    resourceDir: apiResourcePath,
-  });
+  let directiveDefinitions;
+  try {
+    directiveDefinitions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getTransformerDirectives', {
+      resourceDir: apiResourcePath,
+    });
+  } catch {
+    directiveDefinitions = defaultDirectiveDefinitions;
+  }
 
   const schemaContent = loadSchema(apiResourcePath);
   const baseOutputDir = overrideOutputDir || path.join(projectRoot, getModelOutputPath(context));

--- a/packages/amplify-codegen/src/utils/defaultDirectiveDefinitions.js
+++ b/packages/amplify-codegen/src/utils/defaultDirectiveDefinitions.js
@@ -1,0 +1,113 @@
+const defaultDirectiveDefinitions = `
+directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
+
+directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
+
+directive @aws_api_key on FIELD_DEFINITION | OBJECT
+
+directive @aws_iam on FIELD_DEFINITION | OBJECT
+
+directive @aws_oidc on FIELD_DEFINITION | OBJECT
+
+directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT
+
+directive @aws_lambda on FIELD_DEFINITION | OBJECT
+
+directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+
+directive @model(queries: ModelQueryMap, mutations: ModelMutationMap, subscriptions: ModelSubscriptionMap, timestamps: TimestampConfiguration) on OBJECT
+input ModelMutationMap {
+  create: String
+  update: String
+  delete: String
+}
+input ModelQueryMap {
+  get: String
+  list: String
+}
+input ModelSubscriptionMap {
+  onCreate: [String]
+  onUpdate: [String]
+  onDelete: [String]
+  level: ModelSubscriptionLevel
+}
+enum ModelSubscriptionLevel {
+  off
+  public
+  on
+}
+input TimestampConfiguration {
+  createdAt: String
+  updatedAt: String
+}
+directive @function(name: String!, region: String, accountId: String) repeatable on FIELD_DEFINITION
+directive @http(method: HttpMethod = GET, url: String!, headers: [HttpHeader] = []) on FIELD_DEFINITION
+enum HttpMethod {
+  GET
+  POST
+  PUT
+  DELETE
+  PATCH
+}
+input HttpHeader {
+  key: String
+  value: String
+}
+directive @predictions(actions: [PredictionsActions!]!) on FIELD_DEFINITION
+enum PredictionsActions {
+  identifyText
+  identifyLabels
+  convertTextToSpeech
+  translateText
+}
+directive @primaryKey(sortKeyFields: [String]) on FIELD_DEFINITION
+directive @index(name: String, sortKeyFields: [String], queryField: String) repeatable on FIELD_DEFINITION
+directive @hasMany(indexName: String, fields: [String!], limit: Int = 100) on FIELD_DEFINITION
+directive @hasOne(fields: [String!]) on FIELD_DEFINITION
+directive @manyToMany(relationName: String!, limit: Int = 100) on FIELD_DEFINITION
+directive @belongsTo(fields: [String!]) on FIELD_DEFINITION
+directive @default(value: String!) on FIELD_DEFINITION
+directive @auth(rules: [AuthRule!]!) on OBJECT | FIELD_DEFINITION
+input AuthRule {
+  allow: AuthStrategy!
+  provider: AuthProvider
+  identityClaim: String
+  groupClaim: String
+  ownerField: String
+  groupsField: String
+  groups: [String]
+  operations: [ModelOperation]
+}
+enum AuthStrategy {
+  owner
+  groups
+  private
+  public
+  custom
+}
+enum AuthProvider {
+  apiKey
+  iam
+  oidc
+  userPools
+  function
+}
+enum ModelOperation {
+  create
+  update
+  delete
+  read
+  list
+  get
+  sync
+  listen
+  search
+}
+directive @mapsTo(name: String!) on OBJECT
+directive @searchable(queries: SearchableQueryMap) on OBJECT
+input SearchableQueryMap {
+  search: String
+}
+`;
+
+module.exports = defaultDirectiveDefinitions;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -15,6 +15,7 @@ const getSDLSchemaLocation = require('./getSDLSchemaLocation');
 const switchToSDLSchema = require('./switchToSDLSchema');
 const ensureIntrospectionSchema = require('./ensureIntrospectionSchema');
 const { readSchemaFromFile } = require('./readSchemaFromFile');
+const defaultDirectiveDefinitions = require('./defaultDirectiveDefinitions');
 module.exports = {
   getAppSyncAPIDetails,
   getFrontEndHandler,
@@ -33,4 +34,5 @@ module.exports = {
   switchToSDLSchema,
   ensureIntrospectionSchema,
   readSchemaFromFile,
+  defaultDirectiveDefinitions,
 };

--- a/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
@@ -61,3 +61,12 @@ Array [
   "schema.js",
 ]
 `;
+
+exports[`command-models-generates models in expected output path should use default directive definitions if getTransformerDirectives fails 1`] = `
+Array [
+  "index.d.ts",
+  "index.js",
+  "schema.d.ts",
+  "schema.js",
+]
+`;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* add hard coded default directive definitions to amplify-codegen
* Use default directives if `getTransformerDirectives` fails (outside of amplify project)


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit testing
* E2E tests to come in later PR

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.