### PR TITLE
fix: codegen --apiId broken state

### DIFF
--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -4,7 +4,7 @@ const generateTypes = require('./types');
 const generateStatements = require('./statements');
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getAppSyncAPIDetails, getAppSyncAPIInfo } = require('../utils');
+const { ensureIntrospectionSchema, getAppSyncAPIDetails, getAppSyncAPIInfoFromProject } = require('../utils');
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -33,11 +33,11 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
-  } else if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
-    const {
-      amplifyExtension: { apiId, region },
-    } = project;
-    apis = [await getAppSyncAPIInfo(context, apiId, region)];
+  } else {
+    const api = getAppSyncAPIInfoFromProject(context, project);
+    if (api) {
+      apis = [api];
+    }
   }
   if (!apis.length && !withoutInit) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_META);

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -4,7 +4,7 @@ const generateTypes = require('./types');
 const generateStatements = require('./statements');
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../utils');
+const { ensureIntrospectionSchema, getAppSyncAPIDetails, getAppSyncAPIInfo } = require('../utils');
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -17,30 +17,31 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     withoutInit = true;
   }
 
-  // Check if introspection schema exists
-  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
-  if (withoutInit && !schemaPath) {
-    throw Error(
-      `Please download the schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`
-    );
-  }
-
-  if (withoutInit) {
-    forceDownloadSchema = false;
-  }
   const config = loadConfig(context, withoutInit);
   const projects = config.getProjects();
   if (!projects.length) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   }
+  const project = projects[0];
+  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
+  if (withoutInit && !project && !schemaPath) {
+    throw Error(
+      `Please download the schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
+    );
+  }
+
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
+  } else if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
+    const {
+      amplifyExtension: { apiId, region },
+    } = project;
+    apis = [await getAppSyncAPIInfo(context, apiId, region)];
   }
   if (!apis.length && !withoutInit) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_META);
   }
-  const project = projects[0];
   const { frontend } = project.amplifyExtension;
   let projectPath = process.cwd();
   if (!withoutInit) {
@@ -48,10 +49,10 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
   }
 
   let downloadPromises;
-  if (!withoutInit) {
+  if (apis.length) {
     downloadPromises = projects.map(
       async cfg =>
-        await ensureIntrospectionSchema(context, join(projectPath, cfg.schema), apis[0], cfg.amplifyExtension.region, forceDownloadSchema)
+        await ensureIntrospectionSchema(context, join(projectPath, cfg.schema), apis[0], cfg.amplifyExtension.region, forceDownloadSchema),
     );
     await Promise.all(downloadPromises);
   }

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -4,7 +4,13 @@ const Ora = require('ora');
 
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, readSchemaFromFile, getAppSyncAPIInfo } = require('../utils');
+const {
+  ensureIntrospectionSchema,
+  getFrontEndHandler,
+  getAppSyncAPIDetails,
+  readSchemaFromFile,
+  getAppSyncAPIInfoFromProject,
+} = require('../utils');
 const { generateGraphQLDocuments } = require('@aws-amplify/graphql-docs-generator');
 const { generateStatements: generateStatementsHelper } = require('@aws-amplify/graphql-generator');
 
@@ -23,11 +29,11 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
-  } else if (projects[0].amplifyExtension.apiId && projects[0].amplifyExtension.region) {
-    const {
-      amplifyExtension: { apiId, region },
-    } = projects[0];
-    apis = [await getAppSyncAPIInfo(context, apiId, region)];
+  } else {
+    const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+    if (api) {
+      apis = [api];
+    }
   }
   let projectPath = process.cwd();
   if (!withoutInit) {

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -52,16 +52,11 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
       : path.dirname(path.dirname(includeFiles));
     const schemaPath = path.join(projectPath, cfg.schema);
-    let frontend;
     if (apis.length) {
       const { region } = cfg.amplifyExtension;
       await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
     }
-    if (!withoutInit) {
-      frontend = getFrontEndHandler(context);
-    } else {
-      ({ frontend } = cfg.amplifyExtension);
-    }
+    const frontend = withoutInit ? cfg.amplifyExtension.frontend : getFrontEndHandler(context);
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
 
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -4,7 +4,7 @@ const Ora = require('ora');
 
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, readSchemaFromFile } = require('../utils');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, readSchemaFromFile, getAppSyncAPIInfo } = require('../utils');
 const { generateGraphQLDocuments } = require('@aws-amplify/graphql-docs-generator');
 const { generateStatements: generateStatementsHelper } = require('@aws-amplify/graphql-generator');
 
@@ -16,9 +16,18 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
   }
   const config = loadConfig(context, withoutInit);
   const projects = config.getProjects();
+  if (!projects.length && withoutInit) {
+    context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+    return;
+  }
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
+  } else if (projects[0].amplifyExtension.apiId && projects[0].amplifyExtension.region) {
+    const {
+      amplifyExtension: { apiId, region },
+    } = projects[0];
+    apis = [await getAppSyncAPIInfo(context, apiId, region)];
   }
   let projectPath = process.cwd();
   if (!withoutInit) {
@@ -30,10 +39,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       return;
     }
   }
-  if (!projects.length && withoutInit) {
-    context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
-    return;
-  }
 
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
@@ -41,14 +46,15 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
       : path.dirname(path.dirname(includeFiles));
     const schemaPath = path.join(projectPath, cfg.schema);
-    let region;
     let frontend;
-    if (!withoutInit) {
-      ({ region } = cfg.amplifyExtension);
+    if (apis.length) {
+      const { region } = cfg.amplifyExtension;
       await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
+    }
+    if (!withoutInit) {
       frontend = getFrontEndHandler(context);
     } else {
-      frontend = decoupleFrontend;
+      ({ frontend } = cfg.amplifyExtension);
     }
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
 

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -5,7 +5,7 @@ const glob = require('glob-all');
 
 const constants = require('../constants');
 const { loadConfig } = require('../codegen-config');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, getAppSyncAPIInfo } = require('../utils');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, getAppSyncAPIInfoFromProject } = require('../utils');
 const { generateTypes: generateTypesHelper } = require('@aws-amplify/graphql-generator');
 const { extractDocumentFromJavascript } = require('@aws-amplify/graphql-types-generator');
 
@@ -29,11 +29,11 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
     let apis = [];
     if (!withoutInit) {
       apis = getAppSyncAPIDetails(context);
-    } else if (projects[0].amplifyExtension.apiId && projects[0].amplifyExtension.region) {
-      const {
-        amplifyExtension: { apiId, region },
-      } = projects[0];
-      apis = [await getAppSyncAPIInfo(context, apiId, region)];
+    } else {
+      const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+      if (api) {
+        apis = [api];
+      }
     }
     if (!projects.length || !apis.length) {
       if (!withoutInit) {

--- a/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
@@ -4,9 +4,15 @@ const generateIntrospectionSchema = require('./generateIntrospectionSchema');
 const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
 
 async function ensureIntrospectionSchema(context, schemaPath, apiConfig, region, forceDownloadSchema) {
-  const meta = context.amplify.getProjectMeta();
+  let meta;
+  let withoutInit = false;
+  try {
+    meta = context.amplify.getProjectMeta();
+  } catch (e) {
+    withoutInit = true;
+  }
   const { id, name } = apiConfig;
-  const isTransformedAPI = Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
+  const isTransformedAPI = meta && Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
   if (isTransformedAPI && getFrontendHandler(context) === 'android') {
     generateIntrospectionSchema(context, name);
   } else if (schemaPath.endsWith('.json')) {

--- a/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
@@ -5,12 +5,9 @@ const downloadIntrospectionSchemaWithProgress = require('./generateIntrospection
 
 async function ensureIntrospectionSchema(context, schemaPath, apiConfig, region, forceDownloadSchema) {
   let meta;
-  let withoutInit = false;
   try {
     meta = context.amplify.getProjectMeta();
-  } catch (e) {
-    withoutInit = true;
-  }
+  } catch {}
   const { id, name } = apiConfig;
   const isTransformedAPI = meta && Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
   if (isTransformedAPI && getFrontendHandler(context) === 'android') {

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
@@ -1,0 +1,15 @@
+const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+
+/* Get AppSync api info if api id and region are avialable.
+ * Otherwise return undefined.
+ */
+function getAppSyncAPIInfoFromProject(project, context) {
+  if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
+    const {
+      amplifyExtension: { apiId, region },
+    } = project;
+    return getAppSyncAPIInfo(context, apiId, region);
+  }
+  return undefined;
+}
+module.exports = getAppSyncAPIInfoFromProject;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -5,6 +5,7 @@ const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
 const getSchemaDownloadLocation = require('./getSchemaDownloadLocation');
 const getIncludePattern = require('./getIncludePattern');
 const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+const getAppSyncAPIInfoFromProject = require('./getAppSyncAPIInfoFromProject');
 const getProjectAwsRegion = require('./getProjectAWSRegion');
 const getGraphQLDocPath = require('./getGraphQLDocPath');
 const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
@@ -24,6 +25,7 @@ module.exports = {
   downloadIntrospectionSchemaWithProgress,
   getIncludePattern,
   getAppSyncAPIInfo,
+  getAppSyncAPIInfoFromProject,
   getProjectAwsRegion,
   getGraphQLDocPath,
   isAppSyncApiPendingPush,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The customer can end in a broken state if:
1. `amplify codegen add --apiId <api-id>`
2. `rm -rf schema.json`
3. `amplify codegen`

There is no way the customer can use the codegen CLI to download the introspection schema. 

```
$ amplify-dev codegen types
⠋ Generating🛑 ENOENT: no such file or directory, open '/Users/dppilche/amplify/apps/testnoamplify/schema.json'

Resolution: Please report this issue at https://github.com/aws-amplify/amplify-cli/issues and include the project identifier from: 'amplify diagnose --send-report'
Learn more at: https://docs.amplify.aws/cli/project/troubleshooting/
⠹ Generating^Aborted!
```

```
$ amplify-dev codegen statements 
Cannot find GraphQL schema file: /Users/dppilche/amplify/apps/testnoamplify/schema.json
```

```
$ amplify codegen 
Please download the schema.graphql or schema.json and place in /Users/dppilche/amplify/apps/testnoamplify before adding codegen when not in an amplify project
```

`amplify codegen`, `amplify codegen types`, and `amplify codegen statements` now download the introspection schema if `apiId` is set in `.graphqlconfig.yml` and the project is without amplify init.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit testing.
* E2E tests to come in later pr.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.