### PR TITLE
feat: support amplify codegen models without initialized amplify backend

### DIFF
--- a/packages/amplify-codegen/src/utils/getModelSchemaPathParam.js
+++ b/packages/amplify-codegen/src/utils/getModelSchemaPathParam.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+/**
+ * Retrieve the specified model schema path parameter, returning as an absolute path.
+ * @param context the CLI invocation context
+ * @returns the absolute path to the model schema path
+ */
+function getModelSchemaPathParam(context) {
+  const modelSchemaPathParam = context.parameters?.options?.['model-schema'];
+  if ( !modelSchemaPathParam ) {
+    return null;
+  }
+  let projectRoot;
+  try {
+    context.amplify.getProjectMeta();
+    projectRoot = context.amplify.getEnvInfo().projectPath;
+  } catch (e) {
+    projectRoot = process.cwd();
+  }
+  return path.isAbsolute(modelSchemaPathParam) ? modelSchemaPathParam : path.join(projectRoot, modelSchemaPathParam);
+}
+
+module.exports = getModelSchemaPathParam;

--- a/packages/amplify-codegen/src/utils/getOutputDirParam.js
+++ b/packages/amplify-codegen/src/utils/getOutputDirParam.js
@@ -15,7 +15,13 @@ function getOutputDirParam(context, isRequired) {
   if ( !outputDirParam ) {
     return null;
   }
-  return path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
+  let projectRoot;
+  try {
+    projectRoot = context.amplify.getEnvInfo().projectPath;
+  } catch (e) {
+    projectRoot = process.cwd();
+  }
+  return path.isAbsolute(outputDirParam) ? outputDirParam : path.join(projectRoot, outputDirParam);
 }
 
 module.exports = getOutputDirParam;


### PR DESCRIPTION
#### Description of changes
WIP PR refactoring modelgen in order to support executing commands like `amplify codegen models --target android --model-schema src/schema.graphql` without needing to have an initialized amplify project locally.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit tests, + E2E Tests (To be written), and manual exploratory testing, test cases TB added.

#### Checklist
- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.