### PR TITLE
chore: refactor command/models.js into independent functions, add jsdoc type annotations

### DIFF
--- a/packages/amplify-codegen/tests/commands/model-introspection.test.js
+++ b/packages/amplify-codegen/tests/commands/model-introspection.test.js
@@ -31,6 +31,7 @@ const MOCK_CONTEXT = {
   print: {
     info: jest.fn(),
     warning: jest.fn(),
+    error: jest.fn(),
   },
   amplify: {
     getProjectMeta: jest.fn(),


### PR DESCRIPTION
#### Description of changes
This refactor should make the functional change to support modelgen without an amplify initialized backend a bit more straightforward, and the type annotations have helped me in the refactor. There are no functional changes, and I'm relying on unit tests to verify that fact.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit Tests

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.