### PR TITLE
feat: merge noinit-modelgen into main to support executing amplify codegen models without an initialized amplify app

### DIFF
--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -120,13 +120,24 @@ batch:
           CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_ts
+    - identifier: >-
+        build_app_ts_uninitialized_project_modelgen_android_uninitialized_project_modelgen_flutter_uninitialized_project_modelgen_ios
       buildspec: .codebuild/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          TEST_SUITE: >-
+            src/__tests__/build-app-ts.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts
           CLI_REGION: ap-southeast-1
+      depend-on:
+        - publish_to_local_registry
+    - identifier: uninitialized_project_modelgen_js
+      buildspec: .codebuild/run_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/uninitialized-project-modelgen-js.test.ts
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: cleanup_e2e_resources

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -20,6 +20,16 @@ export function generateModels(cwd: string, outputDir?: string, settings: { errM
   });
 }
 
+export const generateModelsWithOptions = (cwd: string, options: Record<string, any>): Promise<void> => new Promise((resolve, reject) => {
+  spawn(getCLIPath(), ['codegen', 'models', ...(Object.entries(options).flat())], { cwd, stripColors: true }).run((err: Error) => {
+    if (!err) {
+      resolve();
+    } else {
+      reject(err);
+    }
+  });
+});
+
 export function generateStatementsAndTypes(cwd: string) : Promise<void> {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['codegen'], { cwd, stripColors: true })

--- a/packages/amplify-codegen-e2e-core/src/utils/frontend-config-helper.ts
+++ b/packages/amplify-codegen-e2e-core/src/utils/frontend-config-helper.ts
@@ -1,5 +1,6 @@
 export enum AmplifyFrontend {
   javascript = 'javascript',
+  typescript = 'typescript',
   ios = 'ios',
   android = 'android',
   flutter = 'flutter'

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-android.test.ts
@@ -1,0 +1,44 @@
+import { createNewProjectDir, DEFAULT_ANDROID_CONFIG, deleteProjectDir } from '@aws-amplify/amplify-codegen-e2e-core';
+import { testUninitializedCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
+
+const schemaName = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
+
+describe('Uninitialized Project Modelgen tests - Android', () => {
+    let projectRoot: string;
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('uninitializedProjectModelgenAndroid');
+    });
+
+    afterEach(() => deleteProjectDir(projectRoot));
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_ANDROID_CONFIG,
+            projectRoot,
+            schemaName,
+            outputDir: path.join('app', 'src', 'main', 'guava'),
+            shouldSucceed: true,
+            expectedFilenames: [
+                'AmplifyModelProvider.java',
+                'Attration.java',
+                'Comment.java',
+                'License.java',
+                'Person.java',
+                'Post.java',
+                'Status.java',
+                'User.java',
+            ],
+        });
+    });
+
+    it(`should not generate files at desired location and not delete src files if no output dir is specified`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_ANDROID_CONFIG,
+            projectRoot,
+            schemaName,
+            shouldSucceed: false,
+        });
+    });
+});

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-flutter.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-flutter.test.ts
@@ -1,0 +1,44 @@
+import { createNewProjectDir, DEFAULT_FLUTTER_CONFIG, deleteProjectDir } from '@aws-amplify/amplify-codegen-e2e-core';
+import { testUninitializedCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
+
+const schemaName = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
+
+describe('Uninitialized Project Modelgen tests - Flutter', () => {
+    let projectRoot: string;
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('uninitializedProjectModelgenFlutter');
+    });
+
+    afterEach(() => deleteProjectDir(projectRoot));
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_FLUTTER_CONFIG,
+            projectRoot,
+            schemaName,
+            outputDir: path.join('lib', 'blueprints'),
+            shouldSucceed: true,
+            expectedFilenames: [
+                'Attration.dart',
+                'Comment.dart',
+                'License.dart',
+                'ModelProvider.dart',
+                'Person.dart',
+                'Post.dart',
+                'Status.dart',
+                'User.dart',
+            ],
+        });
+    });
+
+    it(`should not generate files at desired location and not delete src files if no output dir is specified`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_FLUTTER_CONFIG,
+            projectRoot,
+            schemaName,
+            shouldSucceed: false,
+        });
+    });
+});

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-ios.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-ios.test.ts
@@ -1,0 +1,50 @@
+import { createNewProjectDir, DEFAULT_IOS_CONFIG, deleteProjectDir } from '@aws-amplify/amplify-codegen-e2e-core';
+import { testUninitializedCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
+
+const schemaName = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
+
+describe('Uninitialized Project Modelgen tests - IOS', () => {
+    let projectRoot: string;
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('uninitializedProjectModelgenIOS');
+    });
+
+    afterEach(() => deleteProjectDir(projectRoot));
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_IOS_CONFIG,
+            projectRoot,
+            schemaName,
+            outputDir: path.join('amplification', 'manufactured', 'models'),
+            shouldSucceed: true,
+            expectedFilenames: [
+                'AmplifyModels.swift',
+                'Attration+Schema.swift',
+                'Attration.swift',
+                'Comment+Schema.swift',
+                'Comment.swift',
+                'License+Schema.swift',
+                'License.swift',
+                'Person+Schema.swift',
+                'Person.swift',
+                'Post+Schema.swift',
+                'Post.swift',
+                'Status.swift',
+                'User+Schema.swift',
+                'User.swift',
+            ],
+        });
+    });
+
+    it(`should not generate files at desired location and not delete src files if no output dir is specified`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_IOS_CONFIG,
+            projectRoot,
+            schemaName,
+            shouldSucceed: false,
+        });
+    });
+});

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-modelgen-js.test.ts
@@ -1,0 +1,57 @@
+import { AmplifyFrontend, createNewProjectDir, DEFAULT_JS_CONFIG, deleteProjectDir } from '@aws-amplify/amplify-codegen-e2e-core';
+import { testUninitializedCodegenModels } from '../codegen-tests-base';
+import * as path from 'path';
+
+const schemaName = 'modelgen/model_gen_schema_with_aws_scalars.graphql';
+
+describe('Uninitialized Project Modelgen tests - JS', () => {
+    let projectRoot: string;
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('uninitializedProjectModelgenJS');
+    });
+
+    afterEach(() => deleteProjectDir(projectRoot));
+
+    it(`should generate files at desired location and not delete src files`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_JS_CONFIG,
+            projectRoot,
+            schemaName,
+            outputDir: path.join('src', 'backmodels'),
+            shouldSucceed: true,
+            expectedFilenames: [
+                'index.d.ts',
+                'index.js',
+                'schema.d.ts',
+                'schema.js',
+            ],
+        });
+    });
+
+    it(`should generate files at desired location and not delete src files for typescript variant`, async () => {
+        await testUninitializedCodegenModels({
+            config: {
+                ...DEFAULT_JS_CONFIG,
+                frontendType: AmplifyFrontend.typescript,
+            },
+            projectRoot,
+            schemaName,
+            outputDir: path.join('src', 'backmodels'),
+            shouldSucceed: true,
+            expectedFilenames: [
+                'index.ts',
+                'schema.ts',
+            ],
+        });
+    });
+
+    it(`should not generate files at desired location and not delete src files if no output dir is specified`, async () => {
+        await testUninitializedCodegenModels({
+            config: DEFAULT_JS_CONFIG,
+            projectRoot,
+            schemaName,
+            shouldSucceed: false,
+        });
+    });
+});

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/index.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/index.ts
@@ -5,3 +5,4 @@ export * from './configure-codegen';
 export * from './remove-codegen';
 export * from './datastore-modelgen';
 export * from './push-codegen';
+export * from './uninitialized-modelgen';

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/uninitialized-modelgen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/uninitialized-modelgen.ts
@@ -1,0 +1,70 @@
+import { generateModelsWithOptions, AmplifyFrontendConfig, AmplifyFrontend, getSchemaPath } from '@aws-amplify/amplify-codegen-e2e-core';
+import { existsSync, writeFileSync, readFileSync, readdirSync } from 'fs';
+import { isNotEmptyDir, generateSourceCode } from '../utils';
+import { createPubspecLockFile } from './datastore-modelgen';
+import path from 'path';
+
+export type TestUninitializedCodegenModelsProps = {
+    config: AmplifyFrontendConfig;
+    projectRoot: string;
+    schemaName: string;
+    shouldSucceed: boolean;
+    outputDir?: string;
+    featureFlags?: Record<string, any>;
+    expectedFilenames?: Array<string>;
+};
+
+export const testUninitializedCodegenModels = async ({
+    config,
+    projectRoot,
+    schemaName,
+    outputDir,
+    shouldSucceed,
+    featureFlags,
+    expectedFilenames,
+}: TestUninitializedCodegenModelsProps): Promise<void> => {
+    // generate pre existing user file
+    const userSourceCodePath = generateSourceCode(projectRoot, config.srcDir);
+
+    // Write Schema File to Schema Path
+    const schemaPath = getSchemaPath(schemaName);
+    const schema = readFileSync(schemaPath).toString();
+    const modelSchemaPath = path.join(config.srcDir, 'schema.graphql');
+    writeFileSync(path.join(projectRoot, modelSchemaPath), schema);
+
+    // For flutter frontend, we need to have a pubspec lock file with supported dart version
+    if (config?.frontendType === AmplifyFrontend.flutter) {
+        createPubspecLockFile(projectRoot);
+    }
+
+    // generate models
+    try {
+        await generateModelsWithOptions(projectRoot, {
+            '--target': config.frontendType,
+            '--model-schema': modelSchemaPath,
+            '--output-dir': outputDir,
+            ...(featureFlags ? Object.entries(featureFlags).map(([ffName, ffVal]) => [`--feature-flag:${ffName}`, ffVal]).flat() : []),
+        });
+    } catch (_) {
+        // This is temporarily expected to throw, since the post-modelgen hook in amplify cli fails, even though modelgen succeeds.
+    }
+
+    // pre-existing file should still exist
+    expect(existsSync(userSourceCodePath)).toBe(true);
+
+    // datastore models are generated at correct location
+    const partialDirToCheck = outputDir
+        ? path.join(projectRoot, outputDir)
+        : path.join(projectRoot, config.modelgenDir);
+    const dirToCheck = config.frontendType === AmplifyFrontend.android
+        ? path.join(partialDirToCheck, 'com', 'amplifyframework', 'datastore', 'generated', 'model')
+        : partialDirToCheck;
+
+    expect(isNotEmptyDir(dirToCheck)).toBe(shouldSucceed);
+
+    if (expectedFilenames) {
+        const foundFiles = new Set(readdirSync(dirToCheck));
+        console.log(`Comparing written files: ${JSON.stringify(Array.from(foundFiles))} to expected files: ${JSON.stringify(expectedFilenames)}`);
+        expectedFilenames.forEach((expectedFilename) => expect(foundFiles.has(expectedFilename)).toBe(true));
+    }
+};

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -5,6 +5,7 @@ const glob = require('glob-all');
 const { FeatureFlags, pathManager } = require('@aws-amplify/amplify-cli-core');
 const { generateModels: generateModelsHelper } = require('@aws-amplify/graphql-generator');
 const { validateAmplifyFlutterMinSupportedVersion } = require('../utils/validateAmplifyFlutterMinSupportedVersion');
+const defaultDirectiveDefinitions = require('../utils/defaultDirectiveDefinitions');
 
 const platformToLanguageMap = {
   android: 'java',
@@ -85,9 +86,14 @@ async function generateModels(context, generateOptions = null) {
   const backendPath = await context.amplify.pathManager.getBackendDirPath();
   const apiResourcePath = path.join(backendPath, 'api', apiResource.resourceName);
 
-  const directiveDefinitions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getTransformerDirectives', {
-    resourceDir: apiResourcePath,
-  });
+  let directiveDefinitions;
+  try {
+    directiveDefinitions = await context.amplify.executeProviderUtils(context, 'awscloudformation', 'getTransformerDirectives', {
+      resourceDir: apiResourcePath,
+    });
+  } catch {
+    directiveDefinitions = defaultDirectiveDefinitions;
+  }
 
   const schemaContent = loadSchema(apiResourcePath);
   const baseOutputDir = overrideOutputDir || path.join(projectRoot, getModelOutputPath(context));

--- a/packages/amplify-codegen/src/commands/models.js
+++ b/packages/amplify-codegen/src/commands/models.js
@@ -5,6 +5,8 @@ const { FeatureFlags, pathManager } = require('@aws-amplify/amplify-cli-core');
 const { generateModels: generateModelsHelper } = require('@aws-amplify/graphql-generator');
 const { validateAmplifyFlutterMinSupportedVersion } = require('../utils/validateAmplifyFlutterMinSupportedVersion');
 const defaultDirectiveDefinitions = require('../utils/defaultDirectiveDefinitions');
+const getProjectRoot = require('../utils/getProjectRoot');
+const { getModelSchemaPathParam, hasModelSchemaPathParam } = require('../utils/getModelSchemaPathParam');
 
 /**
  * Amplify Context type.
@@ -35,44 +37,54 @@ const modelgenFrontendToTargetMap = {
 };
 
 /**
+ * Return feature flag override values from the cli in the format --feature-flag:<feature flag name> <feature flag value>
+ * @param {!AmplifyContext} context the amplify runtime context
+ * @param {!string} flagName the feature flag name
+ * @returns {any | null} the raw value if found, else null
+ */
+const cliFeatureFlagOverride = (context, flagName) => context.parameters?.options?.[`feature-flag:${flagName}`];
+
+/**
  * Returns feature flag value, default to `false`
- * @param {!string} key feature flag id
+ * @param {!AmplifyContext} context the amplify runtime context
+ * @param {!string} flagName feature flag id
  * @returns {!boolean} the feature flag value
  */
-const readFeatureFlag = key => {
-  let flagValue = false;
-  try {
-    flagValue = FeatureFlags.getBoolean(key);
-  } catch (err) {
-    flagValue = false;
+const readFeatureFlag = (context, flagName) => {
+  const cliValue = cliFeatureFlagOverride(context, flagName);
+  if (cliValue) {
+    if (cliValue === 'true' || cliValue === 'True' || cliValue === true) {
+      return true;
+    }
+    if (cliValue === 'false' || cliValue === 'False' || cliValue === false) {
+      return false;
+    }
+    throw new Error(`Feature flag value for parameter ${flagName} could not be marshalled to boolean type, found ${cliValue}`);
   }
-  return flagValue;
+
+  try {
+    return FeatureFlags.getBoolean(flagName);
+  } catch (_) {
+    return false;
+  }
 };
 
 /**
  * Returns feature flag value, default to `1`
- * @param {!string} key feature flag id
+ * @param {!AmplifyContext} context the amplify runtime context
+ * @param {!string} flagName feature flag id
  * @returns {!number} the feature flag value
  */
-const readNumericFeatureFlag = key => {
-  try {
-    return FeatureFlags.getNumber(key);
-  } catch (err) {
-    return 1;
+const readNumericFeatureFlag = (context, flagName) => {
+  const cliValue = cliFeatureFlagOverride(context, flagName);
+  if (cliValue) {
+    return Number.parseInt(cliValue, 10);
   }
-};
 
-/**
- * Retrieve the project root for use in validation and tk
- * @param {!AmplifyContext} context the amplify runtime context
- * @returns {!string} path to the project root, or cwd if not found
- */
-const getProjectRoot = (context) => {
   try {
-    context.amplify.getProjectMeta();
-    return context.amplify.getEnvInfo().projectPath;
+    return FeatureFlags.getNumber(flagName);
   } catch (_) {
-    return process.cwd();
+    return 1;
   }
 };
 
@@ -82,17 +94,26 @@ const getProjectRoot = (context) => {
  * @returns {!Promise<string | null>} the api path, if one can be found, else null
  */
 const getApiResourcePath = async (context) => {
-  const allApiResources = await context.amplify.getResourceStatus('api');
-  const apiResource = allApiResources.allResources.find(
-    resource => resource.service === 'AppSync' && resource.providerPlugin === 'awscloudformation',
-  );
-  if (!apiResource) {
-    context.print.info('No AppSync API configured. Please add an API');
-    return null;
+  const modelSchemaPathParam = getModelSchemaPathParam(context);
+  if (modelSchemaPathParam) {
+    return modelSchemaPathParam;
   }
 
-  const backendPath = await context.amplify.pathManager.getBackendDirPath();
-  return path.join(backendPath, 'api', apiResource.resourceName);
+  try {
+    const allApiResources = await context.amplify.getResourceStatus('api');
+    const apiResource = allApiResources.allResources.find(
+      resource => resource.service === 'AppSync' && resource.providerPlugin === 'awscloudformation',
+    );
+    if (!apiResource) {
+      context.print.info('No AppSync API configured. Please add an API');
+      return null;
+    }
+
+    const backendPath = await context.amplify.pathManager.getBackendDirPath();
+    return path.join(backendPath, 'api', apiResource.resourceName);
+  } catch (_) {
+    throw new Error('Schema resource path not found, if you are running this command from a directory without a local amplify directory, be sure to specify the path to your model schema file or folder via --model-schema.');
+  }
 };
 
 /**
@@ -123,7 +144,11 @@ const getOutputDir = (context, projectRoot, overrideOutputDir) => {
   if (overrideOutputDir) {
     return overrideOutputDir;
   }
-  return path.join(projectRoot, getModelOutputPath(context));
+  try {
+    return path.join(projectRoot, getModelOutputPath(context.amplify.getProjectConfig()));
+  } catch (_) {
+    throw new Error('Output directory could not be determined, to specify, set the --output-dir CLI property.')
+  }
 };
 
 /**
@@ -135,7 +160,20 @@ const getFrontend = (context, isIntrospection) => {
   if (isIntrospection === true) {
     return 'introspection';
   }
-  return context.amplify.getProjectConfig().frontend;
+
+  const targetParam = context.parameters?.options?.['target'];
+  if (targetParam) {
+    if (!modelgenFrontendToTargetMap[targetParam]) {
+      throw new Error(`Unexpected --target value ${targetParam} provided, expected one of ${JSON.stringify(Object.keys(modelgenFrontendToTargetMap))}`)
+    }
+    return targetParam;
+  }
+
+  try {
+    return context.amplify.getProjectConfig().frontend;
+  } catch (_) {
+    throw new Error('Modelgen target not found, if you are running this command from a directory without a local amplify directory, be sure to specify the modelgen target via --target.');
+  }
 };
 
 /**
@@ -149,14 +187,16 @@ const validateProject = async (context, frontend, projectRoot) => {
   const validationFailures = [];
   const validationWarnings = [];
 
-  // Attempt to validate schema compilation, and print any errors
+  // Attempt to validate schema compilation, and print any errors if an override schema path was not presented (in which case this will fail)
   try {
-    await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
-      noConfig: true,
-      forceCompile: true,
-      dryRun: true,
-      disableResolverOverrides: true,
-    });
+    if (!hasModelSchemaPathParam(context)) {
+      await context.amplify.executeProviderUtils(context, 'awscloudformation', 'compileSchema', {
+        noConfig: true,
+        forceCompile: true,
+        dryRun: true,
+        disableResolverOverrides: true,
+      });
+    }
   } catch (err) {
     validationWarnings.push(err.toString());
   }
@@ -221,15 +261,15 @@ async function generateModels(context, generateOptions = null) {
     schema: loadSchema(apiResourcePath),
     directives: await getDirectives(context, apiResourcePath),
     target: modelgenFrontendToTargetMap[frontend],
-    generateIndexRules: readFeatureFlag('codegen.generateIndexRules'),
-    emitAuthProvider: readFeatureFlag('codegen.emitAuthProvider'),
-    useExperimentalPipelinedTransformer: readFeatureFlag('graphQLTransformer.useExperimentalPipelinedTransformer'),
-    transformerVersion: readNumericFeatureFlag('graphQLTransformer.transformerVersion'),
-    respectPrimaryKeyAttributesOnConnectionField: readFeatureFlag('graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField'),
-    improvePluralization: readFeatureFlag('graphQLTransformer.improvePluralization'),
-    generateModelsForLazyLoadAndCustomSelectionSet: readFeatureFlag('codegen.generateModelsForLazyLoadAndCustomSelectionSet'),
-    addTimestampFields: readFeatureFlag('codegen.addTimestampFields'),
-    handleListNullabilityTransparently: readFeatureFlag('codegen.handleListNullabilityTransparently'),
+    generateIndexRules: readFeatureFlag(context, 'codegen.generateIndexRules'),
+    emitAuthProvider: readFeatureFlag(context, 'codegen.emitAuthProvider'),
+    useExperimentalPipelinedTransformer: readFeatureFlag(context, 'graphQLTransformer.useExperimentalPipelinedTransformer'),
+    transformerVersion: readNumericFeatureFlag(context, 'graphQLTransformer.transformerVersion'),
+    respectPrimaryKeyAttributesOnConnectionField: readFeatureFlag(context, 'graphQLTransformer.respectPrimaryKeyAttributesOnConnectionField'),
+    improvePluralization: readFeatureFlag(context, 'graphQLTransformer.improvePluralization'),
+    generateModelsForLazyLoadAndCustomSelectionSet: readFeatureFlag(context, 'codegen.generateModelsForLazyLoadAndCustomSelectionSet'),
+    addTimestampFields: readFeatureFlag(context, 'codegen.addTimestampFields'),
+    handleListNullabilityTransparently: readFeatureFlag(context, 'codegen.handleListNullabilityTransparently'),
   });
 
   if (writeToDisk) {
@@ -253,6 +293,9 @@ async function generateModels(context, generateOptions = null) {
  * @returns {!string} the graphql string for all schema files found
  */
 function loadSchema(apiResourcePath) {
+  if (fs.lstatSync(apiResourcePath).isFile()) {
+    return fs.readFileSync(apiResourcePath, 'utf8');
+  }
   const schemaFilePath = path.join(apiResourcePath, 'schema.graphql');
   const schemaDirectory = path.join(apiResourcePath, 'schema');
   if (fs.pathExistsSync(schemaFilePath)) {
@@ -269,11 +312,10 @@ function loadSchema(apiResourcePath) {
 
 /**
  * Retrieve the model output path for the given project configuration
- * @param {!AmplifyContext} context the amplify runtime context
+ * @param {any} projectConfig the amplify runtime context
  * @returns the model output path, relative to the project root
  */
-function getModelOutputPath(context) {
-  const projectConfig = context.amplify.getProjectConfig();
+function getModelOutputPath(projectConfig) {
   switch (projectConfig.frontend) {
     case 'javascript':
       return path.join(
@@ -301,20 +343,26 @@ function getModelOutputPath(context) {
  * @returns once eslint side effecting is complete
  */
 function generateEslintIgnore(context) {
-  const projectConfig = context.amplify.getProjectConfig();
+  let projectConfig;
+  let projectPath;
+  try {
+    projectConfig = context.amplify.getProjectConfig();
+    projectPath = pathManager.findProjectRoot();
+  } catch (_) {
+    return;
+  }
 
   if (projectConfig.frontend !== 'javascript') {
     return;
   }
 
-  const projectPath = pathManager.findProjectRoot();
 
   if (!projectPath) {
     return;
   }
 
   const eslintIgnorePath = path.join(projectPath, '.eslintignore');
-  const modelFolder = path.join(getModelOutputPath(context), 'models');
+  const modelFolder = path.join(getModelOutputPath(projectConfig), 'models');
 
   if (!fs.existsSync(eslintIgnorePath)) {
     fs.writeFileSync(eslintIgnorePath, modelFolder);

--- a/packages/amplify-codegen/src/utils/defaultDirectiveDefinitions.js
+++ b/packages/amplify-codegen/src/utils/defaultDirectiveDefinitions.js
@@ -1,0 +1,113 @@
+const defaultDirectiveDefinitions = `
+directive @aws_subscribe(mutations: [String!]!) on FIELD_DEFINITION
+
+directive @aws_auth(cognito_groups: [String!]!) on FIELD_DEFINITION
+
+directive @aws_api_key on FIELD_DEFINITION | OBJECT
+
+directive @aws_iam on FIELD_DEFINITION | OBJECT
+
+directive @aws_oidc on FIELD_DEFINITION | OBJECT
+
+directive @aws_cognito_user_pools(cognito_groups: [String!]) on FIELD_DEFINITION | OBJECT
+
+directive @aws_lambda on FIELD_DEFINITION | OBJECT
+
+directive @deprecated(reason: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION | ENUM | ENUM_VALUE
+
+directive @model(queries: ModelQueryMap, mutations: ModelMutationMap, subscriptions: ModelSubscriptionMap, timestamps: TimestampConfiguration) on OBJECT
+input ModelMutationMap {
+  create: String
+  update: String
+  delete: String
+}
+input ModelQueryMap {
+  get: String
+  list: String
+}
+input ModelSubscriptionMap {
+  onCreate: [String]
+  onUpdate: [String]
+  onDelete: [String]
+  level: ModelSubscriptionLevel
+}
+enum ModelSubscriptionLevel {
+  off
+  public
+  on
+}
+input TimestampConfiguration {
+  createdAt: String
+  updatedAt: String
+}
+directive @function(name: String!, region: String, accountId: String) repeatable on FIELD_DEFINITION
+directive @http(method: HttpMethod = GET, url: String!, headers: [HttpHeader] = []) on FIELD_DEFINITION
+enum HttpMethod {
+  GET
+  POST
+  PUT
+  DELETE
+  PATCH
+}
+input HttpHeader {
+  key: String
+  value: String
+}
+directive @predictions(actions: [PredictionsActions!]!) on FIELD_DEFINITION
+enum PredictionsActions {
+  identifyText
+  identifyLabels
+  convertTextToSpeech
+  translateText
+}
+directive @primaryKey(sortKeyFields: [String]) on FIELD_DEFINITION
+directive @index(name: String, sortKeyFields: [String], queryField: String) repeatable on FIELD_DEFINITION
+directive @hasMany(indexName: String, fields: [String!], limit: Int = 100) on FIELD_DEFINITION
+directive @hasOne(fields: [String!]) on FIELD_DEFINITION
+directive @manyToMany(relationName: String!, limit: Int = 100) on FIELD_DEFINITION
+directive @belongsTo(fields: [String!]) on FIELD_DEFINITION
+directive @default(value: String!) on FIELD_DEFINITION
+directive @auth(rules: [AuthRule!]!) on OBJECT | FIELD_DEFINITION
+input AuthRule {
+  allow: AuthStrategy!
+  provider: AuthProvider
+  identityClaim: String
+  groupClaim: String
+  ownerField: String
+  groupsField: String
+  groups: [String]
+  operations: [ModelOperation]
+}
+enum AuthStrategy {
+  owner
+  groups
+  private
+  public
+  custom
+}
+enum AuthProvider {
+  apiKey
+  iam
+  oidc
+  userPools
+  function
+}
+enum ModelOperation {
+  create
+  update
+  delete
+  read
+  list
+  get
+  sync
+  listen
+  search
+}
+directive @mapsTo(name: String!) on OBJECT
+directive @searchable(queries: SearchableQueryMap) on OBJECT
+input SearchableQueryMap {
+  search: String
+}
+`;
+
+module.exports = defaultDirectiveDefinitions;

--- a/packages/amplify-codegen/src/utils/getModelSchemaPathParam.js
+++ b/packages/amplify-codegen/src/utils/getModelSchemaPathParam.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const getProjectRoot = require('./getProjectRoot');
+
+/**
+ * Retrieve the specified model schema path parameter, returning as an absolute path.
+ * @param {!import('@aws-amplify/amplify-cli-core').$TSContext} context the CLI invocation context
+ * @returns {string | null} the absolute path to the model schema path
+ */
+const getModelSchemaPathParam = (context) => {
+  const modelSchemaPathParam = context.parameters?.options?.['model-schema'];
+  if ( !modelSchemaPathParam ) {
+    return null;
+  }
+  return path.isAbsolute(modelSchemaPathParam) ? modelSchemaPathParam : path.join(getProjectRoot(context), modelSchemaPathParam);
+};
+
+/**
+ * Retrieve whether or not a model schema path param was specified during invocation.
+ * @param {!import('@aws-amplify/amplify-cli-core').$TSContext} context the CLI invocation context
+ * @returns {!boolean} whether or not a model schema path param is specified via the CLI
+ */
+const hasModelSchemaPathParam = (context) => getModelSchemaPathParam(context) !== null;
+
+module.exports = {
+  getModelSchemaPathParam,
+  hasModelSchemaPathParam,
+};

--- a/packages/amplify-codegen/src/utils/getOutputDirParam.js
+++ b/packages/amplify-codegen/src/utils/getOutputDirParam.js
@@ -1,11 +1,12 @@
 const path = require('path');
+const getProjectRoot = require('./getProjectRoot');
 
 /**
  * Retrieve the output directory parameter from the command line. Throws on invalid value,
  *   or if isRequired is set and the flag isn't in the options. Returns null on optional and not defined.
- * @param context the CLI invocation context
- * @param isRequired whether or not the flag is required
- * @returns the absolute path to the output directory
+ * @param {!import('@aws-amplify/amplify-cli-core').$TSContext} context the CLI invocation context
+ * @param {!boolean} isRequired whether or not the flag is required
+ * @returns {!string} the absolute path to the output directory
  */
 function getOutputDirParam(context, isRequired) {
   const outputDirParam = context.parameters?.options?.['output-dir'];
@@ -15,7 +16,7 @@ function getOutputDirParam(context, isRequired) {
   if ( !outputDirParam ) {
     return null;
   }
-  return path.isAbsolute(outputDirParam) ? outputDirParam : path.join(context.amplify.getEnvInfo().projectPath, outputDirParam);
+  return path.isAbsolute(outputDirParam) ? outputDirParam : path.join(getProjectRoot(context), outputDirParam);
 }
 
 module.exports = getOutputDirParam;

--- a/packages/amplify-codegen/src/utils/getProjectRoot.js
+++ b/packages/amplify-codegen/src/utils/getProjectRoot.js
@@ -1,0 +1,14 @@
+/**
+ * Find the project root.
+ * @param {!import('@aws-amplify/amplify-cli-core').$TSContext} context the amplify runtime context
+ * @returns {!string} the project root, or cwd
+ */
+const getProjectRoot = (context) => {
+  try {
+    return context.amplify.getEnvInfo().projectPath;
+  } catch (_) {
+    return process.cwd();
+  }
+  };
+
+module.exports = getProjectRoot;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -15,6 +15,7 @@ const getSDLSchemaLocation = require('./getSDLSchemaLocation');
 const switchToSDLSchema = require('./switchToSDLSchema');
 const ensureIntrospectionSchema = require('./ensureIntrospectionSchema');
 const { readSchemaFromFile } = require('./readSchemaFromFile');
+const defaultDirectiveDefinitions = require('./defaultDirectiveDefinitions');
 module.exports = {
   getAppSyncAPIDetails,
   getFrontEndHandler,
@@ -33,4 +34,5 @@ module.exports = {
   switchToSDLSchema,
   ensureIntrospectionSchema,
   readSchemaFromFile,
+  defaultDirectiveDefinitions,
 };

--- a/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`command-models-generates models in expected output path android: Should generate for frontend when backend is not initialized locally, and logs no warnings or errors 1`] = `
+Array [
+  "AmplifyModelProvider.java",
+  "SimpleModel.java",
+]
+`;
+
 exports[`command-models-generates models in expected output path android: Should generate models from a single schema file 1`] = `
 Array [
   "AmplifyModelProvider.java",
@@ -11,6 +18,13 @@ exports[`command-models-generates models in expected output path android: Should
 Array [
   "AmplifyModelProvider.java",
   "SimpleModel.java",
+]
+`;
+
+exports[`command-models-generates models in expected output path flutter: Should generate for frontend when backend is not initialized locally, and logs no warnings or errors 1`] = `
+Array [
+  "ModelProvider.dart",
+  "SimpleModel.dart",
 ]
 `;
 
@@ -28,6 +42,14 @@ Array [
 ]
 `;
 
+exports[`command-models-generates models in expected output path ios: Should generate for frontend when backend is not initialized locally, and logs no warnings or errors 1`] = `
+Array [
+  "AmplifyModels.swift",
+  "SimpleModel+Schema.swift",
+  "SimpleModel.swift",
+]
+`;
+
 exports[`command-models-generates models in expected output path ios: Should generate models from a single schema file 1`] = `
 Array [
   "AmplifyModels.swift",
@@ -41,6 +63,15 @@ Array [
   "AmplifyModels.swift",
   "SimpleModel+Schema.swift",
   "SimpleModel.swift",
+]
+`;
+
+exports[`command-models-generates models in expected output path javascript: Should generate for frontend when backend is not initialized locally, and logs no warnings or errors 1`] = `
+Array [
+  "index.d.ts",
+  "index.js",
+  "schema.d.ts",
+  "schema.js",
 ]
 `;
 

--- a/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/models.test.js.snap
@@ -61,3 +61,12 @@ Array [
   "schema.js",
 ]
 `;
+
+exports[`command-models-generates models in expected output path should use default directive definitions if getTransformerDirectives fails 1`] = `
+Array [
+  "index.d.ts",
+  "index.js",
+  "schema.d.ts",
+  "schema.js",
+]
+`;

--- a/packages/amplify-codegen/tests/commands/model-introspection.test.js
+++ b/packages/amplify-codegen/tests/commands/model-introspection.test.js
@@ -31,6 +31,7 @@ const MOCK_CONTEXT = {
   print: {
     info: jest.fn(),
     warning: jest.fn(),
+    error: jest.fn(),
   },
   amplify: {
     getProjectMeta: jest.fn(),

--- a/packages/amplify-codegen/tests/commands/models.test.js
+++ b/packages/amplify-codegen/tests/commands/models.test.js
@@ -32,6 +32,9 @@ const MOCK_CONTEXT = {
     },
     getProjectConfig: jest.fn(),
   },
+  parameters: {
+    options: {},
+  },
 };
 const OUTPUT_PATHS = {
   javascript: 'src/models',
@@ -42,11 +45,11 @@ const OUTPUT_PATHS = {
 const MOCK_PROJECT_ROOT = 'project';
 const MOCK_PROJECT_NAME = 'myapp';
 const MOCK_BACKEND_DIRECTORY = 'backend';
-const MOCK_GENERATED_CODE = 'This code is auto-generated!';
 
 describe('command-models-generates models in expected output path', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    MOCK_CONTEXT.parameters.options = {};
     addMocksToContext();
     validateAmplifyFlutterMinSupportedVersion.mockReturnValue(true);
   });
@@ -57,7 +60,6 @@ describe('command-models-generates models in expected output path', () => {
       const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
       const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
       const mockedFiles = {};
-      const nodeModules = path.resolve(path.join(__dirname, '../../../../node_modules'));
       mockedFiles[schemaFilePath] = {
         'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
       };
@@ -142,7 +144,131 @@ describe('command-models-generates models in expected output path', () => {
         expect(MOCK_CONTEXT.print.error).toBeCalled();
       });
     }
+
+    it(frontend + ': Should generate for frontend when backend is not initialized locally, and logs no warnings or errors', async () => {
+      // mock the input and output file structure
+      const mockedFiles = {};
+      mockedFiles[MOCK_PROJECT_ROOT] = {
+        'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
+      };
+      const overrideOutputDir = 'some/other/dir';
+      mockedFiles[overrideOutputDir] = {};
+      mockFs(mockedFiles);
+
+      // For non-intialized projects, assume the amplify context throws primarily errors, and instead input is provided via options
+      MOCK_CONTEXT.amplify.getEnvInfo.mockImplementation(() => { throw new Error('getEnvInfo Internal Error') });
+      MOCK_CONTEXT.amplify.getProjectConfig.mockImplementation(() => { throw new Error('getProjectConfig Internal Error') });
+      MOCK_CONTEXT.amplify.getResourceStatus.mockImplementation(() => { throw new Error('getResourceStatus Internal Error') });
+      MOCK_CONTEXT.amplify.executeProviderUtils.mockImplementation(() => { throw new Error('executeProviderUtils Internal Error') });
+      MOCK_CONTEXT.parameters.options = { target: frontend, 'model-schema': path.join(MOCK_PROJECT_ROOT, 'schema.graphql') };
+
+      // assert empty folder before generation
+      expect(fs.readdirSync(overrideOutputDir).length).toEqual(0);
+
+      await generateModels(MOCK_CONTEXT, { overrideOutputDir });
+
+      // assert model files are generated in expected output directory
+      expect(fs.readdirSync(overrideOutputDir).length).not.toEqual(0);
+
+      expect(MOCK_CONTEXT.print.error).not.toBeCalled();
+      expect(MOCK_CONTEXT.print.warning).not.toBeCalled();
+
+      if (frontend === 'android') {
+        // Android/Java creates a deeply nested structure, which is preserved as a partial in the output files.
+        expect(fs.readdirSync(path.join(overrideOutputDir, 'com', 'amplifyframework', 'datastore', 'generated', 'model'))).toMatchSnapshot();
+      } else {
+        expect(fs.readdirSync(overrideOutputDir)).toMatchSnapshot();
+      }
+    });
   }
+
+  it('throws an understandable error on invalid target option', async () => {
+    // mock the input and output file structure
+    const mockedFiles = {};
+    mockedFiles[MOCK_PROJECT_ROOT] = {
+      'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
+    };
+    const overrideOutputDir = 'some/other/dir';
+    mockedFiles[overrideOutputDir] = {};
+    mockFs(mockedFiles);
+
+    // For non-intialized projects, assume the amplify context throws primarily errors, and instead input is provided via options
+    MOCK_CONTEXT.amplify.getEnvInfo.mockImplementation(() => { throw new Error('getEnvInfo Internal Error') });
+    MOCK_CONTEXT.amplify.getProjectConfig.mockImplementation(() => { throw new Error('getProjectConfig Internal Error') });
+    MOCK_CONTEXT.amplify.getResourceStatus.mockImplementation(() => { throw new Error('getResourceStatus Internal Error') });
+    MOCK_CONTEXT.amplify.executeProviderUtils.mockImplementation(() => { throw new Error('executeProviderUtils Internal Error') });
+    MOCK_CONTEXT.parameters.options = { target: 'clojure', 'model-schema': path.join(MOCK_PROJECT_ROOT, 'schema.graphql') };
+
+    await expect(() => generateModels(MOCK_CONTEXT, { overrideOutputDir }))
+      .rejects
+      .toThrowErrorMatchingInlineSnapshot('"Unexpected --target value clojure provided, expected one of [\\"android\\",\\"ios\\",\\"flutter\\",\\"javascript\\",\\"typescript\\",\\"introspection\\"]"');
+  });
+
+  it('throws an understandable error on missing model-schema flag and uninitialized backend', async () => {
+    // mock the input and output file structure
+    const mockedFiles = {};
+    mockedFiles[MOCK_PROJECT_ROOT] = {
+      'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
+    };
+    const overrideOutputDir = 'some/other/dir';
+    mockedFiles[overrideOutputDir] = {};
+    mockFs(mockedFiles);
+
+    // For non-intialized projects, assume the amplify context throws primarily errors, and instead input is provided via options
+    MOCK_CONTEXT.amplify.getEnvInfo.mockImplementation(() => { throw new Error('getEnvInfo Internal Error') });
+    MOCK_CONTEXT.amplify.getProjectConfig.mockImplementation(() => { throw new Error('getProjectConfig Internal Error') });
+    MOCK_CONTEXT.amplify.getResourceStatus.mockImplementation(() => { throw new Error('getResourceStatus Internal Error') });
+    MOCK_CONTEXT.amplify.executeProviderUtils.mockImplementation(() => { throw new Error('executeProviderUtils Internal Error') });
+    MOCK_CONTEXT.parameters.options = { target: 'javascript' };
+
+    await expect(() => generateModels(MOCK_CONTEXT, { overrideOutputDir }))
+      .rejects
+      .toThrowErrorMatchingInlineSnapshot('"Schema resource path not found, if you are running this command from a directory without a local amplify directory, be sure to specify the path to your model schema file or folder via --model-schema."');
+  });
+
+  it('throws an understandable error on missing target flag and uninitialized backend', async () => {
+    // mock the input and output file structure
+    const mockedFiles = {};
+    mockedFiles[MOCK_PROJECT_ROOT] = {
+      'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
+    };
+    const overrideOutputDir = 'some/other/dir';
+    mockedFiles[overrideOutputDir] = {};
+    mockFs(mockedFiles);
+
+    // For non-intialized projects, assume the amplify context throws primarily errors, and instead input is provided via options
+    MOCK_CONTEXT.amplify.getEnvInfo.mockImplementation(() => { throw new Error('getEnvInfo Internal Error') });
+    MOCK_CONTEXT.amplify.getProjectConfig.mockImplementation(() => { throw new Error('getProjectConfig Internal Error') });
+    MOCK_CONTEXT.amplify.getResourceStatus.mockImplementation(() => { throw new Error('getResourceStatus Internal Error') });
+    MOCK_CONTEXT.amplify.executeProviderUtils.mockImplementation(() => { throw new Error('executeProviderUtils Internal Error') });
+    MOCK_CONTEXT.parameters.options = { 'model-schema': path.join(MOCK_PROJECT_ROOT, 'schema.graphql') };
+
+    await expect(() => generateModels(MOCK_CONTEXT, { overrideOutputDir }))
+      .rejects
+      .toThrowErrorMatchingInlineSnapshot('"Modelgen target not found, if you are running this command from a directory without a local amplify directory, be sure to specify the modelgen target via --target."');
+  });
+
+  it('throws an understandable error on missing override output dir and uninitialized backend', async () => {
+    // mock the input and output file structure
+    const mockedFiles = {};
+    mockedFiles[MOCK_PROJECT_ROOT] = {
+      'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
+    };
+    const overrideOutputDir = 'some/other/dir';
+    mockedFiles[overrideOutputDir] = {};
+    mockFs(mockedFiles);
+
+    // For non-intialized projects, assume the amplify context throws primarily errors, and instead input is provided via options
+    MOCK_CONTEXT.amplify.getEnvInfo.mockImplementation(() => { throw new Error('getEnvInfo Internal Error') });
+    MOCK_CONTEXT.amplify.getProjectConfig.mockImplementation(() => { throw new Error('getProjectConfig Internal Error') });
+    MOCK_CONTEXT.amplify.getResourceStatus.mockImplementation(() => { throw new Error('getResourceStatus Internal Error') });
+    MOCK_CONTEXT.amplify.executeProviderUtils.mockImplementation(() => { throw new Error('executeProviderUtils Internal Error') });
+    MOCK_CONTEXT.parameters.options = { target: 'javascript', 'model-schema': path.join(MOCK_PROJECT_ROOT, 'schema.graphql') };
+
+    await expect(() => generateModels(MOCK_CONTEXT))
+      .rejects
+      .toThrowErrorMatchingInlineSnapshot('"Output directory could not be determined, to specify, set the --output-dir CLI property."');
+  });
 
   it('should use default directive definitions if getTransformerDirectives fails', async () => {
     MOCK_CONTEXT.amplify.executeProviderUtils.mockRejectedValue('no amplify project');
@@ -151,7 +277,6 @@ describe('command-models-generates models in expected output path', () => {
     const schemaFilePath = path.join(MOCK_BACKEND_DIRECTORY, 'api', MOCK_PROJECT_NAME);
     const outputDirectory = path.join(MOCK_PROJECT_ROOT, OUTPUT_PATHS[frontend]);
     const mockedFiles = {};
-    const nodeModules = path.resolve(path.join(__dirname, '../../../../node_modules'));
     mockedFiles[schemaFilePath] = {
       'schema.graphql': ' type SimpleModel @model { id: ID! status: String } ',
     };

--- a/packages/amplify-codegen/tests/utils/getModelSchemaPathParam.test.js
+++ b/packages/amplify-codegen/tests/utils/getModelSchemaPathParam.test.js
@@ -1,0 +1,39 @@
+const { getModelSchemaPathParam, hasModelSchemaPathParam } = require('../../src/utils/getModelSchemaPathParam');
+const path = require('path');
+
+const PROJECT_PATH = path.join(__dirname, 'project');
+
+const createContextWithOptions = (options) => ({
+  amplify: {
+    getEnvInfo: () => ({
+      projectPath: PROJECT_PATH
+    }),
+  },
+  ...(options ? { parameters: { options } } : {})
+});
+
+describe('getModelSchemaPathParam', () => {
+  it('should return null when no flag is set', () => {
+    expect(getModelSchemaPathParam(createContextWithOptions(null))).toBeNull();
+  });
+
+  it('should return for relative path', () => {
+    const context = createContextWithOptions({ 'model-schema': path.join('src', 'models') });
+    expect(getModelSchemaPathParam(context)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+  });
+
+  it('should return for absolute path', () => {
+    const context = createContextWithOptions({ 'model-schema': path.join(PROJECT_PATH, 'src', 'models') });
+    expect(getModelSchemaPathParam(context)).toEqual(path.join(PROJECT_PATH, 'src', 'models'));
+  });
+});
+
+describe('hasModelSchemaPathParam', () => {
+  it('returns true when a path is set', () => {
+    expect(hasModelSchemaPathParam(createContextWithOptions({ 'model-schema': 'path' }))).toEqual(true);
+  });
+
+  it('returns false when no path is set', () => {
+    expect(hasModelSchemaPathParam(createContextWithOptions(null))).toEqual(false);
+  });
+});

--- a/packages/amplify-codegen/tests/utils/getProjectRoot.test.js
+++ b/packages/amplify-codegen/tests/utils/getProjectRoot.test.js
@@ -1,0 +1,25 @@
+const getProjectRoot = require('../../src/utils/getProjectRoot');
+const path = require('path');
+const process = require('process');
+
+const PROJECT_PATH = path.join(__dirname, 'project');
+
+describe('getProjectRoot', () => {
+  it('returns project path from context when it returns', () => {
+    expect(getProjectRoot(({
+      amplify: {
+        getEnvInfo: () => ({ projectPath: PROJECT_PATH }),
+      },
+    }))).toEqual(PROJECT_PATH);
+  });
+
+  it('returns os.cwd when context throws', () => {
+    expect(getProjectRoot(({
+      amplify: {
+        getEnvInfo: () => {
+          throw new Error();
+        },
+      },
+    }))).toEqual(process.cwd());
+  });
+});


### PR DESCRIPTION
#### Description of changes
Release support fro amplify codegen models without an amplify app initialized locally.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests + Exploratory Testing with the CLI

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.