### PR TITLE
fix: avoid name collision on java model build step

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -7494,6 +7494,206 @@ public final class Todo implements Model {
 "
 `;
 
+exports[`AppSyncModelVisitor should avoid name collision on builder step 1`] = `
+"package com.amplifyframework.datastore.generated.model;
+
+import com.amplifyframework.core.model.temporal.Temporal;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.Objects;
+
+import androidx.core.util.ObjectsCompat;
+
+import com.amplifyframework.core.model.Model;
+import com.amplifyframework.core.model.annotations.Index;
+import com.amplifyframework.core.model.annotations.ModelConfig;
+import com.amplifyframework.core.model.annotations.ModelField;
+import com.amplifyframework.core.model.query.predicate.QueryField;
+
+import static com.amplifyframework.core.model.query.predicate.QueryField.field;
+
+/** This is an auto generated class representing the MyObject type in your schema. */
+@SuppressWarnings(\\"all\\")
+@ModelConfig(pluralName = \\"MyObjects\\")
+public final class MyObject implements Model {
+  public static final QueryField ID = field(\\"MyObject\\", \\"id\\");
+  public static final QueryField TUTORIAL = field(\\"MyObject\\", \\"tutorial\\");
+  public static final QueryField FORM_CUES = field(\\"MyObject\\", \\"formCues\\");
+  private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
+  private final @ModelField(targetType=\\"TutorialStep\\", isRequired = true) List<TutorialStep> tutorial;
+  private final @ModelField(targetType=\\"FormCue\\", isRequired = true) List<FormCue> formCues;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
+  private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
+  public String getId() {
+      return id;
+  }
+  
+  public List<TutorialStep> getTutorial() {
+      return tutorial;
+  }
+  
+  public List<FormCue> getFormCues() {
+      return formCues;
+  }
+  
+  public Temporal.DateTime getCreatedAt() {
+      return createdAt;
+  }
+  
+  public Temporal.DateTime getUpdatedAt() {
+      return updatedAt;
+  }
+  
+  private MyObject(String id, List<TutorialStep> tutorial, List<FormCue> formCues) {
+    this.id = id;
+    this.tutorial = tutorial;
+    this.formCues = formCues;
+  }
+  
+  @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      } else if(obj == null || getClass() != obj.getClass()) {
+        return false;
+      } else {
+      MyObject myObject = (MyObject) obj;
+      return ObjectsCompat.equals(getId(), myObject.getId()) &&
+              ObjectsCompat.equals(getTutorial(), myObject.getTutorial()) &&
+              ObjectsCompat.equals(getFormCues(), myObject.getFormCues()) &&
+              ObjectsCompat.equals(getCreatedAt(), myObject.getCreatedAt()) &&
+              ObjectsCompat.equals(getUpdatedAt(), myObject.getUpdatedAt());
+      }
+  }
+  
+  @Override
+   public int hashCode() {
+    return new StringBuilder()
+      .append(getId())
+      .append(getTutorial())
+      .append(getFormCues())
+      .append(getCreatedAt())
+      .append(getUpdatedAt())
+      .toString()
+      .hashCode();
+  }
+  
+  @Override
+   public String toString() {
+    return new StringBuilder()
+      .append(\\"MyObject {\\")
+      .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
+      .append(\\"tutorial=\\" + String.valueOf(getTutorial()) + \\", \\")
+      .append(\\"formCues=\\" + String.valueOf(getFormCues()) + \\", \\")
+      .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
+      .append(\\"}\\")
+      .toString();
+  }
+  
+  public static TutorialBuildStep builder() {
+      return new Builder();
+  }
+  
+  /**
+   * WARNING: This method should not be used to build an instance of this object for a CREATE mutation.
+   * This is a convenience method to return an instance of the object with only its ID populated
+   * to be used in the context of a parameter in a delete mutation or referencing a foreign key
+   * in a relationship.
+   * @param id the id of the existing item this instance will represent
+   * @return an instance of this model with only ID populated
+   */
+  public static MyObject justId(String id) {
+    return new MyObject(
+      id,
+      null,
+      null
+    );
+  }
+  
+  public CopyOfBuilder copyOfBuilder() {
+    return new CopyOfBuilder(id,
+      tutorial,
+      formCues);
+  }
+  public interface TutorialBuildStep {
+    FormCuesStep tutorial(List<TutorialStep> tutorial);
+  }
+  
+
+  public interface FormCuesStep {
+    BuildStep formCues(List<FormCue> formCues);
+  }
+  
+
+  public interface BuildStep {
+    MyObject build();
+    BuildStep id(String id);
+  }
+  
+
+  public static class Builder implements TutorialBuildStep, FormCuesStep, BuildStep {
+    private String id;
+    private List<TutorialStep> tutorial;
+    private List<FormCue> formCues;
+    @Override
+     public MyObject build() {
+        String id = this.id != null ? this.id : UUID.randomUUID().toString();
+        
+        return new MyObject(
+          id,
+          tutorial,
+          formCues);
+    }
+    
+    @Override
+     public FormCuesStep tutorial(List<TutorialStep> tutorial) {
+        Objects.requireNonNull(tutorial);
+        this.tutorial = tutorial;
+        return this;
+    }
+    
+    @Override
+     public BuildStep formCues(List<FormCue> formCues) {
+        Objects.requireNonNull(formCues);
+        this.formCues = formCues;
+        return this;
+    }
+    
+    /**
+     * @param id id
+     * @return Current Builder instance, for fluent method chaining
+     */
+    public BuildStep id(String id) {
+        this.id = id;
+        return this;
+    }
+  }
+  
+
+  public final class CopyOfBuilder extends Builder {
+    private CopyOfBuilder(String id, List<TutorialStep> tutorial, List<FormCue> formCues) {
+      super.id(id);
+      super.tutorial(tutorial)
+        .formCues(formCues);
+    }
+    
+    @Override
+     public CopyOfBuilder tutorial(List<TutorialStep> tutorial) {
+      return (CopyOfBuilder) super.tutorial(tutorial);
+    }
+    
+    @Override
+     public CopyOfBuilder formCues(List<FormCue> formCues) {
+      return (CopyOfBuilder) super.formCues(formCues);
+    }
+  }
+  
+}
+"
+`;
+
 exports[`AppSyncModelVisitor should generate Temporal type for AWSDate* scalars 1`] = `
 "package com.amplifyframework.datastore.generated.model;
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -13,7 +13,14 @@ import {
 } from '../configs/java-config';
 import { JAVA_TYPE_IMPORT_MAP } from '../scalars';
 import { JavaDeclarationBlock } from '../languages/java-declaration-block';
-import { AppSyncModelVisitor, CodeGenField, CodeGenModel, CodeGenPrimaryKeyType, ParsedAppSyncModelConfig, RawAppSyncModelConfig } from './appsync-visitor';
+import {
+  AppSyncModelVisitor,
+  CodeGenField,
+  CodeGenModel,
+  CodeGenPrimaryKeyType,
+  ParsedAppSyncModelConfig,
+  RawAppSyncModelConfig,
+} from './appsync-visitor';
 import { CodeGenConnectionType } from '../utils/process-connections';
 import { AuthDirective, AuthStrategy } from '../utils/process-auth';
 import { printWarning } from '../utils/warn';
@@ -31,10 +38,7 @@ export class AppSyncModelJavaVisitor<
     const shouldUseModelNameFieldInHasManyAndBelongsTo = true;
     // This flag is going to be used to tight-trigger on JS implementations only.
     const shouldImputeKeyForUniDirectionalHasMany = false;
-    this.processDirectives(
-      shouldUseModelNameFieldInHasManyAndBelongsTo,
-      shouldImputeKeyForUniDirectionalHasMany
-    );
+    this.processDirectives(shouldUseModelNameFieldInHasManyAndBelongsTo, shouldImputeKeyForUniDirectionalHasMany);
 
     if (this._parsedConfig.generate === 'loader') {
       return this.generateClassLoader();
@@ -377,7 +381,13 @@ export class AppSyncModelJavaVisitor<
    * @param classDeclaration
    */
   protected generateIdentifierClassField(model: CodeGenModel, classDeclaration: JavaDeclarationBlock): void {
-    classDeclaration.addClassMember(this.getModelIdentifierClassFieldName(model), this.getModelIdentifierClassName(model), '', undefined, 'private');
+    classDeclaration.addClassMember(
+      this.getModelIdentifierClassFieldName(model),
+      this.getModelIdentifierClassName(model),
+      '',
+      undefined,
+      'private',
+    );
   }
   /**
    * Generate step builder interfaces for each non-null field in the model
@@ -386,11 +396,15 @@ export class AppSyncModelJavaVisitor<
   protected generateStepBuilderInterfaces(model: CodeGenModel, isIdAsModelPrimaryKey: boolean = true): JavaDeclarationBlock[] {
     const nonNullableFields = this.getWritableFields(model).filter(field => this.isRequiredField(field));
     const nullableFields = this.getWritableFields(model).filter(field => !this.isRequiredField(field));
-    const requiredInterfaces = nonNullableFields.filter((field: CodeGenField) => !(isIdAsModelPrimaryKey && this.READ_ONLY_FIELDS.includes(field.name)));
+    const requiredInterfaces = nonNullableFields.filter(
+      (field: CodeGenField) => !(isIdAsModelPrimaryKey && this.READ_ONLY_FIELDS.includes(field.name)),
+    );
+    const types = this.getTypesUsedByModel(model);
+
     const interfaces = requiredInterfaces.map((field, idx) => {
       const isLastField = requiredInterfaces.length - 1 === idx ? true : false;
       const returnType = isLastField ? 'Build' : requiredInterfaces[idx + 1].name;
-      const interfaceName = this.getStepInterfaceName(field.name);
+      const interfaceName = this.getStepInterfaceName(field.name, types);
       const methodName = this.getStepFunctionName(field);
       const argumentType = this.getNativeType(field);
       const argumentName = this.getStepFunctionArgumentName(field);
@@ -398,14 +412,16 @@ export class AppSyncModelJavaVisitor<
         .asKind('interface')
         .withName(interfaceName)
         .access('public');
-      interfaceDeclaration.withBlock(indent(`${this.getStepInterfaceName(returnType)} ${methodName}(${argumentType} ${argumentName});`));
+      interfaceDeclaration.withBlock(
+        indent(`${this.getStepInterfaceName(returnType, types)} ${methodName}(${argumentType} ${argumentName});`),
+      );
       return interfaceDeclaration;
     });
 
     // Builder
     const builder = new JavaDeclarationBlock()
       .asKind('interface')
-      .withName(this.getStepInterfaceName('Build'))
+      .withName(this.getStepInterfaceName('Build', types))
       .access('public');
     const builderBody = [];
     // build method
@@ -413,13 +429,13 @@ export class AppSyncModelJavaVisitor<
 
     if (isIdAsModelPrimaryKey) {
       // id method. Special case as this can throw exception
-      builderBody.push(`${this.getStepInterfaceName('Build')} id(String id);`);
+      builderBody.push(`${this.getStepInterfaceName('Build', types)} id(String id);`);
     }
 
     nullableFields.forEach(field => {
       const fieldName = this.getStepFunctionArgumentName(field);
       const methodName = this.getStepFunctionName(field);
-      builderBody.push(`${this.getStepInterfaceName('Build')} ${methodName}(${this.getNativeType(field)} ${fieldName});`);
+      builderBody.push(`${this.getStepInterfaceName('Build', types)} ${methodName}(${this.getNativeType(field)} ${fieldName});`);
     });
 
     builder.withBlock(indentMultiline(builderBody.join('\n')));
@@ -434,15 +450,18 @@ export class AppSyncModelJavaVisitor<
   protected generateBuilderClass(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isIdAsModelPrimaryKey: boolean = true): void {
     const nonNullableFields = this.getWritableFields(model).filter(field => this.isRequiredField(field));
     const nullableFields = this.getWritableFields(model).filter(field => !this.isRequiredField(field));
-    const stepFields = nonNullableFields.filter((field: CodeGenField) => !(isIdAsModelPrimaryKey && this.READ_ONLY_FIELDS.includes(field.name)));
-    const stepInterfaces = stepFields.map((field: CodeGenField) => this.getStepInterfaceName(field.name));
+    const stepFields = nonNullableFields.filter(
+      (field: CodeGenField) => !(isIdAsModelPrimaryKey && this.READ_ONLY_FIELDS.includes(field.name)),
+    );
+    const types = this.getTypesUsedByModel(model);
+    const stepInterfaces = stepFields.map((field: CodeGenField) => this.getStepInterfaceName(field.name, types));
 
     const builderClassDeclaration = new JavaDeclarationBlock()
       .access('public')
       .static()
       .asKind('class')
       .withName('Builder')
-      .implements([...stepInterfaces, this.getStepInterfaceName('Build')]);
+      .implements([...stepInterfaces, this.getStepInterfaceName('Build', types)]);
 
     // Add private instance fields
     [...nonNullableFields, ...nullableFields].forEach((field: CodeGenField) => {
@@ -452,7 +471,9 @@ export class AppSyncModelJavaVisitor<
 
     // methods
     // build();
-    const buildImplementation = isIdAsModelPrimaryKey ? [`String id = this.id != null ? this.id : UUID.randomUUID().toString();`, ''] : [''];
+    const buildImplementation = isIdAsModelPrimaryKey
+      ? [`String id = this.id != null ? this.id : UUID.randomUUID().toString();`, '']
+      : [''];
     const buildParams = this.getWritableFields(model)
       .map(field => this.getFieldName(field))
       .join(',\n');
@@ -473,7 +494,7 @@ export class AppSyncModelJavaVisitor<
       const isLastStep = idx === fields.length - 1;
       const fieldName = this.getFieldName(field);
       const methodName = this.getStepFunctionName(field);
-      const returnType = isLastStep ? this.getStepInterfaceName('Build') : this.getStepInterfaceName(fields[idx + 1].name);
+      const returnType = isLastStep ? this.getStepInterfaceName('Build', types) : this.getStepInterfaceName(fields[idx + 1].name, types);
       const argumentType = this.getNativeType(field);
       const argumentName = this.getStepFunctionArgumentName(field);
       const body = [`Objects.requireNonNull(${argumentName});`, `this.${fieldName} = ${argumentName};`, `return this;`].join('\n');
@@ -493,7 +514,7 @@ export class AppSyncModelJavaVisitor<
     nullableFields.forEach((field: CodeGenField) => {
       const fieldName = this.getFieldName(field);
       const methodName = this.getStepFunctionName(field);
-      const returnType = this.getStepInterfaceName('Build');
+      const returnType = this.getStepInterfaceName('Build', types);
       const argumentType = this.getNativeType(field);
       const argumentName = this.getStepFunctionArgumentName(field);
       const body = [`this.${fieldName} = ${argumentName};`, `return this;`].join('\n');
@@ -520,7 +541,7 @@ export class AppSyncModelJavaVisitor<
 
       builderClassDeclaration.addClassMethod(
         'id',
-        this.getStepInterfaceName('Build'),
+        this.getStepInterfaceName('Build', types),
         indentMultiline(idBuildStepBody),
         [{ name: 'id', type: 'String' }],
         [],
@@ -541,7 +562,11 @@ export class AppSyncModelJavaVisitor<
    * @param model
    * @param classDeclaration
    */
-  protected generateCopyOfBuilderClass(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isIdAsModelPrimaryKey: boolean = true): void {
+  protected generateCopyOfBuilderClass(
+    model: CodeGenModel,
+    classDeclaration: JavaDeclarationBlock,
+    isIdAsModelPrimaryKey: boolean = true,
+  ): void {
     const builderName = 'CopyOfBuilder';
     const copyOfBuilderClassDeclaration = new JavaDeclarationBlock()
       .access('public')
@@ -616,11 +641,11 @@ export class AppSyncModelJavaVisitor<
     primaryKeyClassDeclaration.addClassMember('serialVersionUID', 'long', '1L', [], 'private', { static: true, final: true });
     // constructor
     const primaryKeyComponentFields: CodeGenField[] = [primaryKeyField, ...sortKeyFields];
-    const constructorParams = primaryKeyComponentFields.map(field => ({name: this.getFieldName(field), type: this.getNativeType(field)}));
+    const constructorParams = primaryKeyComponentFields.map(field => ({ name: this.getFieldName(field), type: this.getNativeType(field) }));
     const constructorImpl = `super(${primaryKeyComponentFields.map(field => this.getFieldName(field)).join(', ')});`;
     primaryKeyClassDeclaration.addClassMethod(modelPrimaryKeyClassName, null, constructorImpl, constructorParams, [], 'public');
     classDeclaration.nestedClass(primaryKeyClassDeclaration);
-}
+  }
 
   /**
    * adds a copyOfBuilder method to the Model class. This method is used to create a copy of the model to mutate it
@@ -647,12 +672,27 @@ export class AppSyncModelJavaVisitor<
     const body = isCompositeKey
       ? [
           `if (${modelIdentifierClassFieldName} == null) {`,
-          indent(`this.${modelIdentifierClassFieldName} = new ${this.getModelIdentifierClassName(model)}(${[primaryKeyField, ...sortKeyFields].map(f => this.getFieldName(f)).join(', ')});`),
+          indent(
+            `this.${modelIdentifierClassFieldName} = new ${this.getModelIdentifierClassName(model)}(${[primaryKeyField, ...sortKeyFields]
+              .map(f => this.getFieldName(f))
+              .join(', ')});`,
+          ),
           '}',
-          `return ${modelIdentifierClassFieldName};`
+          `return ${modelIdentifierClassFieldName};`,
         ].join('\n')
       : `return ${this.getFieldName(primaryKeyField)};`;
-    declarationsBlock.addClassMethod('resolveIdentifier', returnType, body, [], [], 'public', {}, ["Deprecated"], [], "@deprecated This API is internal to Amplify and should not be used.");
+    declarationsBlock.addClassMethod(
+      'resolveIdentifier',
+      returnType,
+      body,
+      [],
+      [],
+      'public',
+      {},
+      ['Deprecated'],
+      [],
+      '@deprecated This API is internal to Amplify and should not be used.',
+    );
   }
 
   /**
@@ -823,11 +863,18 @@ export class AppSyncModelJavaVisitor<
    * @param model
    * @param classDeclaration
    */
-  protected generateBuilderMethod(model: CodeGenModel, classDeclaration: JavaDeclarationBlock, isIdAsModelPrimaryKey: boolean = true): void {
+  protected generateBuilderMethod(
+    model: CodeGenModel,
+    classDeclaration: JavaDeclarationBlock,
+    isIdAsModelPrimaryKey: boolean = true,
+  ): void {
     const requiredFields = this.getWritableFields(model).filter(
       field => !field.isNullable && !(isIdAsModelPrimaryKey && this.READ_ONLY_FIELDS.includes(field.name)),
     );
-    const returnType = requiredFields.length ? this.getStepInterfaceName(requiredFields[0].name) : this.getStepInterfaceName('Build');
+    const types = this.getTypesUsedByModel(model);
+    const returnType = requiredFields.length
+      ? this.getStepInterfaceName(requiredFields[0].name, types)
+      : this.getStepInterfaceName('Build', types);
     classDeclaration.addClassMethod(
       'builder',
       returnType,
@@ -843,10 +890,27 @@ export class AppSyncModelJavaVisitor<
   /**
    * Generate the name of the step builder interface
    * @param nextFieldName: string
+   * @param types: string - set of types for all fields on model
    * @returns string
    */
-  private getStepInterfaceName(nextFieldName: string): string {
-    return `${pascalCase(nextFieldName)}Step`;
+  private getStepInterfaceName(nextFieldName: string, types: Set<string>): string {
+    const pascalCaseFieldName = pascalCase(nextFieldName);
+    const stepInterfaceName = `${pascalCaseFieldName}Step`;
+
+    if (types.has(stepInterfaceName)) {
+      return `${pascalCaseFieldName}BuildStep`;
+    }
+
+    return stepInterfaceName;
+  }
+
+  /**
+   * Get set of all types used by a model
+   * @param model
+   * @return Set<string>
+   */
+  private getTypesUsedByModel(model: CodeGenModel): Set<string> {
+    return new Set(model.fields.map(field => field.type));
   }
 
   protected generateModelAnnotations(model: CodeGenModel): string[] {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Avoid name collision on Java model build step by adding `Build` if name is used by a type.

See https://github.com/aws-amplify/amplify-codegen/issues/695 for details.

It is still possible for a collision to occur if the model has a second type that includes `Build`.

```
type TutorialStep {
  position: Int!
  text: String!
}

type TutorialBuild {
  position: Int!
  text: String!
}

type MyObject @model {
  id: ID!
  tutorial: [TutorialStep]
  tutorialBuild: [TutorialBuildStep]
}
```

We could add another layer of checks or use a randomly generated string, but I think this case is so rare that it should be ok.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves https://github.com/aws-amplify/amplify-codegen/issues/695

#### Description of how you validated changes

Unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.