### PR TITLE
feat: support running codegen without an initialized amplify backend set up locally.

### DIFF
--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -121,22 +121,23 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        build_app_ts_uninitialized_project_modelgen_android_uninitialized_project_modelgen_flutter_uninitialized_project_modelgen_ios
+        build_app_ts_uninitialized_project_codegen_js_uninitialized_project_modelgen_android_uninitialized_project_modelgen_flutter
       buildspec: .codebuild/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           TEST_SUITE: >-
-            src/__tests__/build-app-ts.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts
+            src/__tests__/build-app-ts.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts
           CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
-    - identifier: uninitialized_project_modelgen_js
+    - identifier: uninitialized_project_modelgen_ios_uninitialized_project_modelgen_js
       buildspec: .codebuild/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/uninitialized-project-modelgen-js.test.ts
+          TEST_SUITE: >-
+            src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -168,7 +168,7 @@ export function generateModelIntrospection(cwd: string, settings: { outputDir?: 
 // CLI workflow to add codegen to non-Amplify JS project
 export function addCodegenNonAmplifyJS(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const cmdOptions = ['codegen', 'add', '--apiId', 'mockapiid'];
+    const cmdOptions = ['codegen', 'add'];
     const chain = spawn(getCLIPath(), cmdOptions, { cwd, stripColors: true });
     chain
       .wait("Choose the type of app that you're building")

--- a/packages/amplify-codegen-e2e-tests/schemas/sdl/schema.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/sdl/schema.graphql
@@ -1,0 +1,11 @@
+type Query {
+  echo: String
+}
+
+type Mutation {
+  mymutation: String
+}
+
+type Subscription {
+  mysub: String
+}

--- a/packages/amplify-codegen-e2e-tests/schemas/sdl/schema.json
+++ b/packages/amplify-codegen-e2e-tests/schemas/sdl/schema.json
@@ -1,0 +1,1163 @@
+{
+    "data": {
+        "__schema": {
+            "queryType": {
+                "name": "Query"
+            },
+            "mutationType": {
+                "name": "Mutation"
+            },
+            "subscriptionType": {
+                "name": "Subscription"
+            },
+            "types": [
+                {
+                    "kind": "OBJECT",
+                    "name": "Query",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "echo",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "description": "Built-in String",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Mutation",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "mymutation",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "Subscription",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "mysub",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Schema",
+                    "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+                    "fields": [
+                        {
+                            "name": "types",
+                            "description": "A list of all types supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Type",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "queryType",
+                            "description": "The type that query operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "mutationType",
+                            "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "directives",
+                            "description": "'A list of all directives supported by this server.",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__Directive",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "subscriptionType",
+                            "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "kind",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "__TypeKind",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "fields",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Field",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "interfaces",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "possibleTypes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "enumValues",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "includeDeprecated",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__EnumValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "inputFields",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ofType",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__TypeKind",
+                    "description": "An enum describing what kind of type a given __Type is",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates this type is a scalar.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "LIST",
+                            "description": "Indicates this type is a list. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "NON_NULL",
+                            "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "defaultValue",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "description": "Built-in Boolean",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "isDeprecated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deprecationReason",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "__Directive",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "locations",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "args",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "__InputValue",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "onOperation",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onFragment",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        },
+                        {
+                            "name": "onField",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": true,
+                            "deprecationReason": "Use `locations`."
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "description": "An enum describing valid locations where a directive can be placed",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": [
+                        {
+                            "name": "QUERY",
+                            "description": "Indicates the directive is valid on queries.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "MUTATION",
+                            "description": "Indicates the directive is valid on mutations.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD",
+                            "description": "Indicates the directive is valid on fields.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on fragment definitions.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FRAGMENT_SPREAD",
+                            "description": "Indicates the directive is valid on fragment spreads.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INLINE_FRAGMENT",
+                            "description": "Indicates the directive is valid on inline fragments.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCHEMA",
+                            "description": "Indicates the directive is valid on a schema SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "SCALAR",
+                            "description": "Indicates the directive is valid on a scalar SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "OBJECT",
+                            "description": "Indicates the directive is valid on an object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on a field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ARGUMENT_DEFINITION",
+                            "description": "Indicates the directive is valid on a field argument SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INTERFACE",
+                            "description": "Indicates the directive is valid on an interface SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "UNION",
+                            "description": "Indicates the directive is valid on an union SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM",
+                            "description": "Indicates the directive is valid on an enum SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ENUM_VALUE",
+                            "description": "Indicates the directive is valid on an enum value SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_OBJECT",
+                            "description": "Indicates the directive is valid on an input object SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "INPUT_FIELD_DEFINITION",
+                            "description": "Indicates the directive is valid on an input object field SDL definition.",
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "possibleTypes": null
+                }
+            ],
+            "directives": [
+                {
+                    "name": "include",
+                    "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Included when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "skip",
+                    "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT"
+                    ],
+                    "args": [
+                        {
+                            "name": "if",
+                            "description": "Skipped when true.",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": true,
+                    "onField": true
+                },
+                {
+                    "name": "defer",
+                    "description": "This directive allows results to be deferred during execution",
+                    "locations": [
+                        "FIELD"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": true
+                },
+                {
+                    "name": "aws_api_key",
+                    "description": "Tells the service this field/object has access authorized by an API key.",
+                    "locations": [
+                        "OBJECT",
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_iam",
+                    "description": "Tells the service this field/object has access authorized by sigv4 signing.",
+                    "locations": [
+                        "OBJECT",
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_oidc",
+                    "description": "Tells the service this field/object has access authorized by an OIDC token.",
+                    "locations": [
+                        "OBJECT",
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_lambda",
+                    "description": "Tells the service this field/object has access authorized by a Lambda Authorizer.",
+                    "locations": [
+                        "OBJECT",
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_subscribe",
+                    "description": "Tells the service which mutation triggers this subscription.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "mutations",
+                            "description": "List of mutations which will trigger this subscription when they are called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_cognito_user_pools",
+                    "description": "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+                    "locations": [
+                        "OBJECT",
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "cognito_groups",
+                            "description": "List of cognito user pool groups which have access on this field",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "deprecated",
+                    "description": null,
+                    "locations": [
+                        "FIELD_DEFINITION",
+                        "ENUM_VALUE"
+                    ],
+                    "args": [
+                        {
+                            "name": "reason",
+                            "description": null,
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "defaultValue": "\"No longer supported\""
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_auth",
+                    "description": "Directs the schema to enforce authorization on a field",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "cognito_groups",
+                            "description": "List of cognito user pool groups which have access on this field",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                },
+                {
+                    "name": "aws_publish",
+                    "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+                    "locations": [
+                        "FIELD_DEFINITION"
+                    ],
+                    "args": [
+                        {
+                            "name": "subscriptions",
+                            "description": "List of subscriptions which will be published to when this mutation is called.",
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "onOperation": false,
+                    "onFragment": false,
+                    "onField": false
+                }
+            ]
+        }
+    }
+}

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/add-codegen-js.test.ts
@@ -6,13 +6,17 @@ import {
     createRandomName,
     addApiWithoutSchema,
     updateApiSchema,
-    addCodegenNonAmplifyJS
 } from "@aws-amplify/amplify-codegen-e2e-core";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';
-import { deleteAmplifyProject, testAddCodegen, testSetupBeforeAddCodegen, 
-getGraphQLConfigFilePath, testValidGraphQLConfig } from '../codegen-tests-base';
+import {
+    deleteAmplifyProject,
+    testAddCodegen,
+    testSetupBeforeAddCodegen,
+    getGraphQLConfigFilePath,
+    testValidGraphQLConfig,
+} from '../codegen-tests-base';
 
 const schema = 'simple_model.graphql';
 
@@ -74,35 +78,7 @@ describe('codegen add tests - JS', () => {
         await testAddCodegen(config, projectRoot, schema);
     });
 
-    it(`Adding codegen outside of Amplify project`, async () => {
-        // init project and add API category
-        const testSchema = `
-        type Query {
-            echo: String
-        }
-
-        type Mutation {
-            mymutation: String
-        }
-
-        type Subscription {
-            mysub: String
-        }          
-        `;
-
-        // Setup the non-amplify project with schema and pre-existing files
-        const userSourceCodePath = testSetupBeforeAddCodegen(projectRoot, config);
-        const schemaPath = path.join(projectRoot, 'schema.graphql');
-        writeFileSync(schemaPath, testSchema);
-
-        // add codegen without init
-        await expect(addCodegenNonAmplifyJS(projectRoot)).resolves.not.toThrow();
-
-        // pre-existing file should still exist
-        expect(existsSync(userSourceCodePath)).toBe(true);
-        // GraphQL statements are generated
-        expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
-        // graphql configuration should be added
-        expect(existsSync(getGraphQLConfigFilePath(projectRoot))).toBe(true);
+    it(`supports add codegen with redundant region parameter`, async () => {
+        await testAddCodegen(config, projectRoot, schema, ['--region', 'us-fake-1']);
     });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-codegen-js.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/uninitialized-project-codegen-js.test.ts
@@ -1,0 +1,114 @@
+import {  createNewProjectDir, DEFAULT_JS_CONFIG, AmplifyFrontend, generateStatementsAndTypes } from '@aws-amplify/amplify-codegen-e2e-core';
+import path from 'path';
+import { deleteAmplifyProject, testAddCodegenUninitialized } from '../codegen-tests-base';
+import { rmSync } from "fs-extra";
+
+describe('codegen add tests - JS', () => {
+    let projectRoot: string;
+    const javascriptConfig = DEFAULT_JS_CONFIG;
+    const typescriptConfig = {
+        ...DEFAULT_JS_CONFIG,
+        frontendType: AmplifyFrontend.typescript,
+    };
+
+    beforeEach(async () => {
+        projectRoot = await createNewProjectDir('uninitializedProjectCodegenJS');
+    });
+
+    afterEach(async () => {
+        await deleteAmplifyProject(projectRoot);
+    });
+
+    it(`graphql sdl file`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: javascriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.js', 'queries.js', 'subscriptions.js'],
+        });
+    });
+
+    it(`region is ignored if schema file is provided`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: javascriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.js', 'queries.js', 'subscriptions.js'],
+            additionalParams: ['--region', 'us-fake-1'],
+        });
+    });
+
+    it(`json sdl file`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: javascriptConfig,
+            sdlFilename: 'schema.json',
+            expectedFilenames: ['mutations.js', 'queries.js', 'subscriptions.js'],
+        });
+    });
+
+    it(`typescript`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: typescriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.ts', 'queries.ts', 'subscriptions.ts'],
+        });
+    });
+
+    it(`drop and regenerate`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: typescriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.ts', 'queries.ts', 'subscriptions.ts'],
+            dropAndRunCodegen: true,
+        });
+    });
+
+    it(`drop and regenerate statements`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: typescriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.ts', 'queries.ts', 'subscriptions.ts'],
+            dropAndRunCodegenStatements: true,
+        });
+    });
+
+    it(`drop and regenerate types`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: typescriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.ts', 'queries.ts', 'subscriptions.ts'],
+            dropAndRunCodegenStatements: true,
+            dropAndRunCodegenTypes: true,
+        });
+    });
+
+    it(`throws a sane warning on missing graphqlconfig file`, async () => {
+        // Add codegen
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: javascriptConfig,
+            sdlFilename: 'schema.graphql',
+            expectedFilenames: ['mutations.js', 'queries.js', 'subscriptions.js'],
+        });
+
+        // Remove .graphqlconfig.yml file
+        rmSync(path.join(projectRoot, '.graphqlconfig.yml'));
+
+        // Run and expect failure message
+        await generateStatementsAndTypes(projectRoot, 'code generation is not configured');
+    });
+
+    it(`throws a sane warning on missing sdl schema and no api id specified`, async () => {
+        await testAddCodegenUninitialized({
+            projectRoot,
+            config: javascriptConfig,
+            expectedFilenames: ['mutations.js', 'queries.js', 'subscriptions.js'],
+            initialFailureMessage: 'Provide an AppSync API ID with --apiId or manually download schema.graphql or schema.json'
+        });
+    });
+});

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/add-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/add-codegen.ts
@@ -4,14 +4,20 @@ import {
     updateApiSchema,
     addCodegen,
     AmplifyFrontendConfig,
-    createRandomName
+    createRandomName,
+    addCodegenNonAmplifyJS,
+    addCodegenNonAmplifyTS,
+    AmplifyFrontend,
+    generateStatementsAndTypes,
+    generateStatements,
+    generateTypes,
 } from "@aws-amplify/amplify-codegen-e2e-core";
-import { existsSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, readdirSync, rmSync } from "fs";
 import path from 'path';
 import { isNotEmptyDir } from '../utils';
-import { testSetupBeforeAddCodegen, testValidGraphQLConfig } from "./test-setup";
+import { getGraphQLConfigFilePath, testSetupBeforeAddCodegen, testValidGraphQLConfig } from "./test-setup";
 
-export async function testAddCodegen(config: AmplifyFrontendConfig, projectRoot: string, schema: string) {
+export async function testAddCodegen(config: AmplifyFrontendConfig, projectRoot: string, schema: string, additionalParams?: Array<string>) {
     // init project and add API category
     await initProjectWithProfile(projectRoot, { ...config });
     const projectName = createRandomName();
@@ -21,11 +27,120 @@ export async function testAddCodegen(config: AmplifyFrontendConfig, projectRoot:
     const userSourceCodePath = testSetupBeforeAddCodegen(projectRoot, config);
 
     // add codegen succeeds
-    await expect(addCodegen(projectRoot, { ...config })).resolves.not.toThrow();
+    await expect(addCodegen(projectRoot, { ...config, params: additionalParams ?? [] })).resolves.not.toThrow();
 
     // pre-existing file should still exist
     expect(existsSync(userSourceCodePath)).toBe(true);
     // GraphQL statements are generated
     expect(isNotEmptyDir(path.join(projectRoot, config.graphqlCodegenDir))).toBe(true);
     testValidGraphQLConfig(projectRoot, config);
+}
+
+export type TestAddCodegenUninitializedProps = {
+    config: AmplifyFrontendConfig;
+    projectRoot: string;
+    sdlFilename?: string;
+    expectedFilenames: Array<string>;
+    dropAndRunCodegen?: boolean;
+    dropAndRunCodegenStatements?: boolean;
+    dropAndRunCodegenTypes?: boolean;
+    initialFailureMessage?: string;
+    additionalParams?: Array<string>;
+};
+
+const assertTypeFileExists = (projectRoot: string): void => {
+    expect(existsSync(path.join(projectRoot, 'src', 'API.ts'))).toBe(true)
+};
+
+/**
+ * Ensure that all values provided in the expected set are present in the received set, allowing for additional values in received.
+ * @param expectedValues the expected values to check
+ * @param receivedValues the received values to check
+ */
+const ensureAllExpectedValuesAreReceived = <T>(expectedValues: Array<T>, receivedValues: Array<T>): void => {
+    const receivedValueSet = new Set(receivedValues);
+    console.log(`Comparing received values: ${JSON.stringify(receivedValues)} to expected values: ${JSON.stringify(expectedValues)}`);
+    expectedValues.forEach((expectedFilename) => expect(receivedValueSet.has(expectedFilename)).toBe(true));
+};
+
+export async function testAddCodegenUninitialized({
+    config,
+    projectRoot,
+    sdlFilename,
+    expectedFilenames,
+    dropAndRunCodegen,
+    dropAndRunCodegenStatements,
+    dropAndRunCodegenTypes,
+    initialFailureMessage,
+    additionalParams,
+}: TestAddCodegenUninitializedProps) {
+    // Setup the non-amplify project with schema and pre-existing files
+    const userSourceCodePath = testSetupBeforeAddCodegen(projectRoot, config);
+
+    // Write SDL Schema
+    if (sdlFilename) {
+        const sdlSchema = readFileSync(path.join(__dirname, '..', '..', 'schemas', 'sdl', sdlFilename), 'utf-8');
+        writeFileSync(path.join(projectRoot, sdlFilename), sdlSchema);
+    }
+
+    // add codegen without init
+    switch (config.frontendType) {
+        case AmplifyFrontend.javascript:
+            await addCodegenNonAmplifyJS(projectRoot, additionalParams ?? [], initialFailureMessage);
+            break;
+        case AmplifyFrontend.typescript:
+            await addCodegenNonAmplifyTS(projectRoot, additionalParams ?? [], initialFailureMessage);
+            break;
+        default:
+            throw new Error(`Received unexpected frontendType ${config.frontendType}`);
+    }
+
+    // return if we expected the add command to fail
+    if (initialFailureMessage) {
+        return;
+    }
+
+    // pre-existing file should still exist
+    expect(existsSync(userSourceCodePath)).toBe(true);
+    // GraphQL statements are generated
+    ensureAllExpectedValuesAreReceived(expectedFilenames, readdirSync(path.join(projectRoot, config.graphqlCodegenDir)))
+    // graphql configuration should be added
+    expect(existsSync(getGraphQLConfigFilePath(projectRoot))).toBe(true);
+    if (config.frontendType === AmplifyFrontend.typescript) {
+        assertTypeFileExists(projectRoot)
+    }
+
+    if (dropAndRunCodegen || dropAndRunCodegenStatements || dropAndRunCodegenTypes) {
+        rmSync(path.join(projectRoot, config.graphqlCodegenDir), { recursive: true });
+        // pre-existing file should still exist
+        expect(existsSync(userSourceCodePath)).toBe(true);
+        // Graphql statements are deleted
+        expect(existsSync(path.join(projectRoot, config.graphqlCodegenDir))).toBe(false);
+    }
+
+    if (dropAndRunCodegen) {
+        await generateStatementsAndTypes(projectRoot);
+
+        // GraphQL statements are regenerated
+        ensureAllExpectedValuesAreReceived(expectedFilenames, readdirSync(path.join(projectRoot, config.graphqlCodegenDir)))
+
+        if (config.frontendType === AmplifyFrontend.typescript) {
+            assertTypeFileExists(projectRoot)
+        }
+    }
+
+    if (dropAndRunCodegenStatements) {
+        await generateStatements(projectRoot);
+
+        // GraphQL statements are regenerated
+        ensureAllExpectedValuesAreReceived(expectedFilenames, readdirSync(path.join(projectRoot, config.graphqlCodegenDir)))
+    }
+
+    if (dropAndRunCodegenTypes) {
+        await generateTypes(projectRoot);
+
+        if (config.frontendType === AmplifyFrontend.typescript) {
+            assertTypeFileExists(projectRoot)
+        }
+    }
 }

--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -9,14 +9,16 @@ module.exports = {
     try {
       const { options = {} } = context.parameters;
       const keys = Object.keys(options);
-      if (keys.length && !keys.includes('apiId')) {
-        const paramMsg = keys.length > 1 ? 'Invalid parameters ' : 'Invalid parameter ';
+      // frontend and framework are undocumented, but are read when apiId is also supplied
+      const { apiId = null, region, yes, frontend, framework, ...rest } = options;
+      const extraOptions = Object.keys(rest);
+      if (extraOptions.length) {
+        const paramMsg = extraOptions.length > 1 ? 'Invalid parameters' : 'Invalid parameter';
         context.print.info(`${paramMsg} ${keys.join(', ')}`);
         context.print.info(constants.INFO_MESSAGE_ADD_ERROR);
         return;
       }
-      const apiId = context.parameters.options.apiId || null;
-      await codeGen.add(context, apiId);
+      await codeGen.add(context, apiId, region);
     } catch (ex) {
       context.print.error(ex.message);
     }

--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -10,7 +10,7 @@ module.exports = {
       const { options = {} } = context.parameters;
       const keys = Object.keys(options);
       // frontend and framework are undocumented, but are read when apiId is also supplied
-      const { apiId = null, region, yes, frontend, framework, ...rest } = options;
+      const { apiId = null, region, yes, frontend, framework, debug, ...rest } = options;
       const extraOptions = Object.keys(rest);
       if (extraOptions.length) {
         const paramMsg = extraOptions.length > 1 ? 'Invalid parameters' : 'Invalid parameter';

--- a/packages/amplify-codegen/package.json
+++ b/packages/amplify-codegen/package.json
@@ -46,7 +46,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 54,
-        "functions": 65,
+        "functions": 64,
         "lines": 72
       }
     },

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -1,4 +1,5 @@
 const Ora = require('ora');
+const process = require('process');
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
 const generateStatements = require('./statements');
@@ -23,11 +24,11 @@ const askForFramework = require('../walkthrough/questions/selectFramework');
 const frontends = ['android', 'ios', 'javascript'];
 const frameworks = ['angular', 'ember', 'ionic', 'react', 'react-native', 'vue', 'none'];
 
-async function add(context, apiId = null) {
+async function add(context, apiId = null, region = 'us-east-1') {
   let withoutInit = false;
   // Determine if working in an amplify project
   try {
-    context.amplify.getProjectMeta();
+    await context.amplify.getProjectMeta();
   } catch (e) {
     withoutInit = true;
     const config = loadConfig(context, withoutInit);
@@ -69,7 +70,6 @@ async function add(context, apiId = null) {
     }
   }
 
-  let region = 'us-east-1';
   if (!withoutInit) {
     region = getProjectAwsRegion(context);
   }

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -38,9 +38,9 @@ async function add(context, apiId = null, region = 'us-east-1') {
   }
 
   const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
-  if (withoutInit && !schemaPath) {
+  if (withoutInit && !(apiId || schemaPath)) {
     throw Error(
-      `Please download schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
+      `Provide an AppSync API ID with --apiId or manually download schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
     );
   }
   // Grab the frontend
@@ -78,36 +78,37 @@ async function add(context, apiId = null, region = 'us-east-1') {
     throw new Error(constants.ERROR_CODEGEN_SUPPORT_MAX_ONE_API);
   }
   let apiDetails;
-  if (!withoutInit) {
-    if (!apiId) {
-      const availableAppSyncApis = getAppSyncAPIDetails(context); // published and un-published
-      if (availableAppSyncApis.length === 0) {
-        throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
-      }
-      [apiDetails] = availableAppSyncApis;
-      apiDetails.isLocal = true;
-    } else {
-      let shouldRetry = true;
-      while (shouldRetry) {
-        const apiDetailSpinner = new Ora();
-        try {
-          apiDetailSpinner.start('Getting API details');
-          apiDetails = await getAppSyncAPIInfo(context, apiId, region);
-          apiDetailSpinner.succeed();
+  if (!withoutInit && !apiId) {
+    const availableAppSyncApis = getAppSyncAPIDetails(context); // published and un-published
+    if (availableAppSyncApis.length === 0) {
+      throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_AVAILABLE);
+    }
+    [apiDetails] = availableAppSyncApis;
+    apiDetails.isLocal = true;
+  } else if (apiId) {
+    let shouldRetry = true;
+    while (shouldRetry) {
+      const apiDetailSpinner = new Ora();
+      try {
+        apiDetailSpinner.start('Getting API details');
+        apiDetails = await getAppSyncAPIInfo(context, apiId, region);
+        if (!withoutInit) {
           await updateAmplifyMeta(context, apiDetails);
-          break;
-        } catch (e) {
-          apiDetailSpinner.fail();
-          if (e instanceof AmplifyCodeGenAPINotFoundError) {
-            context.print.info(`AppSync API was not found in region ${region}`);
-            ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
-          } else {
-            throw e;
-          }
+        }
+        apiDetailSpinner.succeed();
+        break;
+      } catch (e) {
+        apiDetailSpinner.fail();
+        if (e instanceof AmplifyCodeGenAPINotFoundError) {
+          context.print.info(`AppSync API was not found in region ${region}`);
+          ({ shouldRetry, region } = await changeAppSyncRegion(context, region));
+        } else {
+          throw e;
         }
       }
     }
   }
+  // else no appsync API, but has schema.graphql or schema.json
 
   if (!withoutInit && !apiDetails) {
     return;
@@ -123,6 +124,8 @@ async function add(context, apiId = null, region = 'us-east-1') {
     } else {
       schema = getSDLSchemaLocation(apiDetails.name);
     }
+  } else if (apiDetails) {
+    schema = await downloadIntrospectionSchemaWithProgress(context, apiDetails.id, path.join(process.cwd(), 'schema.json'), region);
   } else {
     schema = schemaPath;
   }

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -4,7 +4,7 @@ const generateTypes = require('./types');
 const generateStatements = require('./statements');
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getAppSyncAPIDetails } = require('../utils');
+const { ensureIntrospectionSchema, getAppSyncAPIDetails, getAppSyncAPIInfoFromProject } = require('../utils');
 const path = require('path');
 const fs = require('fs-extra');
 
@@ -17,30 +17,31 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
     withoutInit = true;
   }
 
-  // Check if introspection schema exists
-  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
-  if (withoutInit && !schemaPath) {
-    throw Error(
-      `Please download the schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`
-    );
-  }
-
-  if (withoutInit) {
-    forceDownloadSchema = false;
-  }
   const config = loadConfig(context, withoutInit);
   const projects = config.getProjects();
   if (!projects.length) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
   }
+  const project = projects[0];
+  const schemaPath = ['schema.graphql', 'schema.json'].map(p => path.join(process.cwd(), p)).find(p => fs.existsSync(p));
+  if (withoutInit && !project && !schemaPath) {
+    throw Error(
+      `Please download the schema.graphql or schema.json and place in ${process.cwd()} before adding codegen when not in an amplify project`,
+    );
+  }
+
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
+  } else {
+    const api = getAppSyncAPIInfoFromProject(context, project);
+    if (api) {
+      apis = [api];
+    }
   }
   if (!apis.length && !withoutInit) {
     throw new NoAppSyncAPIAvailableError(constants.ERROR_CODEGEN_NO_API_META);
   }
-  const project = projects[0];
   const { frontend } = project.amplifyExtension;
   let projectPath = process.cwd();
   if (!withoutInit) {
@@ -48,10 +49,10 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
   }
 
   let downloadPromises;
-  if (!withoutInit) {
+  if (apis.length) {
     downloadPromises = projects.map(
       async cfg =>
-        await ensureIntrospectionSchema(context, join(projectPath, cfg.schema), apis[0], cfg.amplifyExtension.region, forceDownloadSchema)
+        await ensureIntrospectionSchema(context, join(projectPath, cfg.schema), apis[0], cfg.amplifyExtension.region, forceDownloadSchema),
     );
     await Promise.all(downloadPromises);
   }

--- a/packages/amplify-codegen/src/commands/generateStatementsAndType.js
+++ b/packages/amplify-codegen/src/commands/generateStatementsAndType.js
@@ -34,7 +34,7 @@ async function generateStatementsAndTypes(context, forceDownloadSchema, maxDepth
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
   } else {
-    const api = getAppSyncAPIInfoFromProject(context, project);
+    const api = await getAppSyncAPIInfoFromProject(context, project);
     if (api) {
       apis = [api];
     }

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -30,7 +30,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
   } else {
-    const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+    const api = await getAppSyncAPIInfoFromProject(context, projects[0]);
     if (api) {
       apis = [api];
     }

--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -4,7 +4,13 @@ const Ora = require('ora');
 
 const { loadConfig } = require('../codegen-config');
 const constants = require('../constants');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, readSchemaFromFile } = require('../utils');
+const {
+  ensureIntrospectionSchema,
+  getFrontEndHandler,
+  getAppSyncAPIDetails,
+  readSchemaFromFile,
+  getAppSyncAPIInfoFromProject,
+} = require('../utils');
 const { generateGraphQLDocuments } = require('@aws-amplify/graphql-docs-generator');
 const { generateStatements: generateStatementsHelper } = require('@aws-amplify/graphql-generator');
 
@@ -16,9 +22,18 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
   }
   const config = loadConfig(context, withoutInit);
   const projects = config.getProjects();
+  if (!projects.length && withoutInit) {
+    context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+    return;
+  }
   let apis = [];
   if (!withoutInit) {
     apis = getAppSyncAPIDetails(context);
+  } else {
+    const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+    if (api) {
+      apis = [api];
+    }
   }
   let projectPath = process.cwd();
   if (!withoutInit) {
@@ -30,10 +45,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       return;
     }
   }
-  if (!projects.length && withoutInit) {
-    context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
-    return;
-  }
 
   for (const cfg of projects) {
     const includeFiles = path.join(projectPath, cfg.includes[0]);
@@ -41,15 +52,11 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
       ? path.join(projectPath, cfg.amplifyExtension.docsFilePath)
       : path.dirname(path.dirname(includeFiles));
     const schemaPath = path.join(projectPath, cfg.schema);
-    let region;
-    let frontend;
-    if (!withoutInit) {
-      ({ region } = cfg.amplifyExtension);
+    if (apis.length) {
+      const { region } = cfg.amplifyExtension;
       await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
-      frontend = getFrontEndHandler(context);
-    } else {
-      frontend = decoupleFrontend;
     }
+    const frontend = withoutInit ? cfg.amplifyExtension.frontend : getFrontEndHandler(context);
     const language = frontend === 'javascript' ? cfg.amplifyExtension.codeGenTarget : 'graphql';
 
     const opsGenSpinner = new Ora(constants.INFO_MESSAGE_OPS_GEN);

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -30,7 +30,7 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
     if (!withoutInit) {
       apis = getAppSyncAPIDetails(context);
     } else {
-      const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+      const api = await getAppSyncAPIInfoFromProject(context, projects[0]);
       if (api) {
         apis = [api];
       }
@@ -57,7 +57,7 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         const target = cfg.amplifyExtension.codeGenTarget;
 
         const excludes = cfg.excludes.map(pattern => `!${pattern}`);
-        const queries = glob
+        const queryFiles = glob
           .sync([...includeFiles, ...excludes], {
             cwd: projectPath,
             absolute: true,
@@ -73,8 +73,11 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
               return extractDocumentFromJavascript(fileContents, '');
             }
             return fileContents;
-          })
-          .join('\n');
+          });
+        if (queryFiles.length === 0) {
+          throw new Error('No queries found to generate types for, you may need to run \'codegen statements\' first');
+        }
+        const queries = queryFiles.join('\n');
 
         const schemaPath = path.join(projectPath, cfg.schema);
 

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -5,7 +5,7 @@ const glob = require('glob-all');
 
 const constants = require('../constants');
 const { loadConfig } = require('../codegen-config');
-const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails } = require('../utils');
+const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, getAppSyncAPIInfoFromProject } = require('../utils');
 const { generateTypes: generateTypesHelper } = require('@aws-amplify/graphql-generator');
 const { extractDocumentFromJavascript } = require('@aws-amplify/graphql-types-generator');
 
@@ -22,9 +22,18 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
   if (frontend !== 'android') {
     const config = loadConfig(context, withoutInit);
     const projects = config.getProjects();
+    if (!projects.length && withoutInit) {
+      context.print.info(constants.ERROR_CODEGEN_NO_API_CONFIGURED);
+      return;
+    }
     let apis = [];
     if (!withoutInit) {
       apis = getAppSyncAPIDetails(context);
+    } else {
+      const api = getAppSyncAPIInfoFromProject(context, projects[0]);
+      if (api) {
+        apis = [api];
+      }
     }
     if (!projects.length || !apis.length) {
       if (!withoutInit) {
@@ -68,10 +77,15 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
           .join('\n');
 
         const schemaPath = path.join(projectPath, cfg.schema);
-        let region;
-        if (!withoutInit) {
-          ({ region } = cfg.amplifyExtension);
+
+        const outputPath = path.join(projectPath, generatedFileName);
+        if (apis.length) {
+          const { region } = cfg.amplifyExtension;
           await ensureIntrospectionSchema(context, schemaPath, apis[0], region, forceDownloadSchema);
+        } else {
+          if (!fs.existsSync(schemaPath)) {
+            throw new Error(`Cannot find GraphQL schema file: ${schemaPath}`);
+          }
         }
         const codeGenSpinner = new Ora(constants.INFO_MESSAGE_CODEGEN_GENERATE_STARTED);
         codeGenSpinner.start();

--- a/packages/amplify-codegen/src/constants.js
+++ b/packages/amplify-codegen/src/constants.js
@@ -19,7 +19,8 @@ module.exports = {
   PROMPT_MSG_SELECT_PROJECT: 'Choose the AppSync API',
   PROMPT_MSG_SELECT_REGION: 'Choose AWS Region',
   ERROR_CODEGEN_TARGET_NOT_SUPPORTED: 'is not supported by codegen plugin',
-  ERROR_FLUTTER_CODEGEN_NOT_SUPPORTED: 'Flutter only supports the command $amplify codegen models. All the other codegen commands are not supported.',
+  ERROR_FLUTTER_CODEGEN_NOT_SUPPORTED:
+    'Flutter only supports the command $amplify codegen models. All the other codegen commands are not supported.',
   ERROR_CODEGEN_FRONTEND_NOT_SUPPORTED: 'The project frontend is not supported by codegen',
   ERROR_MSG_MAX_DEPTH: 'Depth should be a integer greater than 0',
   ERROR_CODEGEN_NO_API_AVAILABLE: 'There are no GraphQL APIs available.\nAdd by running $amplify api add',
@@ -37,7 +38,8 @@ module.exports = {
   CMD_DESCRIPTION_CONFIGURE: 'Change/Update codegen configuration',
   ERROR_CODEGEN_NO_API_CONFIGURED: 'code generation is not configured. Configure it by running \n$amplify codegen add',
   ERROR_CODEGEN_PENDING_API_PUSH: 'AppSync API is not pushed to the cloud. Did you forget to do \n$amplify api push',
-  ERROR_CODEGEN_NO_API_META: 'Cannot find API metadata. Please reset codegen by running $amplify codegen remove && amplify codegen add --apiId YOUR_API_ID',
+  ERROR_CODEGEN_NO_API_META:
+    'Cannot find API metadata. Please reset codegen by running $amplify codegen remove && amplify codegen add --apiId YOUR_API_ID',
   WARNING_CODEGEN_PENDING_API_PUSH: 'The APIs listed below are not pushed to the cloud. Run amplify api push',
   ERROR_APPSYNC_API_NOT_FOUND:
     'Could not find the AppSync API. If you have removed the AppSync API in the console run amplify codegen remove',
@@ -55,5 +57,6 @@ module.exports = {
   INFO_MESSAGE_DOWNLOAD_ERROR: 'Downloading schema failed',
   INFO_MESSAGE_OPS_GEN: 'Generating GraphQL operations',
   INFO_MESSAGE_OPS_GEN_SUCCESS: 'Generated GraphQL operations successfully and saved at ',
-  INFO_MESSAGE_ADD_ERROR: 'amplify codegen add takes only apiId as parameter. \n$ amplify codegen add [--apiId <API_ID>]',
+  INFO_MESSAGE_ADD_ERROR:
+    'amplify codegen add takes only apiId and region as parameters. \n$ amplify codegen add [--apiId <API_ID>] [--region <region>]',
 };

--- a/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/downloadIntrospectionSchema.js
@@ -16,7 +16,11 @@ async function downloadIntrospectionSchema(context, apiId, downloadLocation, reg
       const introspectionDir = dirname(downloadLocation);
       fs.ensureDirSync(introspectionDir);
       fs.writeFileSync(downloadLocation, schema, 'utf8');
-      return relative(amplify.getEnvInfo().projectPath, downloadLocation);
+      try {
+        return relative(amplify.getEnvInfo().projectPath, downloadLocation);
+      } catch {
+        return downloadLocation;
+      }
     } catch (ex) {
       if (ex.code === 'NotFoundException') {
         throw new AmplifyCodeGenAPINotFoundError(constants.ERROR_APPSYNC_API_NOT_FOUND);

--- a/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
+++ b/packages/amplify-codegen/src/utils/ensureIntrospectionSchema.js
@@ -4,9 +4,12 @@ const generateIntrospectionSchema = require('./generateIntrospectionSchema');
 const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
 
 async function ensureIntrospectionSchema(context, schemaPath, apiConfig, region, forceDownloadSchema) {
-  const meta = context.amplify.getProjectMeta();
+  let meta;
+  try {
+    meta = context.amplify.getProjectMeta();
+  } catch {}
   const { id, name } = apiConfig;
-  const isTransformedAPI = Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
+  const isTransformedAPI = meta && Object.keys(meta.api || {}).includes(name) && meta.api[name].providerPlugin === 'awscloudformation';
   if (isTransformedAPI && getFrontendHandler(context) === 'android') {
     generateIntrospectionSchema(context, name);
   } else if (schemaPath.endsWith('.json')) {

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
@@ -3,7 +3,7 @@ const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
 /* Get AppSync api info if api id and region are avialable.
  * Otherwise return undefined.
  */
-function getAppSyncAPIInfoFromProject(context, project) {
+async function getAppSyncAPIInfoFromProject(context, project) {
   if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
     const {
       amplifyExtension: { apiId, region },

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
@@ -1,0 +1,15 @@
+const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+
+/* Get AppSync api info if api id and region are avialable.
+ * Otherwise return undefined.
+ */
+function getAppSyncAPIInfoFromProject(project, context) {
+  if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
+    const {
+      amplifyExtension: { apiId, region },
+    } = project;
+    return getAppSyncAPIInfo(context, apiId, region);
+  }
+  return undefined;
+}
+module.exports = getAppSyncAPIInfoFromProject;

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
@@ -3,7 +3,7 @@ const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
 /* Get AppSync api info if api id and region are avialable.
  * Otherwise return undefined.
  */
-function getAppSyncAPIInfoFromProject(project, context) {
+function getAppSyncAPIInfoFromProject(context, project) {
   if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
     const {
       amplifyExtension: { apiId, region },

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -5,6 +5,7 @@ const downloadIntrospectionSchema = require('./downloadIntrospectionSchema');
 const getSchemaDownloadLocation = require('./getSchemaDownloadLocation');
 const getIncludePattern = require('./getIncludePattern');
 const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
+const getAppSyncAPIInfoFromProject = require('./getAppSyncAPIInfoFromProject');
 const getProjectAwsRegion = require('./getProjectAWSRegion');
 const getGraphQLDocPath = require('./getGraphQLDocPath');
 const downloadIntrospectionSchemaWithProgress = require('./generateIntrospectionSchemaWithProgress');
@@ -25,6 +26,7 @@ module.exports = {
   downloadIntrospectionSchemaWithProgress,
   getIncludePattern,
   getAppSyncAPIInfo,
+  getAppSyncAPIInfoFromProject,
   getProjectAwsRegion,
   getGraphQLDocPath,
   isAppSyncApiPendingPush,

--- a/packages/amplify-codegen/tests/cli/add.test.js
+++ b/packages/amplify-codegen/tests/cli/add.test.js
@@ -1,0 +1,144 @@
+const add = require('../../commands/codegen/add');
+const codeGen = require('../../src/index');
+
+jest.mock('../../src/index');
+
+describe('cli - add', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('feature name', () => {
+    expect(add.name).toEqual('add');
+  });
+
+  describe('run', () => {
+    test('executes codegen add', async () => {
+      const context = {
+        parameters: {},
+      };
+      await add.run(context);
+      expect(codeGen.add).toHaveBeenCalledWith(context, null, undefined);
+    });
+
+    test('catches error in codegen add', async () => {
+      const error = jest.fn();
+      const context = {
+        parameters: {},
+        print: {
+          error,
+        },
+      };
+
+      const codegenError = new Error('failed to read file');
+      codeGen.add.mockRejectedValueOnce(codegenError);
+      await add.run(context);
+      expect(error).toHaveBeenCalledWith(codegenError.message);
+    });
+
+    test('passes apiId', async () => {
+      const apiId = 'apiid';
+      const context = {
+        parameters: {
+          options: {
+            apiId,
+          },
+        },
+      };
+      await add.run(context);
+      expect(codeGen.add).toHaveBeenCalledWith(context, apiId, undefined);
+    });
+
+    test('passes region', async () => {
+      const region = 'region';
+      const context = {
+        parameters: {
+          options: {
+            region,
+          },
+        },
+      };
+      await add.run(context);
+      expect(codeGen.add).toHaveBeenCalledWith(context, null, region);
+    });
+
+    test('throws error on invalid arg', async () => {
+      const badArg = 'badArg';
+      const info = jest.fn();
+      const context = {
+        parameters: {
+          options: {
+            badArg,
+          },
+        },
+        print: {
+          info,
+        },
+      };
+      await add.run(context);
+      expect(info).toHaveBeenCalledWith('Invalid parameter badArg');
+
+      expect(info).toHaveBeenCalledWith(
+        'amplify codegen add takes only apiId and region as parameters. \n$ amplify codegen add [--apiId <API_ID>] [--region <region>]',
+      );
+    });
+
+    test('throws error on invalid args', async () => {
+      const badArgOne = 'badArgOne';
+      const badArgTwo = 'badArgTwo';
+      const info = jest.fn();
+      const context = {
+        parameters: {
+          options: {
+            badArgOne,
+            badArgTwo,
+          },
+        },
+        print: {
+          info,
+        },
+      };
+      await add.run(context);
+      expect(info).toHaveBeenCalledWith('Invalid parameters badArgOne, badArgTwo');
+
+      expect(info).toHaveBeenCalledWith(
+        'amplify codegen add takes only apiId and region as parameters. \n$ amplify codegen add [--apiId <API_ID>] [--region <region>]',
+      );
+    });
+
+    test('allows undocummented frontend and framework', async () => {
+      const frontend = 'frontend';
+      const framework = 'framework';
+      const info = jest.fn();
+      const context = {
+        parameters: {
+          options: {
+            frontend,
+            framework,
+          },
+        },
+        print: {
+          info,
+        },
+      };
+      await add.run(context);
+      expect(info).not.toHaveBeenCalled();
+    });
+
+    test('ignores yes arg', async () => {
+      const yes = true;
+      const info = jest.fn();
+      const context = {
+        parameters: {
+          options: {
+            yes,
+          },
+        },
+        print: {
+          info,
+        },
+      };
+      await add.run(context);
+    });
+  });
+});

--- a/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`command - add without init should read frontend and framework from options 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": "MOCK_API_ID",
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "vue",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-east-1",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.graphql",
+}
+`;
+
+exports[`command - add without init should use region supplied when without init 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": "MOCK_API_ID",
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "react",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-west-2",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.graphql",
+}
+`;

--- a/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
+++ b/packages/amplify-codegen/tests/commands/__snapshots__/add.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`command - add without init should download introspection schema when api id 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": "MOCK_API_ID",
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "react",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-east-1",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.json",
+}
+`;
+
 exports[`command - add without init should read frontend and framework from options 1`] = `
 Object {
   "amplifyExtension": Object {
@@ -7,6 +25,24 @@ Object {
     "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
     "docsFilePath": "MOCK_DOCS_FILE_PATH",
     "framework": "vue",
+    "frontend": "javascript",
+    "generatedFileName": "API.TS",
+    "region": "us-east-1",
+  },
+  "excludes": "MOCK_EXCLUDE",
+  "includes": "MOCK_INCLUDE",
+  "projectName": "Codegen Project",
+  "schema": "/user/foo/project/schema.json",
+}
+`;
+
+exports[`command - add without init should use existing schema if no api id 1`] = `
+Object {
+  "amplifyExtension": Object {
+    "apiId": null,
+    "codeGenTarget": "TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE",
+    "docsFilePath": "MOCK_DOCS_FILE_PATH",
+    "framework": "react",
     "frontend": "javascript",
     "generatedFileName": "API.TS",
     "region": "us-east-1",
@@ -32,6 +68,6 @@ Object {
   "excludes": "MOCK_EXCLUDE",
   "includes": "MOCK_INCLUDE",
   "projectName": "Codegen Project",
-  "schema": "/user/foo/project/schema.graphql",
+  "schema": "/user/foo/project/schema.json",
 }
 `;


### PR DESCRIPTION
#### Description of changes
Merge in the `noinit-codegen` branch, which will allow customers to execute codegen commands in the amplify cli without any amplify project initialized locally.

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests, Exploratory Testing per a documented test plan.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.