### PR TITLE
chore: get existing e2e tests passing

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
+++ b/packages/amplify-codegen-e2e-core/src/categories/codegen.ts
@@ -168,7 +168,7 @@ export function generateModelIntrospection(cwd: string, settings: { outputDir?: 
 // CLI workflow to add codegen to non-Amplify JS project
 export function addCodegenNonAmplifyJS(cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const cmdOptions = ['codegen', 'add', '--apiId', 'mockapiid'];
+    const cmdOptions = ['codegen', 'add'];
     const chain = spawn(getCLIPath(), cmdOptions, { cwd, stripColors: true });
     chain
       .wait("Choose the type of app that you're building")

--- a/packages/amplify-codegen/commands/codegen/add.js
+++ b/packages/amplify-codegen/commands/codegen/add.js
@@ -10,7 +10,7 @@ module.exports = {
       const { options = {} } = context.parameters;
       const keys = Object.keys(options);
       // frontend and framework are undocumented, but are read when apiId is also supplied
-      const { apiId = null, region, yes, frontend, framework, ...rest } = options;
+      const { apiId = null, region, yes, frontend, framework, debug, ...rest } = options;
       const extraOptions = Object.keys(rest);
       if (extraOptions.length) {
         const paramMsg = extraOptions.length > 1 ? 'Invalid parameters' : 'Invalid parameter';

--- a/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
+++ b/packages/amplify-codegen/src/utils/getAppSyncAPIInfoFromProject.js
@@ -3,7 +3,7 @@ const getAppSyncAPIInfo = require('./getAppSyncAPIInfo');
 /* Get AppSync api info if api id and region are avialable.
  * Otherwise return undefined.
  */
-function getAppSyncAPIInfoFromProject(project, context) {
+function getAppSyncAPIInfoFromProject(context, project) {
   if (project.amplifyExtension.apiId && project.amplifyExtension.region) {
     const {
       amplifyExtension: { apiId, region },


### PR DESCRIPTION
#### Description of changes
Getting existing e2e tests passing by removing the --apiId param when not downloading a backend API.

Also fixed a minor bug where adding --debug failed the command, and fixed some mixed up params in a function call (yay JS)

#### Issue #, if available
N/A

#### Description of how you validated changes
Unit + E2E Tests now pass on the branch (when caught up to `main`).

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.