### PR TITLE
fix: move types from runtime deps to dev deps

### DIFF
--- a/packages/appsync-modelgen-plugin/package.json
+++ b/packages/appsync-modelgen-plugin/package.json
@@ -29,8 +29,6 @@
     "@graphql-codegen/plugin-helpers": "^1.18.8",
     "@graphql-codegen/visitor-plugin-common": "^1.22.0",
     "@graphql-tools/utils": "^6.0.18",
-    "@types/node": "^12.12.6",
-    "@types/pluralize": "0.0.29",
     "chalk": "^3.0.0",
     "change-case": "^4.1.1",
     "lower-case-first": "^2.0.1",
@@ -43,7 +41,9 @@
     "@graphql-codegen/typescript": "^2.8.3",
     "graphql": "^15.5.0",
     "java-ast": "^0.3.0",
-    "ts-json-schema-generator": "1.0.0"
+    "ts-json-schema-generator": "1.0.0",
+    "@types/node": "^12.12.6",
+    "@types/pluralize": "0.0.29"
   },
   "peerDependencies": {
     "graphql": "^15.5.0"

--- a/packages/graphql-types-generator/package.json
+++ b/packages/graphql-types-generator/package.json
@@ -37,10 +37,6 @@
   "dependencies": {
     "@babel/generator": "7.0.0-beta.4",
     "@babel/types": "7.0.0-beta.4",
-    "@types/babel-generator": "^6.25.0",
-    "@types/fs-extra": "^8.1.0",
-    "@types/prettier": "^1.19.0",
-    "@types/rimraf": "^3.0.0",
     "babel-generator": "^6.26.1",
     "babel-types": "^6.26.0",
     "change-case": "^4.1.1",
@@ -60,7 +56,11 @@
     "@types/glob": "^7.1.1",
     "@types/inflected": "^1.1.29",
     "@types/node": "^10.17.13",
-    "@types/yargs": "^15.0.1"
+    "@types/yargs": "^15.0.1",
+    "@types/babel-generator": "^6.25.0",
+    "@types/fs-extra": "^8.1.0",
+    "@types/prettier": "^1.19.0",
+    "@types/rimraf": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3744,9 +3744,9 @@
     value-or-promise "^1.0.12"
 
 "@graphql-tools/utils@^10.0.0":
-  version "10.0.5"
-  resolved "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.5.tgz#b76c7b5b7fc3f67da734b51cf6e33c52dee09974"
-  integrity sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==
+  version "10.0.6"
+  resolved "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz#8a809d6bc0df27ffe8964696f182af2383b5974b"
+  integrity sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     dset "^3.1.2"
@@ -6128,17 +6128,17 @@
   integrity sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==
 
 "@whatwg-node/fetch@^0.9.0":
-  version "0.9.9"
-  resolved "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz#65e68aaf8353755c20657b803f2fe983dbdabf91"
-  integrity sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==
+  version "0.9.13"
+  resolved "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz#1d084cd546b9cd425ae89cbb1252a3e47a9a2e1c"
+  integrity sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==
   dependencies:
-    "@whatwg-node/node-fetch" "^0.4.8"
+    "@whatwg-node/node-fetch" "^0.4.17"
     urlpattern-polyfill "^9.0.0"
 
-"@whatwg-node/node-fetch@^0.4.8":
-  version "0.4.13"
-  resolved "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.13.tgz#523b046f9511e6e62ac98365653b5ce63175614b"
-  integrity sha512-Wijn8jtXq6VBX6EttABXHJIQBcoOP6RRQllXbiaHGORACTDr1xg6g2UnkoggY3dbDkm1VsMjdSe7NVBPc4ukYg==
+"@whatwg-node/node-fetch@^0.4.17":
+  version "0.4.19"
+  resolved "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz#29c72ff65a8e450949238612ff17a3d3717736d3"
+  integrity sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==
   dependencies:
     "@whatwg-node/events" "^0.1.0"
     busboy "^1.6.0"


### PR DESCRIPTION
#### Description of changes
We incorrectly rely on some `types` packages at runtime, this pollutes the runtime a bit. Moving them into devDeps.

#### Issue #, if available
N/A

#### Description of how you validated changes
Build + Test Passes

#### Checklist
- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.