### PR TITLE
fix: typo in graphql-generator arg

### DIFF
--- a/packages/graphql-generator/API.md
+++ b/packages/graphql-generator/API.md
@@ -22,7 +22,7 @@ export type GenerateModelsOptions = {
     directives: string;
     generateIndexRules?: boolean;
     emitAuthProvider?: boolean;
-    useExperimentalPipelinedTranformer?: boolean;
+    useExperimentalPipelinedTransformer?: boolean;
     transformerVersion?: boolean;
     respectPrimaryKeyAttributesOnConnectionField?: boolean;
     generateModelsForLazyLoadAndCustomSelectionSet?: boolean;

--- a/packages/graphql-generator/src/models.ts
+++ b/packages/graphql-generator/src/models.ts
@@ -13,7 +13,7 @@ export async function generateModels(options: GenerateModelsOptions): Promise<Ge
     // feature flags
     generateIndexRules = true,
     emitAuthProvider = true,
-    useExperimentalPipelinedTranformer = true,
+    useExperimentalPipelinedTransformer = true,
     transformerVersion = true,
     respectPrimaryKeyAttributesOnConnectionField = true,
     generateModelsForLazyLoadAndCustomSelectionSet = true,
@@ -34,7 +34,7 @@ export async function generateModels(options: GenerateModelsOptions): Promise<Ge
       emitAuthProvider,
       generateIndexRules,
       handleListNullabilityTransparently,
-      usePipelinedTransformer: useExperimentalPipelinedTranformer,
+      usePipelinedTransformer: useExperimentalPipelinedTransformer,
       transformerVersion,
       respectPrimaryKeyAttributesOnConnectionField,
       generateModelsForLazyLoadAndCustomSelectionSet,

--- a/packages/graphql-generator/src/typescript.ts
+++ b/packages/graphql-generator/src/typescript.ts
@@ -22,7 +22,7 @@ export type GenerateModelsOptions = {
   // feature flags
   generateIndexRules?: boolean;
   emitAuthProvider?: boolean;
-  useExperimentalPipelinedTranformer?: boolean;
+  useExperimentalPipelinedTransformer?: boolean;
   transformerVersion?: boolean;
   respectPrimaryKeyAttributesOnConnectionField?: boolean;
   generateModelsForLazyLoadAndCustomSelectionSet?: boolean;


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

useExperimentalPipelinedTranformer -> useExperimentalPipelinedTransformer (missing s in Transformer)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.