### PR TITLE
fix: swift file names

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -96,7 +96,7 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
 
         try {
           if (target === 'swift' && fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
-            generate(queryFilePaths, schemaPath, path.join(projectPath, generatedFileName), '', target, '', {
+            generate(queryFilePaths, schemaPath, outputPath, '', target, '', {
               addTypename: true,
               complexObjectSupport: 'auto',
             });

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -81,6 +81,7 @@ describe('command - types', () => {
       schema: 'schema',
       target: 'TYPE_SCRIPT_OR_FLOW_OR_ANY_OTHER_LANGUAGE',
       introspection: false,
+      multipleSwiftFiles: false,
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Type generation for Swift is always generating multiple files. Additionally the when generating multiple files the filename generated is incorrect.

Fallback to old type generation if generating to multiple files. When using the GraphQL generator directly the filenames will still be incorrect.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-codegen/issues/711

#### Description of how you validated changes

* unit testing
* Manual testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.