### PR TITLE
fix: relative types path in same dir as documents

### DIFF
--- a/packages/amplify-codegen/src/commands/statements.js
+++ b/packages/amplify-codegen/src/commands/statements.js
@@ -10,6 +10,7 @@ const {
   getAppSyncAPIDetails,
   readSchemaFromFile,
   getAppSyncAPIInfoFromProject,
+  getRelativeTypesPath,
 } = require('../utils');
 const { generateGraphQLDocuments } = require('@aws-amplify/graphql-docs-generator');
 const { generateStatements: generateStatementsHelper } = require('@aws-amplify/graphql-generator');
@@ -64,9 +65,6 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
 
     try {
       const schemaData = readSchemaFromFile(schemaPath);
-      const relativeTypesPath = cfg.amplifyExtension.generatedFileName
-        ? path.relative(opsGenDirectory, cfg.amplifyExtension.generatedFileName)
-        : null;
       const generatedOps = generateStatementsHelper({
         schema: schemaData,
         target: language,
@@ -75,7 +73,7 @@ async function generateStatements(context, forceDownloadSchema, maxDepth, withou
         // default typenameIntrospection to true when not set
         typenameIntrospection:
           cfg.amplifyExtension.typenameIntrospection === undefined ? true : !!cfg.amplifyExtension.typenameIntrospection,
-        relativeTypesPath,
+        relativeTypesPath: getRelativeTypesPath(opsGenDirectory, cfg.amplifyExtension.generatedFileName),
       });
       if (!generatedOps) {
         context.print.warning('No GraphQL statements are generated. Check if the introspection schema has GraphQL operations defined.');

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -7,7 +7,7 @@ const constants = require('../constants');
 const { loadConfig } = require('../codegen-config');
 const { ensureIntrospectionSchema, getFrontEndHandler, getAppSyncAPIDetails, getAppSyncAPIInfoFromProject } = require('../utils');
 const { generateTypes: generateTypesHelper } = require('@aws-amplify/graphql-generator');
-const { extractDocumentFromJavascript } = require('@aws-amplify/graphql-types-generator');
+const { generate, extractDocumentFromJavascript } = require('@aws-amplify/graphql-types-generator');
 
 async function generateTypes(context, forceDownloadSchema, withoutInit = false, decoupleFrontend = '') {
   let frontend = decoupleFrontend;
@@ -57,25 +57,24 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         const target = cfg.amplifyExtension.codeGenTarget;
 
         const excludes = cfg.excludes.map(pattern => `!${pattern}`);
-        const queryFiles = glob
-          .sync([...includeFiles, ...excludes], {
-            cwd: projectPath,
-            absolute: true,
-          })
-          .map(queryFilePath => {
-            const fileContents = fs.readFileSync(queryFilePath, 'utf8');
-            if (
-              queryFilePath.endsWith('.jsx') ||
-              queryFilePath.endsWith('.js') ||
-              queryFilePath.endsWith('.tsx') ||
-              queryFilePath.endsWith('.ts')
-            ) {
-              return extractDocumentFromJavascript(fileContents, '');
-            }
-            return fileContents;
-          });
+        const queryFilePaths = glob.sync([...includeFiles, ...excludes], {
+          cwd: projectPath,
+          absolute: true,
+        });
+        const queryFiles = queryFilePaths.map(queryFilePath => {
+          const fileContents = fs.readFileSync(queryFilePath, 'utf8');
+          if (
+            queryFilePath.endsWith('.jsx') ||
+            queryFilePath.endsWith('.js') ||
+            queryFilePath.endsWith('.tsx') ||
+            queryFilePath.endsWith('.ts')
+          ) {
+            return extractDocumentFromJavascript(fileContents, '');
+          }
+          return fileContents;
+        });
         if (queryFiles.length === 0) {
-          throw new Error('No queries found to generate types for, you may need to run \'codegen statements\' first');
+          throw new Error("No queries found to generate types for, you may need to run 'codegen statements' first");
         }
         const queries = queryFiles.join('\n');
 
@@ -96,22 +95,29 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         const introspection = path.extname(schemaPath) === '.json';
 
         try {
-          const output = await generateTypesHelper({
-            schema,
-            queries,
-            target,
-            introspection,
-          });
-          const outputs = Object.entries(output);
-
-          const outputPath = path.join(projectPath, generatedFileName);
-          if (outputs.length === 1) {
-            const [[, contents]] = outputs;
-            fs.outputFileSync(path.resolve(outputPath), contents);
-          } else {
-            outputs.forEach(([filepath, contents]) => {
-              fs.outputFileSync(path.resolve(path.join(outputPath, filepath)), contents);
+          if (target === 'swift' && fs.existsSync(outputPath) && fs.statSync(outputPath).isDirectory()) {
+            generate(queryFilePaths, schemaPath, outputPath, '', target, '', {
+              addTypename: true,
+              complexObjectSupport: 'auto',
             });
+          } else {
+            const output = await generateTypesHelper({
+              schema,
+              queries,
+              target,
+              introspection,
+            });
+            const outputs = Object.entries(output);
+
+            const outputPath = path.join(projectPath, generatedFileName);
+            if (outputs.length === 1) {
+              const [[, contents]] = outputs;
+              fs.outputFileSync(path.resolve(outputPath), contents);
+            } else {
+              outputs.forEach(([filepath, contents]) => {
+                fs.outputFileSync(path.resolve(path.join(outputPath, filepath)), contents);
+              });
+            }
           }
           codeGenSpinner.succeed(`${constants.INFO_MESSAGE_CODEGEN_GENERATE_SUCCESS} ${path.relative(path.resolve('.'), outputPath)}`);
         } catch (err) {

--- a/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
+++ b/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+function getRelativeTypesPath(opsGenDirectory, generatedFileName) {
+  if (generatedFileName) {
+    const relativePath = path.relative(opsGenDirectory, generatedFileName);
+
+    // generatedFileName is in same directory as opsGenDirectory
+    // i.e. generatedFileName: src/graphql/API.ts, opsGenDirectory: src/graphql
+    if (!relativePath.startsWith('.')) {
+      // path.join will strip prefixed ./
+      return `./${relativePath}`;
+    }
+
+    return relativePath;
+  }
+  return null;
+}
+
+module.exports = getRelativeTypesPath;

--- a/packages/amplify-codegen/src/utils/index.js
+++ b/packages/amplify-codegen/src/utils/index.js
@@ -17,6 +17,7 @@ const switchToSDLSchema = require('./switchToSDLSchema');
 const ensureIntrospectionSchema = require('./ensureIntrospectionSchema');
 const { readSchemaFromFile } = require('./readSchemaFromFile');
 const defaultDirectiveDefinitions = require('./defaultDirectiveDefinitions');
+const getRelativeTypesPath = require('./getRelativeTypesPath');
 module.exports = {
   getAppSyncAPIDetails,
   getFrontEndHandler,
@@ -37,4 +38,5 @@ module.exports = {
   ensureIntrospectionSchema,
   readSchemaFromFile,
   defaultDirectiveDefinitions,
+  getRelativeTypesPath,
 };

--- a/packages/amplify-codegen/tests/utils/getRelativeTypesPath.test.js
+++ b/packages/amplify-codegen/tests/utils/getRelativeTypesPath.test.js
@@ -17,7 +17,7 @@ describe('getRelativeTypesPath', () => {
     expect(getRelativeTypesPath('src/graphql', 'src/graphql/types/API.ts')).toEqual('./types/API.ts');
   });
 
-  test('one dir down', () => {
+  test('two dir down', () => {
     expect(getRelativeTypesPath('src/graphql', 'src/graphql/types/foo/API.ts')).toEqual('./types/foo/API.ts');
   });
 

--- a/packages/amplify-codegen/tests/utils/getRelativeTypesPath.test.js
+++ b/packages/amplify-codegen/tests/utils/getRelativeTypesPath.test.js
@@ -1,0 +1,31 @@
+const getRelativeTypesPath = require('../../src/utils/getRelativeTypesPath');
+
+describe('getRelativeTypesPath', () => {
+  test('in same directory', () => {
+    expect(getRelativeTypesPath('src/graphql', 'src/graphql/API.ts')).toEqual('./API.ts');
+  });
+
+  test('one dir up', () => {
+    expect(getRelativeTypesPath('src/graphql', 'src/API.ts')).toEqual('../API.ts');
+  });
+
+  test('two dir up', () => {
+    expect(getRelativeTypesPath('src/graphql', 'API.ts')).toEqual('../../API.ts');
+  });
+
+  test('one dir down', () => {
+    expect(getRelativeTypesPath('src/graphql', 'src/graphql/types/API.ts')).toEqual('./types/API.ts');
+  });
+
+  test('one dir down', () => {
+    expect(getRelativeTypesPath('src/graphql', 'src/graphql/types/foo/API.ts')).toEqual('./types/foo/API.ts');
+  });
+
+  test('sibling dirs', () => {
+    expect(getRelativeTypesPath('src/graphql', 'src/types/API.ts')).toEqual('../types/API.ts');
+  });
+
+  test('no types file', () => {
+    expect(getRelativeTypesPath('src/graphql', null)).toEqual(null);
+  });
+});


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The relative types path is incorrect when the types file is in the same directory as the GraphQL documents.

The path does not include a prefixed `./`. This causes JS look for a non-relative import.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves: https://github.com/aws-amplify/amplify-codegen/issues/710


#### Description of how you validated changes

* Unit testing
* Manual testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.