### PR TITLE
fix: generate multiple swift files

### DIFF
--- a/packages/graphql-generator/API.md
+++ b/packages/graphql-generator/API.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Source } from 'graphql';
 import { Target } from '@aws-amplify/appsync-modelgen-plugin';
 import { Target as Target_2 } from '@aws-amplify/graphql-types-generator';
 
@@ -49,7 +50,7 @@ export function generateTypes(options: GenerateTypesOptions): Promise<GeneratedO
 export type GenerateTypesOptions = {
     schema: string;
     target: TypesTarget;
-    queries: string;
+    queries: string | Source[];
     introspection?: boolean;
     multipleSwiftFiles?: boolean;
 };

--- a/packages/graphql-generator/src/__tests__/__snapshots__/types.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/__snapshots__/types.test.ts.snap
@@ -1,8 +1,431 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateTypes multipleSwiftFiles 1`] = `
+exports[`generateTypes multipleSwiftFiles generates multiple files 1`] = `
 Object {
-  "GraphQL request.swift": "//  This file was automatically generated and should not be edited.
+  "Types.graphql.swift": "//  This file was automatically generated and should not be edited.
+
+#if canImport(AWSAPIPlugin)
+import Foundation
+
+public protocol GraphQLInputValue {
+}
+
+public struct GraphQLVariable {
+  let name: String
+  
+  public init(_ name: String) {
+    self.name = name
+  }
+}
+
+extension GraphQLVariable: GraphQLInputValue {
+}
+
+extension JSONEncodable {
+  public func evaluate(with variables: [String: JSONEncodable]?) throws -> Any {
+    return jsonValue
+  }
+}
+
+public typealias GraphQLMap = [String: JSONEncodable?]
+
+extension Dictionary where Key == String, Value == JSONEncodable? {
+  public var withNilValuesRemoved: Dictionary<String, JSONEncodable> {
+    var filtered = Dictionary<String, JSONEncodable>(minimumCapacity: count)
+    for (key, value) in self {
+      if value != nil {
+        filtered[key] = value
+      }
+    }
+    return filtered
+  }
+}
+
+public protocol GraphQLMapConvertible: JSONEncodable {
+  var graphQLMap: GraphQLMap { get }
+}
+
+public extension GraphQLMapConvertible {
+  var jsonValue: Any {
+    return graphQLMap.withNilValuesRemoved.jsonValue
+  }
+}
+
+public typealias GraphQLID = String
+
+public protocol APISwiftGraphQLOperation: AnyObject {
+  
+  static var operationString: String { get }
+  static var requestString: String { get }
+  static var operationIdentifier: String? { get }
+  
+  var variables: GraphQLMap? { get }
+  
+  associatedtype Data: GraphQLSelectionSet
+}
+
+public extension APISwiftGraphQLOperation {
+  static var requestString: String {
+    return operationString
+  }
+
+  static var operationIdentifier: String? {
+    return nil
+  }
+
+  var variables: GraphQLMap? {
+    return nil
+  }
+}
+
+public protocol GraphQLQuery: APISwiftGraphQLOperation {}
+
+public protocol GraphQLMutation: APISwiftGraphQLOperation {}
+
+public protocol GraphQLSubscription: APISwiftGraphQLOperation {}
+
+public protocol GraphQLFragment: GraphQLSelectionSet {
+  static var possibleTypes: [String] { get }
+}
+
+public typealias Snapshot = [String: Any?]
+
+public protocol GraphQLSelectionSet: Decodable {
+  static var selections: [GraphQLSelection] { get }
+  
+  var snapshot: Snapshot { get }
+  init(snapshot: Snapshot)
+}
+
+extension GraphQLSelectionSet {
+    public init(from decoder: Decoder) throws {
+        if let jsonObject = try? APISwiftJSONValue(from: decoder) {
+            let encoder = JSONEncoder()
+            let jsonData = try encoder.encode(jsonObject)
+            let decodedDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
+            let optionalDictionary = decodedDictionary.mapValues { $0 as Any? }
+
+            self.init(snapshot: optionalDictionary)
+        } else {
+            self.init(snapshot: [:])
+        }
+    }
+}
+
+enum APISwiftJSONValue: Codable {
+    case array([APISwiftJSONValue])
+    case boolean(Bool)
+    case number(Double)
+    case object([String: APISwiftJSONValue])
+    case string(String)
+    case null
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let value = try? container.decode([String: APISwiftJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([APISwiftJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .boolean(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            self = .null
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        switch self {
+        case .array(let value):
+            try container.encode(value)
+        case .boolean(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+public protocol GraphQLSelection {
+}
+
+public struct GraphQLField: GraphQLSelection {
+  let name: String
+  let alias: String?
+  let arguments: [String: GraphQLInputValue]?
+  
+  var responseKey: String {
+    return alias ?? name
+  }
+  
+  let type: GraphQLOutputType
+  
+  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
+    self.name = name
+    self.alias = alias
+    
+    self.arguments = arguments
+    
+    self.type = type
+  }
+}
+
+public indirect enum GraphQLOutputType {
+  case scalar(JSONDecodable.Type)
+  case object([GraphQLSelection])
+  case nonNull(GraphQLOutputType)
+  case list(GraphQLOutputType)
+  
+  var namedType: GraphQLOutputType {
+    switch self {
+    case .nonNull(let innerType), .list(let innerType):
+      return innerType.namedType
+    case .scalar, .object:
+      return self
+    }
+  }
+}
+
+public struct GraphQLBooleanCondition: GraphQLSelection {
+  let variableName: String
+  let inverted: Bool
+  let selections: [GraphQLSelection]
+  
+  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
+    self.variableName = variableName
+    self.inverted = inverted;
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLTypeCondition: GraphQLSelection {
+  let possibleTypes: [String]
+  let selections: [GraphQLSelection]
+  
+  public init(possibleTypes: [String], selections: [GraphQLSelection]) {
+    self.possibleTypes = possibleTypes
+    self.selections = selections;
+  }
+}
+
+public struct GraphQLFragmentSpread: GraphQLSelection {
+  let fragment: GraphQLFragment.Type
+  
+  public init(_ fragment: GraphQLFragment.Type) {
+    self.fragment = fragment
+  }
+}
+
+public struct GraphQLTypeCase: GraphQLSelection {
+  let variants: [String: [GraphQLSelection]]
+  let \`default\`: [GraphQLSelection]
+  
+  public init(variants: [String: [GraphQLSelection]], default: [GraphQLSelection]) {
+    self.variants = variants
+    self.default = \`default\`;
+  }
+}
+
+public typealias JSONObject = [String: Any]
+
+public protocol JSONDecodable {
+  init(jsonValue value: Any) throws
+}
+
+public protocol JSONEncodable: GraphQLInputValue {
+  var jsonValue: Any { get }
+}
+
+public enum JSONDecodingError: Error, LocalizedError {
+  case missingValue
+  case nullValue
+  case wrongType
+  case couldNotConvert(value: Any, to: Any.Type)
+  
+  public var errorDescription: String? {
+    switch self {
+    case .missingValue:
+      return \\"Missing value\\"
+    case .nullValue:
+      return \\"Unexpected null value\\"
+    case .wrongType:
+      return \\"Wrong type\\"
+    case .couldNotConvert(let value, let expectedType):
+      return \\"Could not convert \\\\\\"\\\\(value)\\\\\\" to \\\\(expectedType)\\"
+    }
+  }
+}
+
+extension String: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
+    }
+    self = string
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Int: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
+    }
+    self = number.intValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Float: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
+    }
+    self = number.floatValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Double: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let number = value as? NSNumber else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
+    }
+    self = number.doubleValue
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension Bool: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let bool = value as? Bool else {
+        throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
+    }
+    self = bool
+  }
+
+  public var jsonValue: Any {
+    return self
+  }
+}
+
+extension RawRepresentable where RawValue: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    let rawValue = try RawValue(jsonValue: value)
+    if let tempSelf = Self(rawValue: rawValue) {
+      self = tempSelf
+    } else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
+    }
+  }
+}
+
+extension RawRepresentable where RawValue: JSONEncodable {
+  public var jsonValue: Any {
+    return rawValue.jsonValue
+  }
+}
+
+extension Optional where Wrapped: JSONDecodable {
+  public init(jsonValue value: Any) throws {
+    if value is NSNull {
+      self = .none
+    } else {
+      self = .some(try Wrapped(jsonValue: value))
+    }
+  }
+}
+
+extension Optional: JSONEncodable {
+  public var jsonValue: Any {
+    switch self {
+    case .none:
+      return NSNull()
+    case .some(let wrapped as JSONEncodable):
+      return wrapped.jsonValue
+    default:
+      fatalError(\\"Optional is only JSONEncodable if Wrapped is\\")
+    }
+  }
+}
+
+extension Dictionary: JSONEncodable {
+  public var jsonValue: Any {
+    return jsonObject
+  }
+  
+  public var jsonObject: JSONObject {
+    var jsonObject = JSONObject(minimumCapacity: count)
+    for (key, value) in self {
+      if case let (key as String, value as JSONEncodable) = (key, value) {
+        jsonObject[key] = value.jsonValue
+      } else {
+        fatalError(\\"Dictionary is only JSONEncodable if Value is (and if Key is String)\\")
+      }
+    }
+    return jsonObject
+  }
+}
+
+extension Array: JSONEncodable {
+  public var jsonValue: Any {
+    return map() { element -> (Any) in
+      if case let element as JSONEncodable = element {
+        return element.jsonValue
+      } else {
+        fatalError(\\"Array is only JSONEncodable if Element is\\")
+      }
+    }
+  }
+}
+
+extension URL: JSONDecodable, JSONEncodable {
+  public init(jsonValue value: Any) throws {
+    guard let string = value as? String else {
+      throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
+    }
+    self.init(string: string)!
+  }
+
+  public var jsonValue: Any {
+    return self.absoluteString
+  }
+}
+
+extension Dictionary {
+  static func += (lhs: inout Dictionary, rhs: Dictionary) {
+    lhs.merge(rhs) { (_, new) in new }
+  }
+}
+
+#elseif canImport(AWSAppSync)
+import AWSAppSync
+#endif",
+  "queries.graphql.swift": "//  This file was automatically generated and should not be edited.
 
 #if canImport(AWSAPIPlugin)
 import Foundation
@@ -581,429 +1004,6 @@ public final class GetBlogQuery: GraphQLQuery {
     }
   }
 }",
-  "Types.graphql.swift": "//  This file was automatically generated and should not be edited.
-
-#if canImport(AWSAPIPlugin)
-import Foundation
-
-public protocol GraphQLInputValue {
-}
-
-public struct GraphQLVariable {
-  let name: String
-  
-  public init(_ name: String) {
-    self.name = name
-  }
-}
-
-extension GraphQLVariable: GraphQLInputValue {
-}
-
-extension JSONEncodable {
-  public func evaluate(with variables: [String: JSONEncodable]?) throws -> Any {
-    return jsonValue
-  }
-}
-
-public typealias GraphQLMap = [String: JSONEncodable?]
-
-extension Dictionary where Key == String, Value == JSONEncodable? {
-  public var withNilValuesRemoved: Dictionary<String, JSONEncodable> {
-    var filtered = Dictionary<String, JSONEncodable>(minimumCapacity: count)
-    for (key, value) in self {
-      if value != nil {
-        filtered[key] = value
-      }
-    }
-    return filtered
-  }
-}
-
-public protocol GraphQLMapConvertible: JSONEncodable {
-  var graphQLMap: GraphQLMap { get }
-}
-
-public extension GraphQLMapConvertible {
-  var jsonValue: Any {
-    return graphQLMap.withNilValuesRemoved.jsonValue
-  }
-}
-
-public typealias GraphQLID = String
-
-public protocol APISwiftGraphQLOperation: AnyObject {
-  
-  static var operationString: String { get }
-  static var requestString: String { get }
-  static var operationIdentifier: String? { get }
-  
-  var variables: GraphQLMap? { get }
-  
-  associatedtype Data: GraphQLSelectionSet
-}
-
-public extension APISwiftGraphQLOperation {
-  static var requestString: String {
-    return operationString
-  }
-
-  static var operationIdentifier: String? {
-    return nil
-  }
-
-  var variables: GraphQLMap? {
-    return nil
-  }
-}
-
-public protocol GraphQLQuery: APISwiftGraphQLOperation {}
-
-public protocol GraphQLMutation: APISwiftGraphQLOperation {}
-
-public protocol GraphQLSubscription: APISwiftGraphQLOperation {}
-
-public protocol GraphQLFragment: GraphQLSelectionSet {
-  static var possibleTypes: [String] { get }
-}
-
-public typealias Snapshot = [String: Any?]
-
-public protocol GraphQLSelectionSet: Decodable {
-  static var selections: [GraphQLSelection] { get }
-  
-  var snapshot: Snapshot { get }
-  init(snapshot: Snapshot)
-}
-
-extension GraphQLSelectionSet {
-    public init(from decoder: Decoder) throws {
-        if let jsonObject = try? APISwiftJSONValue(from: decoder) {
-            let encoder = JSONEncoder()
-            let jsonData = try encoder.encode(jsonObject)
-            let decodedDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
-            let optionalDictionary = decodedDictionary.mapValues { $0 as Any? }
-
-            self.init(snapshot: optionalDictionary)
-        } else {
-            self.init(snapshot: [:])
-        }
-    }
-}
-
-enum APISwiftJSONValue: Codable {
-    case array([APISwiftJSONValue])
-    case boolean(Bool)
-    case number(Double)
-    case object([String: APISwiftJSONValue])
-    case string(String)
-    case null
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        
-        if let value = try? container.decode([String: APISwiftJSONValue].self) {
-            self = .object(value)
-        } else if let value = try? container.decode([APISwiftJSONValue].self) {
-            self = .array(value)
-        } else if let value = try? container.decode(Double.self) {
-            self = .number(value)
-        } else if let value = try? container.decode(Bool.self) {
-            self = .boolean(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else {
-            self = .null
-        }
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        
-        switch self {
-        case .array(let value):
-            try container.encode(value)
-        case .boolean(let value):
-            try container.encode(value)
-        case .number(let value):
-            try container.encode(value)
-        case .object(let value):
-            try container.encode(value)
-        case .string(let value):
-            try container.encode(value)
-        case .null:
-            try container.encodeNil()
-        }
-    }
-}
-
-public protocol GraphQLSelection {
-}
-
-public struct GraphQLField: GraphQLSelection {
-  let name: String
-  let alias: String?
-  let arguments: [String: GraphQLInputValue]?
-  
-  var responseKey: String {
-    return alias ?? name
-  }
-  
-  let type: GraphQLOutputType
-  
-  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
-    self.name = name
-    self.alias = alias
-    
-    self.arguments = arguments
-    
-    self.type = type
-  }
-}
-
-public indirect enum GraphQLOutputType {
-  case scalar(JSONDecodable.Type)
-  case object([GraphQLSelection])
-  case nonNull(GraphQLOutputType)
-  case list(GraphQLOutputType)
-  
-  var namedType: GraphQLOutputType {
-    switch self {
-    case .nonNull(let innerType), .list(let innerType):
-      return innerType.namedType
-    case .scalar, .object:
-      return self
-    }
-  }
-}
-
-public struct GraphQLBooleanCondition: GraphQLSelection {
-  let variableName: String
-  let inverted: Bool
-  let selections: [GraphQLSelection]
-  
-  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
-    self.variableName = variableName
-    self.inverted = inverted;
-    self.selections = selections;
-  }
-}
-
-public struct GraphQLTypeCondition: GraphQLSelection {
-  let possibleTypes: [String]
-  let selections: [GraphQLSelection]
-  
-  public init(possibleTypes: [String], selections: [GraphQLSelection]) {
-    self.possibleTypes = possibleTypes
-    self.selections = selections;
-  }
-}
-
-public struct GraphQLFragmentSpread: GraphQLSelection {
-  let fragment: GraphQLFragment.Type
-  
-  public init(_ fragment: GraphQLFragment.Type) {
-    self.fragment = fragment
-  }
-}
-
-public struct GraphQLTypeCase: GraphQLSelection {
-  let variants: [String: [GraphQLSelection]]
-  let \`default\`: [GraphQLSelection]
-  
-  public init(variants: [String: [GraphQLSelection]], default: [GraphQLSelection]) {
-    self.variants = variants
-    self.default = \`default\`;
-  }
-}
-
-public typealias JSONObject = [String: Any]
-
-public protocol JSONDecodable {
-  init(jsonValue value: Any) throws
-}
-
-public protocol JSONEncodable: GraphQLInputValue {
-  var jsonValue: Any { get }
-}
-
-public enum JSONDecodingError: Error, LocalizedError {
-  case missingValue
-  case nullValue
-  case wrongType
-  case couldNotConvert(value: Any, to: Any.Type)
-  
-  public var errorDescription: String? {
-    switch self {
-    case .missingValue:
-      return \\"Missing value\\"
-    case .nullValue:
-      return \\"Unexpected null value\\"
-    case .wrongType:
-      return \\"Wrong type\\"
-    case .couldNotConvert(let value, let expectedType):
-      return \\"Could not convert \\\\\\"\\\\(value)\\\\\\" to \\\\(expectedType)\\"
-    }
-  }
-}
-
-extension String: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let string = value as? String else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
-    }
-    self = string
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Int: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
-    }
-    self = number.intValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Float: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
-    }
-    self = number.floatValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Double: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
-    }
-    self = number.doubleValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Bool: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let bool = value as? Bool else {
-        throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
-    }
-    self = bool
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension RawRepresentable where RawValue: JSONDecodable {
-  public init(jsonValue value: Any) throws {
-    let rawValue = try RawValue(jsonValue: value)
-    if let tempSelf = Self(rawValue: rawValue) {
-      self = tempSelf
-    } else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
-    }
-  }
-}
-
-extension RawRepresentable where RawValue: JSONEncodable {
-  public var jsonValue: Any {
-    return rawValue.jsonValue
-  }
-}
-
-extension Optional where Wrapped: JSONDecodable {
-  public init(jsonValue value: Any) throws {
-    if value is NSNull {
-      self = .none
-    } else {
-      self = .some(try Wrapped(jsonValue: value))
-    }
-  }
-}
-
-extension Optional: JSONEncodable {
-  public var jsonValue: Any {
-    switch self {
-    case .none:
-      return NSNull()
-    case .some(let wrapped as JSONEncodable):
-      return wrapped.jsonValue
-    default:
-      fatalError(\\"Optional is only JSONEncodable if Wrapped is\\")
-    }
-  }
-}
-
-extension Dictionary: JSONEncodable {
-  public var jsonValue: Any {
-    return jsonObject
-  }
-  
-  public var jsonObject: JSONObject {
-    var jsonObject = JSONObject(minimumCapacity: count)
-    for (key, value) in self {
-      if case let (key as String, value as JSONEncodable) = (key, value) {
-        jsonObject[key] = value.jsonValue
-      } else {
-        fatalError(\\"Dictionary is only JSONEncodable if Value is (and if Key is String)\\")
-      }
-    }
-    return jsonObject
-  }
-}
-
-extension Array: JSONEncodable {
-  public var jsonValue: Any {
-    return map() { element -> (Any) in
-      if case let element as JSONEncodable = element {
-        return element.jsonValue
-      } else {
-        fatalError(\\"Array is only JSONEncodable if Element is\\")
-      }
-    }
-  }
-}
-
-extension URL: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let string = value as? String else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
-    }
-    self.init(string: string)!
-  }
-
-  public var jsonValue: Any {
-    return self.absoluteString
-  }
-}
-
-extension Dictionary {
-  static func += (lhs: inout Dictionary, rhs: Dictionary) {
-    lhs.merge(rhs) { (_, new) in new }
-  }
-}
-
-#elseif canImport(AWSAppSync)
-import AWSAppSync
-#endif",
 }
 `;
 
@@ -1733,7 +1733,7 @@ object GetBlogQuery extends com.apollographql.scalajs.GraphQLQuery {
 
 exports[`generateTypes targets basic swift 1`] = `
 Object {
-  "GraphQL request.swift": "//  This file was automatically generated and should not be edited.
+  "API.swift": "//  This file was automatically generated and should not be edited.
 
 #if canImport(AWSAPIPlugin)
 import Foundation
@@ -2312,429 +2312,6 @@ public final class GetBlogQuery: GraphQLQuery {
     }
   }
 }",
-  "Types.graphql.swift": "//  This file was automatically generated and should not be edited.
-
-#if canImport(AWSAPIPlugin)
-import Foundation
-
-public protocol GraphQLInputValue {
-}
-
-public struct GraphQLVariable {
-  let name: String
-  
-  public init(_ name: String) {
-    self.name = name
-  }
-}
-
-extension GraphQLVariable: GraphQLInputValue {
-}
-
-extension JSONEncodable {
-  public func evaluate(with variables: [String: JSONEncodable]?) throws -> Any {
-    return jsonValue
-  }
-}
-
-public typealias GraphQLMap = [String: JSONEncodable?]
-
-extension Dictionary where Key == String, Value == JSONEncodable? {
-  public var withNilValuesRemoved: Dictionary<String, JSONEncodable> {
-    var filtered = Dictionary<String, JSONEncodable>(minimumCapacity: count)
-    for (key, value) in self {
-      if value != nil {
-        filtered[key] = value
-      }
-    }
-    return filtered
-  }
-}
-
-public protocol GraphQLMapConvertible: JSONEncodable {
-  var graphQLMap: GraphQLMap { get }
-}
-
-public extension GraphQLMapConvertible {
-  var jsonValue: Any {
-    return graphQLMap.withNilValuesRemoved.jsonValue
-  }
-}
-
-public typealias GraphQLID = String
-
-public protocol APISwiftGraphQLOperation: AnyObject {
-  
-  static var operationString: String { get }
-  static var requestString: String { get }
-  static var operationIdentifier: String? { get }
-  
-  var variables: GraphQLMap? { get }
-  
-  associatedtype Data: GraphQLSelectionSet
-}
-
-public extension APISwiftGraphQLOperation {
-  static var requestString: String {
-    return operationString
-  }
-
-  static var operationIdentifier: String? {
-    return nil
-  }
-
-  var variables: GraphQLMap? {
-    return nil
-  }
-}
-
-public protocol GraphQLQuery: APISwiftGraphQLOperation {}
-
-public protocol GraphQLMutation: APISwiftGraphQLOperation {}
-
-public protocol GraphQLSubscription: APISwiftGraphQLOperation {}
-
-public protocol GraphQLFragment: GraphQLSelectionSet {
-  static var possibleTypes: [String] { get }
-}
-
-public typealias Snapshot = [String: Any?]
-
-public protocol GraphQLSelectionSet: Decodable {
-  static var selections: [GraphQLSelection] { get }
-  
-  var snapshot: Snapshot { get }
-  init(snapshot: Snapshot)
-}
-
-extension GraphQLSelectionSet {
-    public init(from decoder: Decoder) throws {
-        if let jsonObject = try? APISwiftJSONValue(from: decoder) {
-            let encoder = JSONEncoder()
-            let jsonData = try encoder.encode(jsonObject)
-            let decodedDictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
-            let optionalDictionary = decodedDictionary.mapValues { $0 as Any? }
-
-            self.init(snapshot: optionalDictionary)
-        } else {
-            self.init(snapshot: [:])
-        }
-    }
-}
-
-enum APISwiftJSONValue: Codable {
-    case array([APISwiftJSONValue])
-    case boolean(Bool)
-    case number(Double)
-    case object([String: APISwiftJSONValue])
-    case string(String)
-    case null
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        
-        if let value = try? container.decode([String: APISwiftJSONValue].self) {
-            self = .object(value)
-        } else if let value = try? container.decode([APISwiftJSONValue].self) {
-            self = .array(value)
-        } else if let value = try? container.decode(Double.self) {
-            self = .number(value)
-        } else if let value = try? container.decode(Bool.self) {
-            self = .boolean(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else {
-            self = .null
-        }
-    }
-    
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        
-        switch self {
-        case .array(let value):
-            try container.encode(value)
-        case .boolean(let value):
-            try container.encode(value)
-        case .number(let value):
-            try container.encode(value)
-        case .object(let value):
-            try container.encode(value)
-        case .string(let value):
-            try container.encode(value)
-        case .null:
-            try container.encodeNil()
-        }
-    }
-}
-
-public protocol GraphQLSelection {
-}
-
-public struct GraphQLField: GraphQLSelection {
-  let name: String
-  let alias: String?
-  let arguments: [String: GraphQLInputValue]?
-  
-  var responseKey: String {
-    return alias ?? name
-  }
-  
-  let type: GraphQLOutputType
-  
-  public init(_ name: String, alias: String? = nil, arguments: [String: GraphQLInputValue]? = nil, type: GraphQLOutputType) {
-    self.name = name
-    self.alias = alias
-    
-    self.arguments = arguments
-    
-    self.type = type
-  }
-}
-
-public indirect enum GraphQLOutputType {
-  case scalar(JSONDecodable.Type)
-  case object([GraphQLSelection])
-  case nonNull(GraphQLOutputType)
-  case list(GraphQLOutputType)
-  
-  var namedType: GraphQLOutputType {
-    switch self {
-    case .nonNull(let innerType), .list(let innerType):
-      return innerType.namedType
-    case .scalar, .object:
-      return self
-    }
-  }
-}
-
-public struct GraphQLBooleanCondition: GraphQLSelection {
-  let variableName: String
-  let inverted: Bool
-  let selections: [GraphQLSelection]
-  
-  public init(variableName: String, inverted: Bool, selections: [GraphQLSelection]) {
-    self.variableName = variableName
-    self.inverted = inverted;
-    self.selections = selections;
-  }
-}
-
-public struct GraphQLTypeCondition: GraphQLSelection {
-  let possibleTypes: [String]
-  let selections: [GraphQLSelection]
-  
-  public init(possibleTypes: [String], selections: [GraphQLSelection]) {
-    self.possibleTypes = possibleTypes
-    self.selections = selections;
-  }
-}
-
-public struct GraphQLFragmentSpread: GraphQLSelection {
-  let fragment: GraphQLFragment.Type
-  
-  public init(_ fragment: GraphQLFragment.Type) {
-    self.fragment = fragment
-  }
-}
-
-public struct GraphQLTypeCase: GraphQLSelection {
-  let variants: [String: [GraphQLSelection]]
-  let \`default\`: [GraphQLSelection]
-  
-  public init(variants: [String: [GraphQLSelection]], default: [GraphQLSelection]) {
-    self.variants = variants
-    self.default = \`default\`;
-  }
-}
-
-public typealias JSONObject = [String: Any]
-
-public protocol JSONDecodable {
-  init(jsonValue value: Any) throws
-}
-
-public protocol JSONEncodable: GraphQLInputValue {
-  var jsonValue: Any { get }
-}
-
-public enum JSONDecodingError: Error, LocalizedError {
-  case missingValue
-  case nullValue
-  case wrongType
-  case couldNotConvert(value: Any, to: Any.Type)
-  
-  public var errorDescription: String? {
-    switch self {
-    case .missingValue:
-      return \\"Missing value\\"
-    case .nullValue:
-      return \\"Unexpected null value\\"
-    case .wrongType:
-      return \\"Wrong type\\"
-    case .couldNotConvert(let value, let expectedType):
-      return \\"Could not convert \\\\\\"\\\\(value)\\\\\\" to \\\\(expectedType)\\"
-    }
-  }
-}
-
-extension String: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let string = value as? String else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: String.self)
-    }
-    self = string
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Int: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Int.self)
-    }
-    self = number.intValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Float: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Float.self)
-    }
-    self = number.floatValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Double: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let number = value as? NSNumber else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Double.self)
-    }
-    self = number.doubleValue
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension Bool: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let bool = value as? Bool else {
-        throw JSONDecodingError.couldNotConvert(value: value, to: Bool.self)
-    }
-    self = bool
-  }
-
-  public var jsonValue: Any {
-    return self
-  }
-}
-
-extension RawRepresentable where RawValue: JSONDecodable {
-  public init(jsonValue value: Any) throws {
-    let rawValue = try RawValue(jsonValue: value)
-    if let tempSelf = Self(rawValue: rawValue) {
-      self = tempSelf
-    } else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: Self.self)
-    }
-  }
-}
-
-extension RawRepresentable where RawValue: JSONEncodable {
-  public var jsonValue: Any {
-    return rawValue.jsonValue
-  }
-}
-
-extension Optional where Wrapped: JSONDecodable {
-  public init(jsonValue value: Any) throws {
-    if value is NSNull {
-      self = .none
-    } else {
-      self = .some(try Wrapped(jsonValue: value))
-    }
-  }
-}
-
-extension Optional: JSONEncodable {
-  public var jsonValue: Any {
-    switch self {
-    case .none:
-      return NSNull()
-    case .some(let wrapped as JSONEncodable):
-      return wrapped.jsonValue
-    default:
-      fatalError(\\"Optional is only JSONEncodable if Wrapped is\\")
-    }
-  }
-}
-
-extension Dictionary: JSONEncodable {
-  public var jsonValue: Any {
-    return jsonObject
-  }
-  
-  public var jsonObject: JSONObject {
-    var jsonObject = JSONObject(minimumCapacity: count)
-    for (key, value) in self {
-      if case let (key as String, value as JSONEncodable) = (key, value) {
-        jsonObject[key] = value.jsonValue
-      } else {
-        fatalError(\\"Dictionary is only JSONEncodable if Value is (and if Key is String)\\")
-      }
-    }
-    return jsonObject
-  }
-}
-
-extension Array: JSONEncodable {
-  public var jsonValue: Any {
-    return map() { element -> (Any) in
-      if case let element as JSONEncodable = element {
-        return element.jsonValue
-      } else {
-        fatalError(\\"Array is only JSONEncodable if Element is\\")
-      }
-    }
-  }
-}
-
-extension URL: JSONDecodable, JSONEncodable {
-  public init(jsonValue value: Any) throws {
-    guard let string = value as? String else {
-      throw JSONDecodingError.couldNotConvert(value: value, to: URL.self)
-    }
-    self.init(string: string)!
-  }
-
-  public var jsonValue: Any {
-    return self.absoluteString
-  }
-}
-
-extension Dictionary {
-  static func += (lhs: inout Dictionary, rhs: Dictionary) {
-    lhs.merge(rhs) { (_, new) in new }
-  }
-}
-
-#elseif canImport(AWSAppSync)
-import AWSAppSync
-#endif",
 }
 `;
 

--- a/packages/graphql-generator/src/__tests__/types.test.ts
+++ b/packages/graphql-generator/src/__tests__/types.test.ts
@@ -1,3 +1,4 @@
+import { Source } from 'graphql';
 import { generateTypes, GenerateTypesOptions, TypesTarget } from '..';
 import { readSchema } from './utils';
 
@@ -37,15 +38,31 @@ describe('generateTypes', () => {
     });
   });
 
-  test('multipleSwiftFiles', async () => {
-    const options: GenerateTypesOptions = {
-      schema: sdlSchema,
-      queries,
-      target: 'swift',
-      multipleSwiftFiles: true,
-    };
+  describe('multipleSwiftFiles', () => {
+    test('generates multiple files', async () => {
+      const filename = 'queries.graphql';
+      const options: GenerateTypesOptions = {
+        schema: sdlSchema,
+        queries: [new Source(queries, filename)],
+        target: 'swift',
+        multipleSwiftFiles: true,
+      };
 
-    const types = await generateTypes(options);
-    expect(types).toMatchSnapshot();
+      const types = await generateTypes(options);
+      expect(Object.keys(types)).toEqual(['Types.graphql.swift', `${filename}.swift`]);
+      expect(types).toMatchSnapshot();
+    });
+
+    test('throws error if not using Source', async () => {
+      const filename = 'queries.graphql';
+      const options: GenerateTypesOptions = {
+        schema: sdlSchema,
+        queries: queries,
+        target: 'swift',
+        multipleSwiftFiles: true,
+      };
+
+      expect(generateTypes(options)).rejects.toThrow('Query documents must be of type Source[] when generating multiple Swift files.');
+    });
   });
 });

--- a/packages/graphql-generator/src/types.ts
+++ b/packages/graphql-generator/src/types.ts
@@ -3,7 +3,7 @@ import { generate, generateFromString } from '@aws-amplify/graphql-types-generat
 import { GenerateTypesOptions, GeneratedOutput } from './typescript';
 
 export async function generateTypes(options: GenerateTypesOptions): Promise<GeneratedOutput> {
-  const { schema, target, queries, multipleSwiftFiles = true, introspection = false } = options;
+  const { schema, target, queries, multipleSwiftFiles = false, introspection = false } = options;
 
   const generatedOutput = await generateFromString(schema, introspection, queries, target, multipleSwiftFiles, {
     addTypename: true,

--- a/packages/graphql-generator/src/typescript.ts
+++ b/packages/graphql-generator/src/typescript.ts
@@ -1,3 +1,4 @@
+import { Source } from 'graphql';
 import { Target as GraphqlTypesGeneratorTarget } from '@aws-amplify/graphql-types-generator';
 import { Target as AppsyncModelgenPluginTarget } from '@aws-amplify/appsync-modelgen-plugin';
 
@@ -10,7 +11,7 @@ export type FileExtension = 'js' | 'graphql' | 'ts';
 export type GenerateTypesOptions = {
   schema: string;
   target: TypesTarget;
-  queries: string;
+  queries: string | Source[];
   introspection?: boolean;
   multipleSwiftFiles?: boolean; // only used when target is swift
 };

--- a/packages/graphql-types-generator/API.md
+++ b/packages/graphql-types-generator/API.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { Source } from 'graphql';
+
 // @public (undocumented)
 export function extractDocumentFromJavascript(content: string, tagName?: string): string | null;
 
@@ -11,7 +13,7 @@ export function extractDocumentFromJavascript(content: string, tagName?: string)
 export function generate(inputPaths: string[], schemaPath: string, outputPath: string, only: string, target: Target, tagName: string, options: any): void;
 
 // @public (undocumented)
-export function generateFromString(schema: string, introspection: boolean, queryDocuments: string, target: Target, multipleSwiftFiles: boolean, options: any): {
+export function generateFromString(schema: string, introspection: boolean, queryDocuments: string | Source[], target: Target, multipleSwiftFiles: boolean, options: any): {
     [filepath: string]: string;
 };
 

--- a/packages/graphql-types-generator/src/generate.ts
+++ b/packages/graphql-types-generator/src/generate.ts
@@ -84,13 +84,17 @@ function generateFromFile(
 export function generateFromString(
   schema: string,
   introspection: boolean,
-  queryDocuments: string,
+  queryDocuments: string | Source[],
   target: Target,
   multipleSwiftFiles: boolean,
   options: any,
 ): { [filepath: string]: string } {
+  if (typeof queryDocuments === 'string' && multipleSwiftFiles) {
+    throw new Error('Query documents must be of type Source[] when generating multiple Swift files.');
+  }
   const graphqlSchema = parseSchema(schema, introspection);
-  const document = parseAndMergeQueryDocuments([new Source(queryDocuments)]);
+  const queryDocumentSources = typeof queryDocuments === 'string' ? [new Source(queryDocuments)] : queryDocuments;
+  const document = parseAndMergeQueryDocuments(queryDocumentSources);
   validateQueryDocument(graphqlSchema, document);
   const output = generateForTarget(graphqlSchema, document, '', target, multipleSwiftFiles, options);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Generate multiple Swift type files. The separate files are for each GraphQL statement file. The multiple type files need the names of the GraphQL statements files in order to generate with the correct names.

This leaves us a few options for the queries arg.
1. `[fileContents: string, filename: string][]`
2. `Source[]` (from `graphql` package).
3. Type union of the current type (string) and one of the two above options.

I chose `string | Source[]` for this PR, but I don't have strong feelings on the end direction.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-codegen/issues/711

#### Description of how you validated changes

* Unit tests
* Manual tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.