### PR TITLE
fix: replace windows path separator with posix

### DIFF
--- a/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
+++ b/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
@@ -2,7 +2,10 @@ const path = require('path');
 
 function getRelativeTypesPath(opsGenDirectory, generatedFileName) {
   if (generatedFileName) {
-    const relativePath = path.relative(opsGenDirectory, generatedFileName);
+    const relativePath = path
+      .relative(opsGenDirectory, generatedFileName)
+      .split(path.sep)
+      .join(path.posix.sep);
 
     // generatedFileName is in same directory as opsGenDirectory
     // i.e. generatedFileName: src/graphql/API.ts, opsGenDirectory: src/graphql


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

See https://github.com/aws-amplify/amplify-cli/issues/13289 for details. `path.relative` behaves differently on windows. https://nodejs.org/api/path.html#pathrelativefrom-to

This results in the generated path being invalid syntax in TypeScript/JavaScript.

This change replaces the current OS environment path separator (`path.sep`) with the posix path separator (`path.posix.sep`).


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/13289


#### Description of how you validated changes

Nothing yet 😬 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.