### PR TITLE
fix: ensure posix path sep is used

### DIFF
--- a/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
+++ b/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
@@ -2,7 +2,10 @@ const path = require('path');
 
 function getRelativeTypesPath(opsGenDirectory, generatedFileName) {
   if (generatedFileName) {
-    const relativePath = path.relative(opsGenDirectory, generatedFileName);
+    const relativePath = path
+      .relative(opsGenDirectory, generatedFileName)
+      .split(path.sep)
+      .join(path.posix.sep);
 
     // generatedFileName is in same directory as opsGenDirectory
     // i.e. generatedFileName: src/graphql/API.ts, opsGenDirectory: src/graphql

--- a/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
+++ b/packages/amplify-codegen/src/utils/getRelativeTypesPath.js
@@ -4,7 +4,8 @@ function getRelativeTypesPath(opsGenDirectory, generatedFileName) {
   if (generatedFileName) {
     const relativePath = path
       .relative(opsGenDirectory, generatedFileName)
-      .split(path.sep)
+      // ensure posix path separators are used
+      .split(path.win32.sep)
       .join(path.posix.sep);
 
     // generatedFileName is in same directory as opsGenDirectory

--- a/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
+++ b/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
@@ -26,8 +26,13 @@ describe('GraphQL statements Formatter', () => {
     expect(formattedOutput).toMatchSnapshot();
   });
 
-  it('Generates formatted output for TS frontend', () => {
+  it('Generates formatted output for TS frontend with posix path', () => {
     const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '../API.ts').format(statements);
+    expect(formattedOutput).toMatchSnapshot();
+  });
+
+  it('Generates formatted output for TS frontend with windows path', () => {
+    const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '..\\API.ts').format(statements);
     expect(formattedOutput).toMatchSnapshot();
   });
 

--- a/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
@@ -62,7 +62,33 @@ export const getProject = /* GraphQL */ \`
 "
 `;
 
-exports[`GraphQL statements Formatter Generates formatted output for TS frontend 1`] = `
+exports[`GraphQL statements Formatter Generates formatted output for TS frontend with posix path 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+import * as APITypes from \\"../API\\";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
+  getProject(id: $id) {
+    id
+    name
+    createdAt
+    updatedAt
+  }
+}
+\` as GeneratedQuery<
+  APITypes.GetProjectQueryVariables,
+  APITypes.GetProjectQuery
+>;
+"
+`;
+
+exports[`GraphQL statements Formatter Generates formatted output for TS frontend with windows path 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten

--- a/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
+++ b/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import prettier, { BuiltInParserName } from 'prettier';
 import {
   interfaceNameFromOperation,
@@ -34,7 +35,12 @@ export class GraphQLStatementsFormatter {
     }[operation];
     this.lintOverrides = [];
     this.headerComments = [];
-    this.typesPath = typesPath ? typesPath.replace(/.ts/i, '') : null;
+    this.typesPath = typesPath
+      ? typesPath.replace(/.ts/i, '')
+        // ensure posix path separators are used
+        .split(path.win32.sep)
+        .join(path.posix.sep)
+      : null;
     this.includeTypeScriptTypes = !!(this.language === 'typescript' && this.opTypeName && this.typesPath);
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Alternative to https://github.com/aws-amplify/amplify-codegen/pull/727

See https://github.com/aws-amplify/amplify-cli/issues/13289 for details. `path.relative` behaves differently on windows. https://nodejs.org/api/path.html#pathrelativefrom-to

This results in the generated path being invalid syntax in TypeScript/JavaScript.

This change replaces the windows path separator (`path.win32.sep`) with the posix path separator (`path.posix.sep`).


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-cli/issues/13289

#### Description of how you validated changes

* Unit tests
* Need to test on window machine

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.