### PR TITLE
chore: generate empty types so v6 js types work

### DIFF
--- a/packages/graphql-types-generator/src/typescript/codeGeneration.ts
+++ b/packages/graphql-types-generator/src/typescript/codeGeneration.ts
@@ -173,9 +173,6 @@ export function interfaceVariablesDeclarationForOperation(
   generator: CodeGenerator,
   { operationName, operationType, variables }: LegacyOperation,
 ) {
-  if (!variables || variables.length < 1) {
-    return;
-  }
   const interfaceName = interfaceVariablesNameFromOperation({operationName, operationType});
 
   interfaceDeclaration(
@@ -184,7 +181,7 @@ export function interfaceVariablesDeclarationForOperation(
       interfaceName,
     },
     () => {
-      const properties = propertiesFromFields(generator.context, variables);
+      const properties = propertiesFromFields(generator.context, variables ?? []);
       pickedPropertyDeclarations(generator, properties);
     },
   );

--- a/packages/graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
+++ b/packages/graphql-types-generator/test/typescript/__snapshots__/codeGeneration.js.snap
@@ -258,6 +258,9 @@ export type Droid = {
   primaryFunction?: string | null,
 };
 
+export type HeroAndFriendsNamesQueryVariables = {
+};
+
 export type HeroAndFriendsNamesQuery = {
   hero: ( {
       __typename: \\"Human\\",
@@ -480,6 +483,9 @@ export type Droid = {
   primaryFunction?: string | null,
 };
 
+export type HeroAndDetailsQueryVariables = {
+};
+
 export type HeroAndDetailsQuery = {
   hero: ( {
       __typename: \\"Human\\",
@@ -670,6 +676,9 @@ export type Starship = {
   coordinates?: Array< Array< number > > | null,
 };
 
+export type StarshipCoordsQueryVariables = {
+};
+
 export type StarshipCoordsQuery = {
   starship?:  {
     __typename: \\"Starship\\",
@@ -780,6 +789,9 @@ export type Droid = {
   appearsIn: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
+};
+
+export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = {
@@ -942,6 +954,9 @@ export enum EnumCommentTestCase {
 }
 
 
+export type CustomScalarQueryVariables = {
+};
+
 export type CustomScalarQuery = {
   commentTest?:  {
     __typename: \\"CommentTest\\",
@@ -971,6 +986,9 @@ export type ImplB = {
   __typename: \\"ImplB\\",
   prop: string,
   propB?: number | null,
+};
+
+export type CustomScalarQueryVariables = {
 };
 
 export type CustomScalarQuery = {
@@ -1011,6 +1029,9 @@ export enum EnumCommentTestCase {
 }
 
 
+export type CustomScalarQueryVariables = {
+};
+
 export type CustomScalarQuery = {
   commentTest?:  {
     __typename: \\"CommentTest\\",
@@ -1045,6 +1066,9 @@ export enum EnumCommentTestCase {
 }
 
 
+export type CustomScalarQueryVariables = {
+};
+
 export type CustomScalarQuery = {
   commentTest?:  {
     __typename: \\"CommentTest\\",
@@ -1071,6 +1095,9 @@ export type PartialA = {
 export type PartialB = {
   __typename: \\"PartialB\\",
   prop: string,
+};
+
+export type CustomScalarQueryVariables = {
 };
 
 export type CustomScalarQuery = {
@@ -1187,6 +1214,9 @@ export type Droid = {
   appearsIn: Array< Episode | null >,
   // This droid's primary function
   primaryFunction?: string | null,
+};
+
+export type HeroNameQueryVariables = {
 };
 
 export type HeroNameQuery = {
@@ -1316,6 +1346,9 @@ export type Starship = {
   // Length of the starship, along the longest axis
   length?: number | null,
   coordinates?: Array< Array< number > > | null,
+};
+
+export type DroidNameQueryVariables = {
 };
 
 export type DroidNameQuery = {


### PR DESCRIPTION
#### Description of changes
With the v6 JS library, we now add metadata to queries which reference generated types.

I'm not sure I like this approach, since it generates unnecessary types (instead of just inlining an empty object in the `mutations/subscriptions/queries` files).

#### Issue #, if available
https://github.com/aws-amplify/amplify-codegen/issues/736

#### Description of how you validated changes
Unit tests, need to validate in a test app, and run e2e's.

#### Checklist
- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Relevant documentation is changed or added (and PR referenced)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.