### PR TITLE
fix: skip bad statement source on type generation and exclude type file

### DIFF
--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -62,18 +62,27 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
           cwd: projectPath,
           absolute: true,
         });
-        const queries = queryFilePaths.map(queryFilePath => {
-          const fileContents = fs.readFileSync(queryFilePath, 'utf8');
-          if (
-            queryFilePath.endsWith('.jsx') ||
-            queryFilePath.endsWith('.js') ||
-            queryFilePath.endsWith('.tsx') ||
-            queryFilePath.endsWith('.ts')
-          ) {
-            return extractDocumentFromJavascript(fileContents, '');
-          }
-          return new Source(fileContents, queryFilePath);
-        });
+        const queries = queryFilePaths
+          .map(queryFilePath => {
+            const fileContents = fs.readFileSync(queryFilePath, 'utf8');
+            if (
+              queryFilePath.endsWith('.jsx') ||
+              queryFilePath.endsWith('.js') ||
+              queryFilePath.endsWith('.tsx') ||
+              queryFilePath.endsWith('.ts')
+            ) {
+              return [queryFilePath, extractDocumentFromJavascript(fileContents, '')];
+            }
+            return [queryFilePath, new Source(fileContents, queryFilePath)];
+          })
+          .filter(([queryFilePath, source]) => {
+            if (!source) {
+              context.print.warning(`Unable to extract GraphQL queries from ${queryFilePath}. Skipping source.`);
+              return false;
+            }
+            return true;
+          })
+          .map(([, source]) => source);
         if (queries.length === 0) {
           throw new Error("No queries found to generate types for, you may need to run 'codegen statements' first");
         }

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -62,7 +62,6 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
           cwd: projectPath,
           absolute: true,
         });
-        console.log(generatedFileName);
         const queries = queryFilePaths
           .map(queryFilePath => {
             const fileContents = fs.readFileSync(queryFilePath, 'utf8');

--- a/packages/amplify-codegen/src/commands/types.js
+++ b/packages/amplify-codegen/src/commands/types.js
@@ -58,10 +58,11 @@ async function generateTypes(context, forceDownloadSchema, withoutInit = false, 
         const target = cfg.amplifyExtension.codeGenTarget;
 
         const excludes = cfg.excludes.map(pattern => `!${pattern}`);
-        const queryFilePaths = glob.sync([...includeFiles, ...excludes], {
+        const queryFilePaths = glob.sync([...includeFiles, ...excludes, `!${generatedFileName}`], {
           cwd: projectPath,
           absolute: true,
         });
+        console.log(generatedFileName);
         const queries = queryFilePaths
           .map(queryFilePath => {
             const fileContents = fs.readFileSync(queryFilePath, 'utf8');

--- a/packages/amplify-codegen/tests/commands/types.test.js
+++ b/packages/amplify-codegen/tests/commands/types.test.js
@@ -80,7 +80,10 @@ describe('command - types', () => {
     await generateTypes(MOCK_CONTEXT, forceDownload);
     expect(getFrontEndHandler).toHaveBeenCalledWith(MOCK_CONTEXT);
     expect(loadConfig).toHaveBeenCalledWith(MOCK_CONTEXT, false);
-    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`], { cwd: MOCK_PROJECT_ROOT, absolute: true });
+    expect(sync).toHaveBeenCalledWith([MOCK_INCLUDE_PATH, `!${MOCK_EXCLUDE_PATH}`, `!${MOCK_GENERATED_FILE_NAME}`], {
+      cwd: MOCK_PROJECT_ROOT,
+      absolute: true,
+    });
     expect(generateTypesHelper).toHaveBeenCalledWith({
       queries: [new Source('query 1', 'q1.gql'), new Source('query 2', 'q2.gql')],
       schema: 'schema',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Skip bad statement source on type generation. If the GraphQL source is `null` remove it from the sources.
* Automatically exclude the generated type file.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves: https://github.com/aws-amplify/amplify-codegen/issues/734

#### Description of how you validated changes

* Unit testing
* Manual testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.