### PR TITLE
fix: correctly remove file extension on types import path

### DIFF
--- a/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
+++ b/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
@@ -36,6 +36,11 @@ describe('GraphQL statements Formatter', () => {
     expect(formattedOutput).toMatchSnapshot();
   });
 
+  it('Generates formatted output and only remove file extension', () => {
+    const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '../Components/Data/API.tsx').format(statements);
+    expect(formattedOutput).toMatchSnapshot();
+  });
+
   it('Generates formatted output for Flow frontend', () => {
     const formattedOutput = new GraphQLStatementsFormatter('flow').format(statements);
     expect(formattedOutput).toMatchSnapshot();

--- a/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
+++ b/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
@@ -36,6 +36,16 @@ describe('GraphQL statements Formatter', () => {
     expect(formattedOutput).toMatchSnapshot();
   });
 
+  it('Generates formatted output for TS frontend with posix path in same dir', () => {
+    const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', './API.ts').format(statements);
+    expect(formattedOutput).toMatchSnapshot();
+  });
+
+  it('Generates formatted output for TS frontend with windows path in same dir', () => {
+    const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '.\\API.ts').format(statements);
+    expect(formattedOutput).toMatchSnapshot();
+  });
+
   it('Generates formatted output and only remove file extension', () => {
     const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '../Components/Data/API.tsx').format(statements);
     expect(formattedOutput).toMatchSnapshot();

--- a/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
@@ -114,12 +114,64 @@ export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
 "
 `;
 
+exports[`GraphQL statements Formatter Generates formatted output for TS frontend with posix path in same dir 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+import * as APITypes from \\"./API\\";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
+  getProject(id: $id) {
+    id
+    name
+    createdAt
+    updatedAt
+  }
+}
+\` as GeneratedQuery<
+  APITypes.GetProjectQueryVariables,
+  APITypes.GetProjectQuery
+>;
+"
+`;
+
 exports[`GraphQL statements Formatter Generates formatted output for TS frontend with windows path 1`] = `
 "/* tslint:disable */
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
 import * as APITypes from \\"../API\\";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
+  getProject(id: $id) {
+    id
+    name
+    createdAt
+    updatedAt
+  }
+}
+\` as GeneratedQuery<
+  APITypes.GetProjectQueryVariables,
+  APITypes.GetProjectQuery
+>;
+"
+`;
+
+exports[`GraphQL statements Formatter Generates formatted output for TS frontend with windows path in same dir 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+import * as APITypes from \\"./API\\";
 type GeneratedQuery<InputType, OutputType> = string & {
   __generatedQueryInput: InputType;
   __generatedQueryOutput: OutputType;

--- a/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GraphQL statements Formatter Generates formatted output and only remove file extension 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+import * as APITypes from \\"../Components/Data/API\\";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
+  getProject(id: $id) {
+    id
+    name
+    createdAt
+    updatedAt
+  }
+}
+\` as GeneratedQuery<
+  APITypes.GetProjectQueryVariables,
+  APITypes.GetProjectQuery
+>;
+"
+`;
+
 exports[`GraphQL statements Formatter Generates formatted output for Angular frontend 1`] = `
 "# this is an auto generated file. This will be overwritten
 

--- a/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
+++ b/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
@@ -36,7 +36,7 @@ export class GraphQLStatementsFormatter {
     this.lintOverrides = [];
     this.headerComments = [];
     this.typesPath = typesPath
-      ? typesPath.replace(/.ts/i, '')
+      ? typesPath.replace(/\.[^.]+$/, '') // remove file extensions
         // ensure posix path separators are used
         .split(path.win32.sep)
         .join(path.posix.sep)

--- a/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
+++ b/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
@@ -35,12 +35,20 @@ export class GraphQLStatementsFormatter {
     }[operation];
     this.lintOverrides = [];
     this.headerComments = [];
-    this.typesPath = typesPath
-      ? typesPath.replace(/\.[^.]+$/, '') // remove file extensions
-        // ensure posix path separators are used
-        .split(path.win32.sep)
-        .join(path.posix.sep)
-      : null;
+    if (typesPath) {
+      // ensure posix path separators are used
+      const typesPathWithPosixSep = typesPath.split(path.win32.sep).join(path.posix.sep)
+      const { dir, name } = path.parse(typesPathWithPosixSep);
+      const typesPathWithoutExtension = path.join(dir, name);
+      if (!typesPathWithoutExtension.startsWith('.')) {
+        // path.join will strip prefixed ./
+        this.typesPath = `./${typesPathWithoutExtension}`;
+      } else {
+        this.typesPath = typesPathWithoutExtension;
+      }
+    } else {
+      this.typesPath = null;
+    }
     this.includeTypeScriptTypes = !!(this.language === 'typescript' && this.opTypeName && this.typesPath);
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Correctly remove file extensions on types import path. See https://github.com/aws-amplify/amplify-codegen/issues/741 for details.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

Resolves: https://github.com/aws-amplify/amplify-codegen/issues/741

#### Description of how you validated changes

* Unit testing

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.