### PR TITLE
fix: use correct path separators on windows environment (again)

### DIFF
--- a/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
+++ b/packages/graphql-generator/src/__tests__/utils/GraphQLStatementsFormatter.test.ts
@@ -1,4 +1,10 @@
+import * as path from 'path';
 import { GraphQLStatementsFormatter } from '../../utils';
+
+jest.mock('path', () => ({
+  ...jest.requireActual('path'),
+  join: jest.fn(jest.requireActual('path').join),
+}));
 
 describe('GraphQL statements Formatter', () => {
   const statements = new Map();
@@ -43,6 +49,13 @@ describe('GraphQL statements Formatter', () => {
 
   it('Generates formatted output for TS frontend with windows path in same dir', () => {
     const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '.\\API.ts').format(statements);
+    expect(formattedOutput).toMatchSnapshot();
+  });
+
+  // simulate windows path.join functionality until tests are run on windows
+  it('Generates formatted output for TS frontend with windows simulated', () => {
+    path.join.mockReturnValueOnce('..\\types\\API.ts');
+    const formattedOutput = new GraphQLStatementsFormatter('typescript', 'queries', '../types/API.ts').format(statements);
     expect(formattedOutput).toMatchSnapshot();
   });
 

--- a/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/utils/__snapshots__/GraphQLStatementsFormatter.test.ts.snap
@@ -191,3 +191,29 @@ export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
 >;
 "
 `;
+
+exports[`GraphQL statements Formatter Generates formatted output for TS frontend with windows simulated 1`] = `
+"/* tslint:disable */
+/* eslint-disable */
+// this is an auto generated file. This will be overwritten
+
+import * as APITypes from \\"../types/API.ts\\";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getProject = /* GraphQL */ \`query GetProject($id: ID!) {
+  getProject(id: $id) {
+    id
+    name
+    createdAt
+    updatedAt
+  }
+}
+\` as GeneratedQuery<
+  APITypes.GetProjectQueryVariables,
+  APITypes.GetProjectQuery
+>;
+"
+`;

--- a/packages/graphql-generator/src/models.ts
+++ b/packages/graphql-generator/src/models.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { parse } from 'graphql';
 import * as appSyncDataStoreCodeGen from '@aws-amplify/appsync-modelgen-plugin';
 import { codegen } from '@graphql-codegen/core';
@@ -61,7 +62,7 @@ export async function generateModels(options: GenerateModelsOptions): Promise<Ge
   return Promise.all(
     appsyncLocalConfig.map(async config => {
       const content = await codegen(config);
-      return { [config.filename]: content };
+      return { [config.filename.split(path.win32.sep).join(path.posix.sep)]: content };
     }),
   ).then((outputs: GeneratedOutput[]) => outputs.reduce((curr, next) => ({ ...curr, ...next }), {}));
 }

--- a/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
+++ b/packages/graphql-generator/src/utils/GraphQLStatementsFormatter.ts
@@ -36,10 +36,9 @@ export class GraphQLStatementsFormatter {
     this.lintOverrides = [];
     this.headerComments = [];
     if (typesPath) {
+      const { dir, name } = path.parse(typesPath);
       // ensure posix path separators are used
-      const typesPathWithPosixSep = typesPath.split(path.win32.sep).join(path.posix.sep)
-      const { dir, name } = path.parse(typesPathWithPosixSep);
-      const typesPathWithoutExtension = path.join(dir, name);
+      const typesPathWithoutExtension = path.join(dir, name).split(path.win32.sep).join(path.posix.sep);
       if (!typesPathWithoutExtension.startsWith('.')) {
         // path.join will strip prefixed ./
         this.typesPath = `./${typesPathWithoutExtension}`;


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

https://github.com/aws-amplify/amplify-codegen/pull/742 reintroduced the windows path bug. Fortunately, this change has not been released yet.

The `path.join` was called after the path separators are changed resulting in the windows path separators returning.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-codegen/issues/741

#### Description of how you validated changes

* Added a simulated windows unit test.

I found these changes by getting the unit tests to run on windows on CI. https://github.com/aws-amplify/amplify-codegen/pull/743. The PR is not ready to be merged yet, but we can hold off releasing until that is in.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.