### PR TITLE
Fix: many to many auth

### DIFF
--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -909,12 +909,12 @@ export class AppSyncModelVisitor<
       );
 
       const extractedAuthDirectives = [...value[0].model.directives, ...value[1].model.directives]
-      .filter(directive => directive.name === 'auth');
+        .filter(directive => directive.name === 'auth');
 
       const serializedDirectives = extractedAuthDirectives.map(directive => JSON.stringify(directive));
 
       const uniqueSerializedDirectives = serializedDirectives.filter((serializedDirective, index, array) =>
-      array.indexOf(serializedDirective) === index
+        array.indexOf(serializedDirective) === index
       );
 
       const authDirectives = uniqueSerializedDirectives.map(serializedDirective => JSON.parse(serializedDirective));

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -907,6 +907,20 @@ export class AppSyncModelVisitor<
         value[1].model,
         graphqlName(toUpper(value[0].directive.arguments.relationName)),
       );
+
+      const extractedAuthDirectives = [...value[0].model.directives, ...value[1].model.directives]
+      .filter(directive => directive.name === 'auth');
+
+      const serializedDirectives = extractedAuthDirectives.map(directive => JSON.stringify(directive));
+
+      const uniqueSerializedDirectives = serializedDirectives.filter((serializedDirective, index, array) =>
+      array.indexOf(serializedDirective) === index
+      );
+
+      const authDirectives = uniqueSerializedDirectives.map(serializedDirective => JSON.parse(serializedDirective));
+
+      intermediateModel.directives = [...intermediateModel.directives, ...authDirectives];
+
       const modelDirective = intermediateModel.directives.find(directive => directive.name === 'model');
       if (modelDirective) {
         // Maps @primaryKey and @index of intermediate model to old @key


### PR DESCRIPTION
#### Description of changes
This PR addresses the omission of `@auth` directive attributes in the generated schema for `@manyToMany` relations, specifically impacting how Datastore performs calls to the joint tables. By ensuring accurate propagation and merging of the `@auth` directives and their rules to the joint table model, this PR facilitates correct authorization information being available for Datastore operations on the joint tables.


#### Issue #
https://github.com/aws-amplify/amplify-codegen/issues/473



#### Description of how you validated changes
- Unit tests
- Test in sample app using amplify-dev


#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.