### PR TITLE
fix: add codegen for non-ios frontends; updated e2e test for iOS frontend

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/utils/graphql-config-helper.ts
+++ b/packages/amplify-codegen-e2e-core/src/utils/graphql-config-helper.ts
@@ -35,6 +35,7 @@ export function constructGraphQLConfig(
         extensions.amplify.codeGenTarget = 'swift';
         extensions.amplify.docsFilePath = 'graphql';
         extensions.amplify.generatedFileName = 'API.swift';
+        excludes.push('API.swift');
         break;
       default:
         schemaPath = `amplify/backend/api/${projectName}/build/schema.graphql`;

--- a/packages/amplify-codegen/src/commands/add.js
+++ b/packages/amplify-codegen/src/commands/add.js
@@ -133,7 +133,7 @@ async function add(context, apiId = null, region = 'us-east-1') {
   const newProject = {
     projectName: withoutInit ? 'Codegen Project' : apiDetails.name,
     includes: answer.includePattern,
-    excludes: [...answer.excludePattern, answer.generatedFileName],
+    excludes: [...answer.excludePattern, answer.generatedFileName]?.filter(item => item),
     // Set schema path to use posix separators. Node can handle windows and posix separators regradless of platform
     // Ensures all paths in .graphlqconfig.yml use posix style
     schema: schema.split(path.win32.sep).join(path.posix.sep),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- For non-iOS frontends, the excludes is having an `undefined` value which is eventually failing the `add codegen` workflow. This filters any such values before setting them.
- Updated expected addition to `excludes` entry for iOS e2e tests.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
E2Es now pass post fixes


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.