### PR TITLE
feat(introspection): add metadata for custom GraphQL operations

### DIFF
--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -26,6 +26,18 @@ export interface AppSyncModelPluginConfig extends RawDocumentsConfig {
 }
 
 // @public (undocumented)
+export type Argument = {
+    name: string;
+    type: FieldType;
+    isArray: boolean;
+    isRequired: boolean;
+    isArrayNullable?: boolean;
+};
+
+// @public (undocumented)
+export type Arguments = Record<string, Argument>;
+
+// @public (undocumented)
 export type AssociationBaseType = {
     connectionType: CodeGenConnectionType;
 };
@@ -72,6 +84,7 @@ export type Field = {
     isArrayNullable?: boolean;
     attributes?: FieldAttribute[];
     association?: AssociationType;
+    arguments?: Arguments;
 };
 
 // @public (undocumented)
@@ -103,6 +116,9 @@ export type ModelIntrospectionSchema = {
     models: SchemaModels;
     nonModels: SchemaNonModels;
     enums: SchemaEnums;
+    queries?: SchemaQueries;
+    mutations?: SchemaMutations;
+    subscriptions?: SchemaSubscriptions;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RawAppSyncModelConfig" needs to be exported by the entry point index.d.ts
@@ -143,6 +159,12 @@ export type SchemaModel = {
 export type SchemaModels = Record<string, SchemaModel>;
 
 // @public (undocumented)
+export type SchemaMutation = SchemaQuery;
+
+// @public (undocumented)
+export type SchemaMutations = Record<string, SchemaMutation>;
+
+// @public (undocumented)
 export type SchemaNonModel = {
     name: string;
     fields: Fields;
@@ -150,6 +172,18 @@ export type SchemaNonModel = {
 
 // @public (undocumented)
 export type SchemaNonModels = Record<string, SchemaNonModel>;
+
+// @public (undocumented)
+export type SchemaQueries = Record<string, SchemaQuery>;
+
+// @public (undocumented)
+export type SchemaQuery = Pick<Field, 'name' | 'type' | 'isArray' | 'isRequired' | 'isArrayNullable' | 'arguments'>;
+
+// @public (undocumented)
+export type SchemaSubscription = SchemaQuery;
+
+// @public (undocumented)
+export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 
 // @public (undocumented)
 export type Target = 'java' | 'swift' | 'javascript' | 'typescript' | 'dart' | 'introspection';

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -14,6 +14,15 @@
         },
         "enums": {
             "$ref": "#/definitions/SchemaEnums"
+        },
+        "queries": {
+            "$ref": "#/definitions/SchemaQueries"
+        },
+        "mutations": {
+            "$ref": "#/definitions/SchemaMutations"
+        },
+        "subscriptions": {
+            "$ref": "#/definitions/SchemaSubscriptions"
         }
     },
     "required": [
@@ -122,6 +131,9 @@
                 },
                 "association": {
                     "$ref": "#/definitions/AssociationType"
+                },
+                "arguments": {
+                    "$ref": "#/definitions/Arguments"
                 }
             },
             "required": [
@@ -317,6 +329,42 @@
                 "targetNames"
             ]
         },
+        "Arguments": {
+            "$ref": "#/definitions/Record%3Cstring%2CArgument%3E"
+        },
+        "Record<string,Argument>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Argument"
+            }
+        },
+        "Argument": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/FieldType"
+                },
+                "isArray": {
+                    "type": "boolean"
+                },
+                "isRequired": {
+                    "type": "boolean"
+                },
+                "isArrayNullable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "isArray",
+                "isRequired"
+            ],
+            "additionalProperties": false
+        },
         "PrimaryKeyInfo": {
             "type": "object",
             "properties": {
@@ -392,6 +440,72 @@
                 "values"
             ],
             "additionalProperties": false
+        },
+        "SchemaQueries": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaQuery%3E"
+        },
+        "Record<string,SchemaQuery>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaQuery"
+            }
+        },
+        "SchemaQuery": {
+            "$ref": "#/definitions/Pick%3CField%2C(%22name%22%7C%22type%22%7C%22isArray%22%7C%22isRequired%22%7C%22isArrayNullable%22%7C%22arguments%22)%3E"
+        },
+        "Pick<Field,(\"name\"|\"type\"|\"isArray\"|\"isRequired\"|\"isArrayNullable\"|\"arguments\")>": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/FieldType"
+                },
+                "isArray": {
+                    "type": "boolean"
+                },
+                "isRequired": {
+                    "type": "boolean"
+                },
+                "isArrayNullable": {
+                    "type": "boolean"
+                },
+                "arguments": {
+                    "$ref": "#/definitions/Arguments"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "isArray",
+                "isRequired"
+            ],
+            "additionalProperties": false
+        },
+        "SchemaMutations": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaMutation%3E"
+        },
+        "Record<string,SchemaMutation>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaMutation"
+            }
+        },
+        "SchemaMutation": {
+            "$ref": "#/definitions/SchemaQuery"
+        },
+        "SchemaSubscriptions": {
+            "$ref": "#/definitions/Record%3Cstring%2CSchemaSubscription%3E"
+        },
+        "Record<string,SchemaSubscription>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/SchemaSubscription"
+            }
+        },
+        "SchemaSubscription": {
+            "$ref": "#/definitions/SchemaQuery"
         }
     }
 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -246,7 +246,7 @@ describe('processIndex', () => {
         arguments: {
           name: 'testModelsByConnectionFieldAndSortField',
           fields: ['connectionField', 'sortField'],
-          queryField: undefined, 
+          queryField: undefined,
         },
       },
       {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1612,6 +1612,179 @@ exports[`Custom primary key tests should generate correct model intropection fil
 }"
 `;
 
+exports[`Custom queries/mutations/subscriptions tests should generate correct metadata for custom queries/mutations/subscriptions in model introspection schema 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"Todo\\": {
+            \\"name\\": \\"Todo\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"description\\": {
+                    \\"name\\": \\"description\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Todos\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {
+        \\"Phone\\": {
+            \\"name\\": \\"Phone\\",
+            \\"fields\\": {
+                \\"number\\": {
+                    \\"name\\": \\"number\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                }
+            }
+        }
+    },
+    \\"queries\\": {
+        \\"echo\\": {
+            \\"name\\": \\"echo\\",
+            \\"isArray\\": false,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
+                }
+            }
+        },
+        \\"echo2\\": {
+            \\"name\\": \\"echo2\\",
+            \\"isArray\\": false,
+            \\"type\\": {
+                \\"model\\": \\"Todo\\"
+            },
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"todoId\\": {
+                    \\"name\\": \\"todoId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true
+                }
+            }
+        },
+        \\"echo3\\": {
+            \\"name\\": \\"echo3\\",
+            \\"isArray\\": true,
+            \\"type\\": {
+                \\"model\\": \\"Todo\\"
+            },
+            \\"isRequired\\": false,
+            \\"isArrayNullable\\": true
+        },
+        \\"echo4\\": {
+            \\"name\\": \\"echo4\\",
+            \\"isArray\\": false,
+            \\"type\\": {
+                \\"nonModel\\": \\"Phone\\"
+            },
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"number\\": {
+                    \\"name\\": \\"number\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
+                }
+            }
+        }
+    },
+    \\"mutations\\": {
+        \\"mutate\\": {
+            \\"name\\": \\"mutate\\",
+            \\"isArray\\": false,
+            \\"type\\": {
+                \\"model\\": \\"Todo\\"
+            },
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"isArrayNullable\\": false
+                }
+            }
+        }
+    },
+    \\"subscriptions\\": {
+        \\"onMutate\\": {
+            \\"name\\": \\"onMutate\\",
+            \\"isArray\\": true,
+            \\"type\\": {
+                \\"model\\": \\"Todo\\"
+            },
+            \\"isRequired\\": true,
+            \\"isArrayNullable\\": true,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
+                }
+            }
+        }
+    }
+}"
+`;
+
 exports[`Model Introspection Visitor Metadata snapshot should generate correct model intropection file validated by JSON schema 1`] = `
 "{
     \\"version\\": 1,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -273,3 +273,32 @@ describe('schemas with pk on a belongsTo fk', () => {
     }).generate()).toMatchSnapshot();
   });
 });
+
+describe('Custom queries/mutations/subscriptions tests', () => {
+  const schema = /* GraphQL */ `
+    type Todo @model {
+      id: ID!
+      name: String!
+      description: String
+    }
+    type Phone {
+      number: String
+    }
+    type Query {
+      echo(msg: String): String
+      echo2(todoId: ID!): Todo
+      echo3: [Todo]
+      echo4(number: String): Phone
+    }
+    type Mutation {
+      mutate(msg: [String!]!): Todo
+    }
+    type Subscription {
+      onMutate(msg: String): [Todo!]
+    }
+  `;
+  it('should generate correct metadata for custom queries/mutations/subscriptions in model introspection schema', () => {
+    const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema);
+    expect(visitor.generate()).toMatchSnapshot();
+  });
+});

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -1863,7 +1863,7 @@ describe('AppSyncSwiftVisitor', () => {
         `);
       });
 
-      it('should support changing identityClaim ', () => {
+      it('should support changing identityClaim', () => {
         const schema = /* GraphQL */ `
           type Post @model @auth(rules: [{ allow: owner, ownerField: "author", identityClaim: "sub" }]) {
             id: ID!
@@ -2420,7 +2420,7 @@ describe('AppSyncSwiftVisitor', () => {
       `);
     });
 
-    it('should support changing groupsClaim ', () => {
+    it('should support changing groupsClaim', () => {
       const schema = /* GraphQL */ `
         type Post @model @auth(rules: [{ allow: groups, groups: ["admin"], groupClaim: "custom:groups" }]) {
           id: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -188,7 +188,7 @@ describe('AppSyncModelVisitor', () => {
     expect(notRequiredVersion).not.toBe(requiredVersion);
   });
 
-  describe(' 2 Way Connection', () => {
+  describe('2 Way Connection', () => {
     describe('with connection name', () => {
       const schema = /* GraphQL */ `
         type Post @model {
@@ -1171,7 +1171,7 @@ describe('AppSyncModelVisitor', () => {
       expect(() => createAndGeneratePipelinedTransformerVisitor(schema)).not.toThrow();
     });
   });
-  
+
   describe('Connected models with custom primary key testing', () => {
     it('should have correct output for hasOne and belongsTo connection info when model pk is compostie key', () => {
       const schema = /* GraphQL*/ `

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -6,6 +6,9 @@
   models: SchemaModels;
   nonModels: SchemaNonModels;
   enums: SchemaEnums;
+  queries?: SchemaQueries;
+  mutations?: SchemaMutations;
+  subscriptions?: SchemaSubscriptions;
 };
 /**
  * Top-level Entities on a Schema
@@ -13,6 +16,9 @@
 export type SchemaModels = Record<string, SchemaModel>;
 export type SchemaNonModels = Record<string, SchemaNonModel>;
 export type SchemaEnums = Record<string, SchemaEnum>;
+export type SchemaQueries = Record<string, SchemaQuery>;
+export type SchemaMutations = Record<string, SchemaMutation>;
+export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 
 export type SchemaModel = {
   name: string;
@@ -30,6 +36,9 @@ export type SchemaEnum = {
   name: string;
   values: string[];
 };
+export type SchemaQuery = Pick<Field, 'name' | 'type' | 'isArray' | 'isRequired' | 'isArrayNullable' | 'arguments'>;
+export type SchemaMutation = SchemaQuery;
+export type SchemaSubscription = SchemaQuery;
 
 export type ModelAttribute = { type: string; properties?: {[key: string]: any} };
 /**
@@ -45,6 +54,7 @@ export type Field = {
   isArrayNullable?: boolean;
   attributes?: FieldAttribute[];
   association?: AssociationType;
+  arguments?: Arguments;
 };
 export type FieldType = 'ID'
   | 'String'
@@ -99,3 +109,11 @@ export type PrimaryKeyInfo = {
   primaryKeyFieldName: string;
   sortKeyFieldNames: string[];
 };
+export type Arguments = Record<string, Argument>;
+export type Argument = {
+  name: string;
+  type: FieldType;
+  isArray: boolean;
+  isRequired: boolean;
+  isArrayNullable?: boolean;
+}

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -20,6 +20,7 @@ import {
   ObjectTypeDefinitionNode,
   parse,
   valueFromASTUntyped,
+  InputValueDefinitionNode,
 } from 'graphql';
 import { addFieldToModel, getModelPrimaryKeyComponentFields, removeFieldFromModel, toCamelCase } from '../utils/fieldUtils';
 import { getTypeInfo } from '../utils/get-type-info';
@@ -186,10 +187,17 @@ export type CodeGenFieldDirective = CodeGenDirective & {
   fieldName: string;
 };
 
+export type CodeGenInputValue = TypeInfo & {
+  name: string;
+  directives: CodeGenDirectives;
+}
+
 export type CodeGenDirectives = CodeGenDirective[];
+export type CodeGenInputValues = CodeGenInputValue[];
 export type CodeGenField = TypeInfo & {
   name: string;
   directives: CodeGenDirectives;
+  parameters?: CodeGenInputValues;
   connectionInfo?: CodeGenFieldConnection;
   isReadOnly?: boolean;
   primaryKeyInfo?: CodeGenPrimaryKeyFieldInfo;
@@ -230,6 +238,20 @@ export type CodeGenEnumValueMap = { [enumConvertedName: string]: string };
 
 export type CodeGenEnumMap = Record<string, CodeGenEnum>;
 
+// Types for custom query/mutation/subscription
+export type CodeGenQuery = CodeGenField & {
+  operationType: 'query';
+};
+export type CodeGenQueryMap = Record<string, CodeGenQuery>;
+export type CodeGenMutation = CodeGenField & {
+  operationType: 'mutation';
+};
+export type CodeGenMutationMap = Record<string, CodeGenMutation>;
+export type CodeGenSubscription = CodeGenField & {
+  operationType: 'subscription';
+};
+export type CodeGenSubscriptionMap = Record<string, CodeGenSubscription>;
+
 // Used to simplify processing of manyToMany into composing directives hasMany and belongsTo
 type ManyToManyContext = {
   model: CodeGenModel;
@@ -246,6 +268,9 @@ export class AppSyncModelVisitor<
   protected modelMap: CodeGenModelMap = {};
   protected nonModelMap: CodeGenModelMap = {};
   protected enumMap: CodeGenEnumMap = {};
+  protected queryMap: CodeGenQueryMap = {};
+  protected mutationMap: CodeGenMutationMap = {};
+  protected subscriptionMap: CodeGenSubscriptionMap = {};
   protected typesToSkip: string[] = [];
   constructor(
     protected _schema: GraphQLSchema,
@@ -278,15 +303,12 @@ export class AppSyncModelVisitor<
       });
     }
 
-    this.typesToSkip = [this._schema.getQueryType(), this._schema.getMutationType(), this._schema.getSubscriptionType()]
-      .filter(t => t)
-      .map(t => (t && t.name) || '');
+    this.typesToSkip = [];
     this.typesToSkip.push(...typesUsedInDirectives);
   }
 
   ObjectTypeDefinition(node: ObjectTypeDefinitionNode, index?: string | number, parent?: any) {
     if (this.typesToSkip.includes(node.name.value)) {
-      // Skip Query, mutation and subscription type
       return;
     }
     const directives = this.getDirectives(node.directives);
@@ -311,7 +333,32 @@ export class AppSyncModelVisitor<
       this.addTimestampFields(model, modelDirective);
       this.sortFields(model);
       this.modelMap[node.name.value] = model;
-    } else {
+    }
+    else if (node.name.value ===  this._schema.getQueryType()?.name) {
+      fields.forEach(field => {
+        this.queryMap[field.name] = {
+          ...field,
+          operationType: 'query',
+        }
+      });
+    }
+    else if (node.name.value ===  this._schema.getMutationType()?.name) {
+      fields.forEach(field => {
+        this.mutationMap[field.name] = {
+          ...field,
+          operationType: 'mutation',
+        }
+      });
+    }
+    else if (node.name.value ===  this._schema.getSubscriptionType()?.name) {
+      fields.forEach(field => {
+        this.subscriptionMap[field.name] = {
+          ...field,
+          operationType: 'subscription',
+        }
+      });
+    }
+    else {
       const nonModel: CodeGenModel = {
         name: node.name.value,
         type: 'model',
@@ -324,11 +371,22 @@ export class AppSyncModelVisitor<
 
   FieldDefinition(node: FieldDefinitionNode): CodeGenField {
     const directive = this.getDirectives(node.directives);
+    const parameters = ((node.arguments as unknown) as CodeGenInputValue[]) ?? [];
     return {
       name: node.name.value,
       directives: directive,
       ...getTypeInfo(node.type, this._schema),
+      parameters,
     };
+  }
+
+  InputValueDefinition(node: InputValueDefinitionNode): CodeGenInputValue {
+    const directives = this.getDirectives(node.directives);
+    return {
+      name: node.name.value,
+      directives,
+      ...getTypeInfo(node.type, this._schema),
+    }
   }
 
   EnumTypeDefinition(node: EnumTypeDefinitionNode): void {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Added support for custom queries/mutations/subscriptions in the generated model introspection schema. The metadata contains field name, field type and arguments. 
#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Unit & e2e tests
`amplify-dev codegen model-introspection --output-dir .`


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
