### PR TITLE
fix: windows CI not catching latest repo change

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -7,7 +7,7 @@ set -e
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-# storeCache <local path> <cache location>
+# storeCache <local path> <cache location> <os type>
 function storeCache {
   localPath="$1"
   alias="$2"
@@ -38,7 +38,7 @@ function storeCache {
   cd $CODEBUILD_SRC_DIR
 }
 
-# loadCache <cache location> <local path>
+# loadCache <cache location> <local path> <os type>
 function loadCache {
   alias="$1"
   localPath="$2"
@@ -258,6 +258,7 @@ function _setupE2ETestsLinux {
 function _setupE2ETestsWindows {
     echo "Setup E2E Tests Windows"
     loadCacheFromWindowsBuildJob
+    loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache windows
     _installCLIFromLocalRegistry windows
     _loadTestAccountCredentials
     _setShell


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Added verdaccio cache load step in windows e2e setup
#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes
Check the codebuild console and examine the installing CLI log for the installed version of `amplify-codegen`. The newly published version from verdaccio proxy is used instead of the one from npm registry.
```
Loading cache folder from s3://****/verdaccio-cache
Loading cache for Windows
Done loading cache folder verdaccio-cache


using Amplify CLI version: 12.10.0
--
| +-- @aws-amplify/amplify-category-api@5.9.3
| +-- amplify-codegen@4.7.4

```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
