### PR TITLE
fix: process input object, union and interface metadata in model introspection schema codegen

### DIFF
--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -145,24 +145,25 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: >-
-        l_build_app_ts_uninitialized_project_codegen_js_uninitialized_project_modelgen_android_uninitialized_project_modelgen_flutter
+        l_build_app_ts_push_codegen_admin_modelgen_uninitialized_project_codegen_js_uninitialized_project_modelgen_android
       buildspec: .codebuild/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           TEST_SUITE: >-
-            src/__tests__/build-app-ts.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts
+            src/__tests__/build-app-ts.test.ts|src/__tests__/push-codegen-admin-modelgen.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts
           CLI_REGION: ap-southeast-1
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
-    - identifier: l_uninitialized_project_modelgen_ios_uninitialized_project_modelgen_js
+    - identifier: >-
+        l_uninitialized_project_modelgen_flutter_uninitialized_project_modelgen_ios_uninitialized_project_modelgen_js
       buildspec: .codebuild/run_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           TEST_SUITE: >-
-            src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
+            src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
           CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
@@ -251,7 +252,7 @@ batch:
         - publish_to_local_registry
         - build_windows
     - identifier: >-
-        w_build_app_ts_uninitialized_project_codegen_js_uninitialized_project_modelgen_android_uninitialized_project_modelgen_flutter
+        w_build_app_ts_push_codegen_admin_modelgen_uninitialized_project_codegen_js_uninitialized_project_modelgen_android
       buildspec: .codebuild/run_e2e_tests_windows.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -259,13 +260,14 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         variables:
           TEST_SUITE: >-
-            src/__tests__/build-app-ts.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts
+            src/__tests__/build-app-ts.test.ts|src/__tests__/push-codegen-admin-modelgen.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts|src/__tests__/uninitialized-project-modelgen-android.test.ts
           CLI_REGION: us-east-1
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
         - build_windows
-    - identifier: w_uninitialized_project_modelgen_ios_uninitialized_project_modelgen_js
+    - identifier: >-
+        w_uninitialized_project_modelgen_flutter_uninitialized_project_modelgen_ios_uninitialized_project_modelgen_js
       buildspec: .codebuild/run_e2e_tests_windows.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -273,7 +275,7 @@ batch:
         type: WINDOWS_SERVER_2019_CONTAINER
         variables:
           TEST_SUITE: >-
-            src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
+            src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
           CLI_REGION: us-east-1
       depend-on:
         - publish_to_local_registry

--- a/packages/amplify-codegen-e2e-core/src/utils/sdk-calls.ts
+++ b/packages/amplify-codegen-e2e-core/src/utils/sdk-calls.ts
@@ -14,6 +14,7 @@ import {
   AmplifyBackend,
 } from 'aws-sdk';
 import _ from 'lodash';
+import { getProjectMeta } from './projectMeta';
 
 export const getDDBTable = async (tableName: string, region: string) => {
   const service = new DynamoDB({ region });
@@ -40,6 +41,19 @@ export const bucketNotExists = async (bucket: string) => {
     }
     throw error;
   }
+};
+
+export const getDeploymentBucketObject = async (projectRoot: string, objectKey: string) => {
+  const meta = getProjectMeta(projectRoot);
+  const deploymentBucket = meta.providers.awscloudformation.DeploymentBucketName;
+  const s3 = new S3();
+  const result = await s3
+    .getObject({
+      Bucket: deploymentBucket,
+      Key: objectKey,
+    })
+    .promise();
+  return result.Body.toLocaleString();
 };
 
 export const deleteS3Bucket = async (bucket: string, providedS3Client: S3 | undefined = undefined) => {

--- a/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
@@ -4,12 +4,47 @@ type Todo @model {
   id: ID!
   name: String!
   description: String
+  phone: Phone
+}
+type Phone {
+  number: String
+}
+enum BillingSource {
+  CLIENT
+  PROJECT
 }
 input CustomInput {
   customField1: String!
-  customField2: Int
+  customField2: BillingSource
+  customField3: NestedInput!
 }
+input NestedInput {
+  content: String! = "hello"
+}
+interface ICustom {
+  firstName: String!
+  lastName: String
+  birthdays: [INestedCustom!]!
+}
+interface INestedCustom {
+  birthDay: AWSDate!
+}
+# The member types of a Union type must all be Object base types.
+union CustomUnion = Todo | Phone
 
 type Query {
   getAllTodo(msg: String, input: CustomInput): String @function(name: "echofunction-${env}")
+  echo(msg: String): String
+  echo2(todoId: ID!): Todo
+  echo3: [Todo!]!
+  echo4(number: String): Phone
+  echo5: [CustomUnion!]!
+  echo6(customInput: CustomInput): String!
+  echo7: [ICustom]!
+}
+type Mutation {
+  mutate(msg: [String!]!): Todo
+}
+type Subscription {
+  onMutate(msg: String): [Todo!]
 }

--- a/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
@@ -1,0 +1,15 @@
+input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!
+
+type Todo @model {
+  id: ID!
+  name: String!
+  description: String
+}
+input CustomInput {
+  customField1: String!
+  customField2: Int
+}
+
+type Query {
+  getAllTodo(msg: String, input: CustomInput): String @function(name: "echofunction-${env}")
+}

--- a/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
+++ b/packages/amplify-codegen-e2e-tests/schemas/admin-modelgen.graphql
@@ -34,13 +34,16 @@ union CustomUnion = Todo | Phone
 
 type Query {
   getAllTodo(msg: String, input: CustomInput): String @function(name: "echofunction-${env}")
-  echo(msg: String): String
+  echo(msg: String!): String
   echo2(todoId: ID!): Todo
   echo3: [Todo!]!
   echo4(number: String): Phone
   echo5: [CustomUnion!]!
   echo6(customInput: CustomInput): String!
   echo7: [ICustom]!
+  echo8(msg: [Float], msg2: [Int!], enumType: BillingSource, enumList: [BillingSource], inputType: [CustomInput]): [String]
+  echo9(msg: [Float]!, msg2: [Int!]!, enumType: BillingSource!, enumList: [BillingSource!]!, inputType: [CustomInput!]!): [String!]!    
+
 }
 type Mutation {
   mutate(msg: [String!]!): Todo

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_JS_CONFIG, createNewProjectDir } from "@aws-amplify/amplify-codegen-e2e-core";
-import { deleteAmplifyProject, testPushCodegen } from "../codegen-tests-base";
+import { deleteAmplifyProject, testPushAdminModelgen, testPushCodegen } from "../codegen-tests-base";
 
 const schema = 'admin-modelgen.graphql';
 
@@ -13,7 +13,7 @@ describe('Amplify push with codegen tests - admin modelgen', () => {
     await deleteAmplifyProject(projectRoot); 
   });
 
-  it(`should not throw error for executing the modelgen commands (datastore modelgen & model-introspection) post push`, async () => {
-    await testPushCodegen(DEFAULT_JS_CONFIG, projectRoot, schema);
+  it(`should not throw error for executing the admin modelgen step required by studio CMS usage post push`, async () => {
+    await testPushAdminModelgen(DEFAULT_JS_CONFIG, projectRoot, schema);
   });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_JS_CONFIG, createNewProjectDir } from "@aws-amplify/amplify-codegen-e2e-core";
+import { deleteAmplifyProject, testPushCodegen } from "../codegen-tests-base";
+
+const schema = 'admin-modelgen.graphql';
+
+describe('Amplify push with codegen tests - admin modelgen', () => {
+  let projectRoot: string;
+  beforeEach(async () => {
+    projectRoot = await createNewProjectDir('pushCodegenAdminModelgen');
+  });
+
+  afterEach(async () => {
+    await deleteAmplifyProject(projectRoot); 
+  });
+
+  it(`should not throw error for executing the modelgen commands (datastore modelgen & model-introspection) post push`, async () => {
+    await testPushCodegen(DEFAULT_JS_CONFIG, projectRoot, schema);
+  });
+});

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
@@ -13,7 +13,7 @@ describe('Amplify push with codegen tests - admin modelgen', () => {
     await deleteAmplifyProject(projectRoot); 
   });
 
-  it(`should not throw error for executing the admin modelgen step required by studio CMS usage post push`, async () => {
+  it(`should not throw error for executing the admin modelgen step required by studio CMS usage post push given the schema with input, union and interface types`, async () => {
     await testPushAdminModelgen(DEFAULT_JS_CONFIG, projectRoot, schema);
   });
 });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/push-codegen-admin-modelgen.test.ts
@@ -10,7 +10,7 @@ describe('Amplify push with codegen tests - admin modelgen', () => {
   });
 
   afterEach(async () => {
-    await deleteAmplifyProject(projectRoot); 
+    await deleteAmplifyProject(projectRoot);
   });
 
   it(`should not throw error for executing the admin modelgen step required by studio CMS usage post push given the schema with input, union and interface types`, async () => {

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -45,6 +45,7 @@ type AmplifyAppInfo = {
 
 type S3BucketInfo = {
   name: string;
+  region: string;
   jobId?: string;
   cbInfo?: CodeBuild.Build;
 };
@@ -118,7 +119,16 @@ const getOrphanS3TestBuckets = async (account: AWSAccountInfo): Promise<S3Bucket
   const s3Client = new aws.S3(getAWSConfig(account));
   const listBucketResponse = await s3Client.listBuckets().promise();
   const staleBuckets = listBucketResponse.Buckets.filter(testBucketStalenessFilter);
-  return staleBuckets.map(it => ({ name: it.Name }));
+  const bucketInfos = await Promise.all(
+    staleBuckets.map(async (staleBucket): Promise<S3BucketInfo> => {
+      const region = await getBucketRegion(account, staleBucket.Name);
+      return {
+        name: staleBucket.Name,
+        region,
+      };
+    }),
+  );
+  return bucketInfos;
 };
 
 /**
@@ -276,27 +286,52 @@ const getJobCodeBuildDetails = async (jobIds: string[]): Promise<CodeBuild.Build
   }
 };
 
+const getBucketRegion = async (account: AWSAccountInfo, bucketName: string): Promise<string> => {
+  const awsConfig = getAWSConfig(account);
+  const s3Client = new aws.S3(awsConfig);
+  const location = await s3Client.getBucketLocation({ Bucket: bucketName }).promise();
+  const region = location.LocationConstraint ?? 'us-east-1';
+  return region;
+};
+
 const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> => {
-  const s3Client = new aws.S3(getAWSConfig(account));
+  const awsConfig = getAWSConfig(account);
+  const s3Client = new aws.S3(awsConfig);
   const buckets = await s3Client.listBuckets().promise();
   const result: S3BucketInfo[] = [];
   for (const bucket of buckets.Buckets) {
+    let region: string | undefined;
     try {
+      region = await getBucketRegion(account, bucket.Name);
+      // Operations on buckets created in opt-in regions appear to require region-specific clients
+      const regionalizedClient = new aws.S3({
+        region,
+        ...(awsConfig as object),
+      });
       const bucketDetails = await s3Client.getBucketTagging({ Bucket: bucket.Name }).promise();
       const jobId = getJobId(bucketDetails.TagSet);
       if (jobId) {
         result.push({
           name: bucket.Name,
+          region,
           jobId
         });
       }
     } catch (e) {
-      if (e.code !== 'NoSuchTagSet' && e.code !== 'NoSuchBucket') {
+      // TODO: Why do we process the bucket even with these particular errors?
+      if (e.code === 'NoSuchTagSet' || e.code === 'NoSuchBucket') {
+        result.push({
+          name: bucket.Name,
+          region: region ?? 'us-east-1',
+        });
+      } else if (e.code === 'InvalidToken') {
+        // We see some buckets in some accounts that were somehow created in an opt-in region different from the one to which the account is
+        // actually opted in. We don't quite know how this happened, but for now, we'll make a note of the inconsistency and continue
+        // processing the rest of the buckets.
+        console.error(`Skipping processing ${account.accountId}, bucket ${bucket.Name}`, e);
+      } else {
         throw e;
       }
-      result.push({
-        name: bucket.Name,
-      });
     }
   }
   return result;
@@ -516,8 +551,12 @@ const deleteBucket = async (account: AWSAccountInfo, accountIndex: number, bucke
   const { name } = bucket;
   try {
     console.log(`${generateAccountInfo(account, accountIndex)} Deleting S3 Bucket ${name}`);
-    const s3 = new aws.S3(getAWSConfig(account));
-    await deleteS3Bucket(name, s3);
+    const awsConfig = getAWSConfig(account);
+    const regionalizedS3Client = new aws.S3({
+      region: bucket.region,
+      ...(awsConfig as object),
+    });
+    await deleteS3Bucket(name, regionalizedS3Client);
   } catch (e) {
     console.log(`${generateAccountInfo(account, accountIndex)} Deleting bucket ${name} failed with error ${e.message}`);
     if (e.code === 'ExpiredTokenException') {

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -308,7 +308,7 @@ const getS3Buckets = async (account: AWSAccountInfo): Promise<S3BucketInfo[]> =>
         region,
         ...(awsConfig as object),
       });
-      const bucketDetails = await s3Client.getBucketTagging({ Bucket: bucket.Name }).promise();
+      const bucketDetails = await regionalizedClient.getBucketTagging({ Bucket: bucket.Name }).promise();
       const jobId = getJobId(bucketDetails.TagSet);
       if (jobId) {
         result.push({

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
@@ -52,7 +52,7 @@ export async function testPushAdminModelgen(config: AmplifyFrontendConfig, proje
       AmplifyAppId: appId,
     } = getProjectMeta(projectRoot).providers.awscloudformation;
 
-    expect(bucketName).toBeAS3Bucket(bucketName);
+    expect(bucketName).toBeDefined()
     expect(region).toBeDefined();
     expect(appId).toBeDefined();
 

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
@@ -8,7 +8,6 @@ import {
     amplifyPushWithCodegenUpdate,
     updateAPIWithResolutionStrategyWithModels,
     getProjectMeta,
-    checkIfBucketExists,
     getDeploymentBucketObject,
     amplifyPush
 } from "@aws-amplify/amplify-codegen-e2e-core";

--- a/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
+++ b/packages/amplify-codegen-e2e-tests/src/codegen-tests-base/push-codegen.ts
@@ -6,7 +6,11 @@ import {
     amplifyPushWithCodegenAdd,
     AmplifyFrontendConfig,
     amplifyPushWithCodegenUpdate,
-    updateAPIWithResolutionStrategyWithModels
+    updateAPIWithResolutionStrategyWithModels,
+    getProjectMeta,
+    checkIfBucketExists,
+    getDeploymentBucketObject,
+    amplifyPush
 } from "@aws-amplify/amplify-codegen-e2e-core";
 import { existsSync } from "fs";
 import path from 'path';
@@ -37,4 +41,39 @@ export async function testPushCodegen(config: AmplifyFrontendConfig, projectRoot
     await amplifyPushWithCodegenUpdate(projectRoot);
     expect(existsSync(userSourceCodePath)).toBe(true);
     expect(isNotEmptyDir(path.join(projectRoot, config.modelgenDir))).toBe(true);
+}
+
+export async function testPushAdminModelgen(config: AmplifyFrontendConfig, projectRoot: string, schema: string) {
+    // init project and add API category
+    await initProjectWithProfile(projectRoot, { ...config, disableAmplifyAppCreation: false, });
+    const {
+      DeploymentBucketName: bucketName,
+      Region: region,
+      AmplifyAppId: appId,
+    } = getProjectMeta(projectRoot).providers.awscloudformation;
+
+    expect(bucketName).toBeAS3Bucket(bucketName);
+    expect(region).toBeDefined();
+    expect(appId).toBeDefined();
+
+    const projectName = createRandomName();
+    await addApiWithoutSchema(projectRoot, { apiName: projectName });
+    await updateApiSchema(projectRoot, projectName, schema);
+    // add codegen succeeds
+    await amplifyPush(projectRoot);
+
+    /**
+     * Source code from
+     * https://github.com/aws-amplify/amplify-cli/blob/1da5de70c57b15a76f02c92364af4889d1585229/packages/amplify-provider-awscloudformation/src/admin-modelgen.ts#L85-L93
+     */
+    const s3ApiModelsPrefix = `models/${projectName}/`;
+    const cmsArtifactLocalToS3Keys = [
+      `${s3ApiModelsPrefix}schema.graphql`,
+      `${s3ApiModelsPrefix}schema.js`,
+      `${s3ApiModelsPrefix}modelIntrospection.json`,
+    ];
+    // expect CMS assets to be present in S3
+    cmsArtifactLocalToS3Keys.forEach(async (key) => {
+      await expect(getDeploymentBucketObject(projectRoot, key)).resolves.not.toThrow();
+    });
 }

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -102,12 +102,22 @@ export type FieldType = 'ID' | 'String' | 'Int' | 'Float' | 'AWSDate' | 'AWSTime
     nonModel: string;
 } | {
     input: string;
+} | {
+    union: string;
+} | {
+    interface: string;
 };
 
 // @public (undocumented)
 export type Input = {
     name: string;
     arguments: Arguments;
+};
+
+// @public (undocumented)
+export type Interface = {
+    name: string;
+    fields: Fields;
 };
 
 // @public (undocumented)
@@ -128,6 +138,8 @@ export type ModelIntrospectionSchema = {
     mutations?: SchemaMutations;
     subscriptions?: SchemaSubscriptions;
     inputs?: SchemaInputs;
+    unions?: SchemaUnions;
+    interfaces?: SchemaInterfaces;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RawAppSyncModelConfig" needs to be exported by the entry point index.d.ts
@@ -156,6 +168,9 @@ export type SchemaEnums = Record<string, SchemaEnum>;
 
 // @public (undocumented)
 export type SchemaInputs = Record<string, Input>;
+
+// @public (undocumented)
+export type SchemaInterfaces = Record<string, Interface>;
 
 // @public (undocumented)
 export type SchemaModel = {
@@ -198,7 +213,16 @@ export type SchemaSubscription = SchemaQuery;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 
 // @public (undocumented)
+export type SchemaUnions = Record<string, Union>;
+
+// @public (undocumented)
 export type Target = 'java' | 'swift' | 'javascript' | 'typescript' | 'dart' | 'introspection';
+
+// @public (undocumented)
+export type Union = {
+    name: string;
+    typeNames: string[];
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -28,7 +28,7 @@ export interface AppSyncModelPluginConfig extends RawDocumentsConfig {
 // @public (undocumented)
 export type Argument = {
     name: string;
-    type: FieldType;
+    type: InputFieldType;
     isArray: boolean;
     isRequired: boolean;
     isArrayNullable?: boolean;
@@ -94,7 +94,7 @@ export type FieldAttribute = ModelAttribute;
 export type Fields = Record<string, Field>;
 
 // @public (undocumented)
-export type FieldType = 'ID' | 'String' | 'Int' | 'Float' | 'AWSDate' | 'AWSTime' | 'AWSDateTime' | 'AWSTimestamp' | 'AWSEmail' | 'AWSURL' | 'AWSIPAddress' | 'Boolean' | 'AWSJSON' | 'AWSPhone' | {
+export type FieldType = ScalarType | {
     enum: string;
 } | {
     model: string;
@@ -112,6 +112,13 @@ export type FieldType = 'ID' | 'String' | 'Int' | 'Float' | 'AWSDate' | 'AWSTime
 export type Input = {
     name: string;
     arguments: Arguments;
+};
+
+// @public (undocumented)
+export type InputFieldType = ScalarType | {
+    enum: string;
+} | {
+    input: string;
 };
 
 // @public (undocumented)
@@ -156,6 +163,9 @@ export type PrimaryKeyInfo = {
     primaryKeyFieldName: string;
     sortKeyFieldNames: string[];
 };
+
+// @public (undocumented)
+export type ScalarType = 'ID' | 'String' | 'Int' | 'Float' | 'AWSDate' | 'AWSTime' | 'AWSDateTime' | 'AWSTimestamp' | 'AWSEmail' | 'AWSURL' | 'AWSIPAddress' | 'Boolean' | 'AWSJSON' | 'AWSPhone';
 
 // @public (undocumented)
 export type SchemaEnum = {

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -116,17 +116,6 @@ export type InputFieldType = ScalarType | {
 };
 
 // @public (undocumented)
-export type Interface = {
-    name: string;
-    fields: Fields;
-};
-
-// @public (undocumented)
-export type InterfaceFieldType = {
-    interface: string;
-};
-
-// @public (undocumented)
 export type ModelAttribute = {
     type: string;
     properties?: {
@@ -144,8 +133,6 @@ export type ModelIntrospectionSchema = {
     mutations?: SchemaMutations;
     subscriptions?: SchemaSubscriptions;
     inputs?: SchemaInputs;
-    unions?: SchemaUnions;
-    interfaces?: SchemaInterfaces;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RawAppSyncModelConfig" needs to be exported by the entry point index.d.ts
@@ -177,9 +164,6 @@ export type SchemaEnums = Record<string, SchemaEnum>;
 
 // @public (undocumented)
 export type SchemaInputs = Record<string, Input>;
-
-// @public (undocumented)
-export type SchemaInterfaces = Record<string, Interface>;
 
 // @public (undocumented)
 export type SchemaModel = {
@@ -222,21 +206,7 @@ export type SchemaSubscription = SchemaQuery;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 
 // @public (undocumented)
-export type SchemaUnions = Record<string, Union>;
-
-// @public (undocumented)
 export type Target = 'java' | 'swift' | 'javascript' | 'typescript' | 'dart' | 'introspection';
-
-// @public (undocumented)
-export type Union = {
-    name: string;
-    typeNames: string[];
-};
-
-// @public (undocumented)
-export type UnionFieldType = {
-    union: string;
-};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -100,6 +100,14 @@ export type FieldType = 'ID' | 'String' | 'Int' | 'Float' | 'AWSDate' | 'AWSTime
     model: string;
 } | {
     nonModel: string;
+} | {
+    input: string;
+};
+
+// @public (undocumented)
+export type Input = {
+    name: string;
+    arguments: Arguments;
 };
 
 // @public (undocumented)
@@ -119,6 +127,7 @@ export type ModelIntrospectionSchema = {
     queries?: SchemaQueries;
     mutations?: SchemaMutations;
     subscriptions?: SchemaSubscriptions;
+    inputs?: SchemaInputs;
 };
 
 // Warning: (ae-forgotten-export) The symbol "RawAppSyncModelConfig" needs to be exported by the entry point index.d.ts
@@ -144,6 +153,9 @@ export type SchemaEnum = {
 
 // @public (undocumented)
 export type SchemaEnums = Record<string, SchemaEnum>;
+
+// @public (undocumented)
+export type SchemaInputs = Record<string, Input>;
 
 // @public (undocumented)
 export type SchemaModel = {

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -100,12 +100,6 @@ export type FieldType = ScalarType | {
     model: string;
 } | {
     nonModel: string;
-} | {
-    input: string;
-} | {
-    union: string;
-} | {
-    interface: string;
 };
 
 // @public (undocumented)
@@ -125,6 +119,11 @@ export type InputFieldType = ScalarType | {
 export type Interface = {
     name: string;
     fields: Fields;
+};
+
+// @public (undocumented)
+export type InterfaceFieldType = {
+    interface: string;
 };
 
 // @public (undocumented)
@@ -232,6 +231,11 @@ export type Target = 'java' | 'swift' | 'javascript' | 'typescript' | 'dart' | '
 export type Union = {
     name: string;
     typeNames: string[];
+};
+
+// @public (undocumented)
+export type UnionFieldType = {
+    union: string;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/appsync-modelgen-plugin/API.md
+++ b/packages/appsync-modelgen-plugin/API.md
@@ -105,7 +105,7 @@ export type FieldType = ScalarType | {
 // @public (undocumented)
 export type Input = {
     name: string;
-    arguments: Arguments;
+    attributes: Arguments;
 };
 
 // @public (undocumented)

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -193,42 +193,6 @@
                         "nonModel"
                     ],
                     "additionalProperties": false
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "input": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "input"
-                    ],
-                    "additionalProperties": false
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "union": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "union"
-                    ],
-                    "additionalProperties": false
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "interface": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "interface"
-                    ],
-                    "additionalProperties": false
                 }
             ]
         },

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -26,12 +26,6 @@
         },
         "inputs": {
             "$ref": "#/definitions/SchemaInputs"
-        },
-        "unions": {
-            "$ref": "#/definitions/SchemaUnions"
-        },
-        "interfaces": {
-            "$ref": "#/definitions/SchemaInterfaces"
         }
     },
     "required": [
@@ -538,61 +532,6 @@
             ],
             "additionalProperties": false,
             "description": "Input Definition"
-        },
-        "SchemaUnions": {
-            "$ref": "#/definitions/Record%3Cstring%2CUnion%3E"
-        },
-        "Record<string,Union>": {
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/Union"
-            }
-        },
-        "Union": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "typeNames": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "typeNames"
-            ],
-            "additionalProperties": false,
-            "description": "Union Definition"
-        },
-        "SchemaInterfaces": {
-            "$ref": "#/definitions/Record%3Cstring%2CInterface%3E"
-        },
-        "Record<string,Interface>": {
-            "type": "object",
-            "additionalProperties": {
-                "$ref": "#/definitions/Interface"
-            }
-        },
-        "Interface": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "fields": {
-                    "$ref": "#/definitions/Fields"
-                }
-            },
-            "required": [
-                "name",
-                "fields"
-            ],
-            "additionalProperties": false,
-            "description": "Interface Definition"
         }
     }
 }

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -23,6 +23,9 @@
         },
         "subscriptions": {
             "$ref": "#/definitions/SchemaSubscriptions"
+        },
+        "inputs": {
+            "$ref": "#/definitions/SchemaInputs"
         }
     },
     "required": [
@@ -235,6 +238,18 @@
                     },
                     "required": [
                         "nonModel"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "input": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "input"
                     ],
                     "additionalProperties": false
                 }
@@ -506,6 +521,32 @@
         },
         "SchemaSubscription": {
             "$ref": "#/definitions/SchemaQuery"
+        },
+        "SchemaInputs": {
+            "$ref": "#/definitions/Record%3Cstring%2CInput%3E"
+        },
+        "Record<string,Input>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Input"
+            }
+        },
+        "Input": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "arguments": {
+                    "$ref": "#/definitions/Arguments"
+                }
+            },
+            "required": [
+                "name",
+                "arguments"
+            ],
+            "additionalProperties": false,
+            "description": "Input Definition"
         }
     }
 }

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -156,60 +156,7 @@
         "FieldType": {
             "anyOf": [
                 {
-                    "type": "string",
-                    "const": "ID"
-                },
-                {
-                    "type": "string",
-                    "const": "String"
-                },
-                {
-                    "type": "string",
-                    "const": "Int"
-                },
-                {
-                    "type": "string",
-                    "const": "Float"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSDate"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSTime"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSDateTime"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSTimestamp"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSEmail"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSURL"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSIPAddress"
-                },
-                {
-                    "type": "string",
-                    "const": "Boolean"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSJSON"
-                },
-                {
-                    "type": "string",
-                    "const": "AWSPhone"
+                    "$ref": "#/definitions/ScalarType"
                 },
                 {
                     "type": "object",
@@ -283,6 +230,25 @@
                     ],
                     "additionalProperties": false
                 }
+            ]
+        },
+        "ScalarType": {
+            "type": "string",
+            "enum": [
+                "ID",
+                "String",
+                "Int",
+                "Float",
+                "AWSDate",
+                "AWSTime",
+                "AWSDateTime",
+                "AWSTimestamp",
+                "AWSEmail",
+                "AWSURL",
+                "AWSIPAddress",
+                "Boolean",
+                "AWSJSON",
+                "AWSPhone"
             ]
         },
         "FieldAttribute": {
@@ -390,7 +356,7 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/FieldType"
+                    "$ref": "#/definitions/InputFieldType"
                 },
                 "isArray": {
                     "type": "boolean"
@@ -409,6 +375,37 @@
                 "isRequired"
             ],
             "additionalProperties": false
+        },
+        "InputFieldType": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ScalarType"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "enum": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "enum"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "input": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "input"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
         },
         "PrimaryKeyInfo": {
             "type": "object",

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -528,13 +528,13 @@
                 "name": {
                     "type": "string"
                 },
-                "arguments": {
+                "attributes": {
                     "$ref": "#/definitions/Arguments"
                 }
             },
             "required": [
                 "name",
-                "arguments"
+                "attributes"
             ],
             "additionalProperties": false,
             "description": "Input Definition"

--- a/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
+++ b/packages/appsync-modelgen-plugin/schemas/introspection/1/ModelIntrospectionSchema.json
@@ -26,6 +26,12 @@
         },
         "inputs": {
             "$ref": "#/definitions/SchemaInputs"
+        },
+        "unions": {
+            "$ref": "#/definitions/SchemaUnions"
+        },
+        "interfaces": {
+            "$ref": "#/definitions/SchemaInterfaces"
         }
     },
     "required": [
@@ -250,6 +256,30 @@
                     },
                     "required": [
                         "input"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "union": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "union"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "interface"
                     ],
                     "additionalProperties": false
                 }
@@ -547,6 +577,61 @@
             ],
             "additionalProperties": false,
             "description": "Input Definition"
+        },
+        "SchemaUnions": {
+            "$ref": "#/definitions/Record%3Cstring%2CUnion%3E"
+        },
+        "Record<string,Union>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Union"
+            }
+        },
+        "Union": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "typeNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "typeNames"
+            ],
+            "additionalProperties": false,
+            "description": "Union Definition"
+        },
+        "SchemaInterfaces": {
+            "$ref": "#/definitions/Record%3Cstring%2CInterface%3E"
+        },
+        "Record<string,Interface>": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Interface"
+            }
+        },
+        "Interface": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "fields": {
+                    "$ref": "#/definitions/Fields"
+                }
+            },
+            "required": [
+                "name",
+                "fields"
+            ],
+            "additionalProperties": false,
+            "description": "Interface Definition"
         }
     }
 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1640,6 +1640,15 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"isRequired\\": false,
                     \\"attributes\\": []
                 },
+                \\"phone\\": {
+                    \\"name\\": \\"phone\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"nonModel\\": \\"Phone\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
                 \\"createdAt\\": {
                     \\"name\\": \\"createdAt\\",
                     \\"isArray\\": false,
@@ -1696,6 +1705,28 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
         }
     },
     \\"queries\\": {
+        \\"getAllTodo\\": {
+            \\"name\\": \\"getAllTodo\\",
+            \\"isArray\\": false,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
+                },
+                \\"input\\": {
+                    \\"name\\": \\"input\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"input\\": \\"CustomInput\\"
+                    },
+                    \\"isRequired\\": false
+                }
+            }
+        },
         \\"echo\\": {
             \\"name\\": \\"echo\\",
             \\"isArray\\": false,
@@ -1732,8 +1763,8 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
             \\"type\\": {
                 \\"model\\": \\"Todo\\"
             },
-            \\"isRequired\\": false,
-            \\"isArrayNullable\\": true
+            \\"isRequired\\": true,
+            \\"isArrayNullable\\": false
         },
         \\"echo4\\": {
             \\"name\\": \\"echo4\\",
@@ -1753,20 +1784,12 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
         },
         \\"echo5\\": {
             \\"name\\": \\"echo5\\",
-            \\"isArray\\": false,
-            \\"type\\": \\"String\\",
-            \\"isRequired\\": false,
-            \\"arguments\\": {
-                \\"input\\": {
-                    \\"name\\": \\"input\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"input\\": \\"EchoInput\\"
-                    },
-                    \\"isRequired\\": false,
-                    \\"isArrayNullable\\": true
-                }
-            }
+            \\"isArray\\": true,
+            \\"type\\": {
+                \\"union\\": \\"CustomUnion\\"
+            },
+            \\"isRequired\\": true,
+            \\"isArrayNullable\\": false
         },
         \\"echo6\\": {
             \\"name\\": \\"echo6\\",
@@ -1783,6 +1806,15 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"isRequired\\": false
                 }
             }
+        },
+        \\"echo7\\": {
+            \\"name\\": \\"echo7\\",
+            \\"isArray\\": true,
+            \\"type\\": {
+                \\"interface\\": \\"ICustom\\"
+            },
+            \\"isRequired\\": false,
+            \\"isArrayNullable\\": false
         }
     },
     \\"mutations\\": {
@@ -1836,10 +1868,8 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                 \\"customField2\\": {
                     \\"name\\": \\"customField2\\",
                     \\"isArray\\": false,
-                    \\"type\\": {
-                        \\"enum\\": \\"BillingSource\\"
-                    },
-                    \\"isRequired\\": true
+                    \\"type\\": \\"Int\\",
+                    \\"isRequired\\": false
                 },
                 \\"customField3\\": {
                     \\"name\\": \\"customField3\\",
@@ -1861,15 +1891,56 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"isRequired\\": true
                 }
             }
-        },
-        \\"EchoInput\\": {
-            \\"name\\": \\"EchoInput\\",
-            \\"arguments\\": {
-                \\"msg\\": {
-                    \\"name\\": \\"msg\\",
+        }
+    },
+    \\"unions\\": {
+        \\"CustomUnion\\": {
+            \\"name\\": \\"CustomUnion\\",
+            \\"typeNames\\": [
+                \\"Todo\\",
+                \\"Phone\\"
+            ]
+        }
+    },
+    \\"interfaces\\": {
+        \\"ICustom\\": {
+            \\"name\\": \\"ICustom\\",
+            \\"fields\\": {
+                \\"firstName\\": {
+                    \\"name\\": \\"firstName\\",
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
-                    \\"isRequired\\": false
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"lastName\\": {
+                    \\"name\\": \\"lastName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": []
+                },
+                \\"birthdays\\": {
+                    \\"name\\": \\"birthdays\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"interface\\": \\"INestedCustom\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"isArrayNullable\\": false
+                }
+            }
+        },
+        \\"INestedCustom\\": {
+            \\"name\\": \\"INestedCustom\\",
+            \\"fields\\": {
+                \\"birthDay\\": {
+                    \\"name\\": \\"birthDay\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDate\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
                 }
             }
         }
@@ -2130,6 +2201,32 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": false
+                }
+            }
+        }
+    },
+    \\"unions\\": {
+        \\"SimpleUnion\\": {
+            \\"name\\": \\"SimpleUnion\\",
+            \\"typeNames\\": [
+                \\"SimpleModel\\",
+                \\"SimpleEnum\\",
+                \\"SimpleNonModelType\\",
+                \\"SimpleInput\\",
+                \\"SimpleInterface\\"
+            ]
+        }
+    },
+    \\"interfaces\\": {
+        \\"SimpleInterface\\": {
+            \\"name\\": \\"SimpleInterface\\",
+            \\"fields\\": {
+                \\"firstName\\": {
+                    \\"name\\": \\"firstName\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
                 }
             }
         }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1840,7 +1840,7 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
     \\"inputs\\": {
         \\"CustomInput\\": {
             \\"name\\": \\"CustomInput\\",
-            \\"arguments\\": {
+            \\"attributes\\": {
                 \\"customField1\\": {
                     \\"name\\": \\"customField1\\",
                     \\"isArray\\": false,
@@ -1865,7 +1865,7 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
         },
         \\"NestedInput\\": {
             \\"name\\": \\"NestedInput\\",
-            \\"arguments\\": {
+            \\"attributes\\": {
                 \\"content\\": {
                     \\"name\\": \\"content\\",
                     \\"isArray\\": false,
@@ -2167,7 +2167,7 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
     \\"inputs\\": {
         \\"SimpleInput\\": {
             \\"name\\": \\"SimpleInput\\",
-            \\"arguments\\": {
+            \\"attributes\\": {
                 \\"name\\": {
                     \\"name\\": \\"name\\",
                     \\"isArray\\": false,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1612,7 +1612,7 @@ exports[`Custom primary key tests should generate correct model intropection fil
 }"
 `;
 
-exports[`Custom queries/mutations/subscriptions tests should generate correct metadata for custom queries/mutations/subscriptions in model introspection schema 1`] = `
+exports[`Custom queries/mutations/subscriptions & input type tests should generate correct metadata for custom queries/mutations/subscriptions in model introspection schema 1`] = `
 "{
     \\"version\\": 1,
     \\"models\\": {
@@ -1672,7 +1672,15 @@ exports[`Custom queries/mutations/subscriptions tests should generate correct me
             }
         }
     },
-    \\"enums\\": {},
+    \\"enums\\": {
+        \\"BillingSource\\": {
+            \\"name\\": \\"BillingSource\\",
+            \\"values\\": [
+                \\"CLIENT\\",
+                \\"PROJECT\\"
+            ]
+        }
+    },
     \\"nonModels\\": {
         \\"Phone\\": {
             \\"name\\": \\"Phone\\",
@@ -1742,6 +1750,39 @@ exports[`Custom queries/mutations/subscriptions tests should generate correct me
                     \\"isRequired\\": false
                 }
             }
+        },
+        \\"echo5\\": {
+            \\"name\\": \\"echo5\\",
+            \\"isArray\\": false,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": false,
+            \\"arguments\\": {
+                \\"input\\": {
+                    \\"name\\": \\"input\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"input\\": \\"EchoInput\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"isArrayNullable\\": true
+                }
+            }
+        },
+        \\"echo6\\": {
+            \\"name\\": \\"echo6\\",
+            \\"isArray\\": false,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": true,
+            \\"arguments\\": {
+                \\"customInput\\": {
+                    \\"name\\": \\"customInput\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"input\\": \\"CustomInput\\"
+                    },
+                    \\"isRequired\\": false
+                }
+            }
         }
     },
     \\"mutations\\": {
@@ -1772,6 +1813,57 @@ exports[`Custom queries/mutations/subscriptions tests should generate correct me
             },
             \\"isRequired\\": true,
             \\"isArrayNullable\\": true,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
+                }
+            }
+        }
+    },
+    \\"inputs\\": {
+        \\"CustomInput\\": {
+            \\"name\\": \\"CustomInput\\",
+            \\"arguments\\": {
+                \\"customField1\\": {
+                    \\"name\\": \\"customField1\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true
+                },
+                \\"customField2\\": {
+                    \\"name\\": \\"customField2\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"enum\\": \\"BillingSource\\"
+                    },
+                    \\"isRequired\\": true
+                },
+                \\"customField3\\": {
+                    \\"name\\": \\"customField3\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"input\\": \\"NestedInput\\"
+                    },
+                    \\"isRequired\\": true
+                }
+            }
+        },
+        \\"NestedInput\\": {
+            \\"name\\": \\"NestedInput\\",
+            \\"arguments\\": {
+                \\"content\\": {
+                    \\"name\\": \\"content\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": true
+                }
+            }
+        },
+        \\"EchoInput\\": {
+            \\"name\\": \\"EchoInput\\",
             \\"arguments\\": {
                 \\"msg\\": {
                     \\"name\\": \\"msg\\",
@@ -2025,6 +2117,19 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                     \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"isArrayNullable\\": true
+                }
+            }
+        }
+    },
+    \\"inputs\\": {
+        \\"SimpleInput\\": {
+            \\"name\\": \\"SimpleInput\\",
+            \\"arguments\\": {
+                \\"name\\": {
+                    \\"name\\": \\"name\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"String\\",
+                    \\"isRequired\\": false
                 }
             }
         }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1797,6 +1797,104 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"isRequired\\": false
                 }
             }
+        },
+        \\"echo8\\": {
+            \\"name\\": \\"echo8\\",
+            \\"isArray\\": true,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": false,
+            \\"isArrayNullable\\": true,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"Float\\",
+                    \\"isRequired\\": false,
+                    \\"isArrayNullable\\": true
+                },
+                \\"msg2\\": {
+                    \\"name\\": \\"msg2\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"Int\\",
+                    \\"isRequired\\": true,
+                    \\"isArrayNullable\\": true
+                },
+                \\"enumType\\": {
+                    \\"name\\": \\"enumType\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"enum\\": \\"BillingSource\\"
+                    },
+                    \\"isRequired\\": false
+                },
+                \\"enumList\\": {
+                    \\"name\\": \\"enumList\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"enum\\": \\"BillingSource\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"isArrayNullable\\": true
+                },
+                \\"inputType\\": {
+                    \\"name\\": \\"inputType\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"input\\": \\"CustomInput\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"isArrayNullable\\": true
+                }
+            }
+        },
+        \\"echo9\\": {
+            \\"name\\": \\"echo9\\",
+            \\"isArray\\": true,
+            \\"type\\": \\"String\\",
+            \\"isRequired\\": true,
+            \\"isArrayNullable\\": false,
+            \\"arguments\\": {
+                \\"msg\\": {
+                    \\"name\\": \\"msg\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"Float\\",
+                    \\"isRequired\\": false,
+                    \\"isArrayNullable\\": false
+                },
+                \\"msg2\\": {
+                    \\"name\\": \\"msg2\\",
+                    \\"isArray\\": true,
+                    \\"type\\": \\"Int\\",
+                    \\"isRequired\\": true,
+                    \\"isArrayNullable\\": false
+                },
+                \\"enumType\\": {
+                    \\"name\\": \\"enumType\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"enum\\": \\"BillingSource\\"
+                    },
+                    \\"isRequired\\": true
+                },
+                \\"enumList\\": {
+                    \\"name\\": \\"enumList\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"enum\\": \\"BillingSource\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"isArrayNullable\\": false
+                },
+                \\"inputType\\": {
+                    \\"name\\": \\"inputType\\",
+                    \\"isArray\\": true,
+                    \\"type\\": {
+                        \\"input\\": \\"CustomInput\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"isArrayNullable\\": false
+                }
+            }
         }
     },
     \\"mutations\\": {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1782,15 +1782,6 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                 }
             }
         },
-        \\"echo5\\": {
-            \\"name\\": \\"echo5\\",
-            \\"isArray\\": true,
-            \\"type\\": {
-                \\"union\\": \\"CustomUnion\\"
-            },
-            \\"isRequired\\": true,
-            \\"isArrayNullable\\": false
-        },
         \\"echo6\\": {
             \\"name\\": \\"echo6\\",
             \\"isArray\\": false,
@@ -1806,15 +1797,6 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"isRequired\\": false
                 }
             }
-        },
-        \\"echo7\\": {
-            \\"name\\": \\"echo7\\",
-            \\"isArray\\": true,
-            \\"type\\": {
-                \\"interface\\": \\"ICustom\\"
-            },
-            \\"isRequired\\": false,
-            \\"isArrayNullable\\": false
         }
     },
     \\"mutations\\": {
@@ -1919,16 +1901,6 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": false,
                     \\"attributes\\": []
-                },
-                \\"birthdays\\": {
-                    \\"name\\": \\"birthdays\\",
-                    \\"isArray\\": true,
-                    \\"type\\": {
-                        \\"interface\\": \\"INestedCustom\\"
-                    },
-                    \\"isRequired\\": true,
-                    \\"attributes\\": [],
-                    \\"isArrayNullable\\": false
                 }
             }
         },

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1874,48 +1874,6 @@ exports[`Custom queries/mutations/subscriptions & input type tests should genera
                 }
             }
         }
-    },
-    \\"unions\\": {
-        \\"CustomUnion\\": {
-            \\"name\\": \\"CustomUnion\\",
-            \\"typeNames\\": [
-                \\"Todo\\",
-                \\"Phone\\"
-            ]
-        }
-    },
-    \\"interfaces\\": {
-        \\"ICustom\\": {
-            \\"name\\": \\"ICustom\\",
-            \\"fields\\": {
-                \\"firstName\\": {
-                    \\"name\\": \\"firstName\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                },
-                \\"lastName\\": {
-                    \\"name\\": \\"lastName\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": false,
-                    \\"attributes\\": []
-                }
-            }
-        },
-        \\"INestedCustom\\": {
-            \\"name\\": \\"INestedCustom\\",
-            \\"fields\\": {
-                \\"birthDay\\": {
-                    \\"name\\": \\"birthDay\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"AWSDate\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
-                }
-            }
-        }
     }
 }"
 `;
@@ -2173,32 +2131,6 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                     \\"isArray\\": false,
                     \\"type\\": \\"String\\",
                     \\"isRequired\\": false
-                }
-            }
-        }
-    },
-    \\"unions\\": {
-        \\"SimpleUnion\\": {
-            \\"name\\": \\"SimpleUnion\\",
-            \\"typeNames\\": [
-                \\"SimpleModel\\",
-                \\"SimpleEnum\\",
-                \\"SimpleNonModelType\\",
-                \\"SimpleInput\\",
-                \\"SimpleInterface\\"
-            ]
-        }
-    },
-    \\"interfaces\\": {
-        \\"SimpleInterface\\": {
-            \\"name\\": \\"SimpleInterface\\",
-            \\"fields\\": {
-                \\"firstName\\": {
-                    \\"name\\": \\"firstName\\",
-                    \\"isArray\\": false,
-                    \\"type\\": \\"String\\",
-                    \\"isRequired\\": true,
-                    \\"attributes\\": []
                 }
             }
         }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-visitor.test.ts.snap
@@ -1,0 +1,308 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AppSyncModelVisitor Other GraphQL types shoud support query, mutation and subscription types 1`] = `
+Object {
+  "echo": Object {
+    "baseType": "String",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": true,
+    "name": "echo",
+    "operationType": "query",
+    "parameters": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "msg",
+        "type": "String",
+      },
+    ],
+    "type": "String",
+  },
+  "echo2": Object {
+    "baseType": "Todo",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": true,
+    "name": "echo2",
+    "operationType": "query",
+    "parameters": Array [
+      Object {
+        "baseType": "ID",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "todoId",
+        "type": "ID",
+      },
+    ],
+    "type": "Todo",
+  },
+  "echo3": Object {
+    "baseType": "Todo",
+    "directives": Array [],
+    "isList": true,
+    "isListNullable": false,
+    "isNullable": false,
+    "name": "echo3",
+    "operationType": "query",
+    "parameters": Array [],
+    "type": "Todo",
+  },
+  "echo4": Object {
+    "baseType": "Phone",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": true,
+    "name": "echo4",
+    "operationType": "query",
+    "parameters": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "number",
+        "type": "String",
+      },
+    ],
+    "type": "Phone",
+  },
+  "echo5": Object {
+    "baseType": "CustomUnion",
+    "directives": Array [],
+    "isList": true,
+    "isListNullable": false,
+    "isNullable": false,
+    "name": "echo5",
+    "operationType": "query",
+    "parameters": Array [],
+    "type": "CustomUnion",
+  },
+  "echo6": Object {
+    "baseType": "String",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": false,
+    "name": "echo6",
+    "operationType": "query",
+    "parameters": Array [
+      Object {
+        "baseType": "CustomInput",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "customInput",
+        "type": "CustomInput",
+      },
+    ],
+    "type": "String",
+  },
+  "echo7": Object {
+    "baseType": "ICustom",
+    "directives": Array [],
+    "isList": true,
+    "isListNullable": false,
+    "isNullable": true,
+    "name": "echo7",
+    "operationType": "query",
+    "parameters": Array [],
+    "type": "ICustom",
+  },
+  "getAllTodo": Object {
+    "baseType": "String",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": true,
+    "name": "getAllTodo",
+    "operationType": "query",
+    "parameters": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "msg",
+        "type": "String",
+      },
+      Object {
+        "baseType": "CustomInput",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "input",
+        "type": "CustomInput",
+      },
+    ],
+    "type": "String",
+  },
+}
+`;
+
+exports[`AppSyncModelVisitor Other GraphQL types shoud support query, mutation and subscription types 2`] = `
+Object {
+  "mutate": Object {
+    "baseType": "Todo",
+    "directives": Array [],
+    "isList": false,
+    "isNullable": true,
+    "name": "mutate",
+    "operationType": "mutation",
+    "parameters": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": true,
+        "isListNullable": false,
+        "isNullable": false,
+        "name": "msg",
+        "type": "String",
+      },
+    ],
+    "type": "Todo",
+  },
+}
+`;
+
+exports[`AppSyncModelVisitor Other GraphQL types shoud support query, mutation and subscription types 3`] = `
+Object {
+  "onMutate": Object {
+    "baseType": "Todo",
+    "directives": Array [],
+    "isList": true,
+    "isListNullable": true,
+    "isNullable": false,
+    "name": "onMutate",
+    "operationType": "subscription",
+    "parameters": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "msg",
+        "type": "String",
+      },
+    ],
+    "type": "Todo",
+  },
+}
+`;
+
+exports[`AppSyncModelVisitor Other GraphQL types should support input types 1`] = `
+Object {
+  "CustomInput": Object {
+    "inputValues": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "customField1",
+        "type": "String",
+      },
+      Object {
+        "baseType": "BillingSource",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "customField2",
+        "type": "BillingSource",
+      },
+      Object {
+        "baseType": "NestedInput",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "customField3",
+        "type": "NestedInput",
+      },
+    ],
+    "name": "CustomInput",
+    "type": "input",
+  },
+  "NestedInput": Object {
+    "inputValues": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "content",
+        "type": "String",
+      },
+    ],
+    "name": "NestedInput",
+    "type": "input",
+  },
+}
+`;
+
+exports[`AppSyncModelVisitor Other GraphQL types should support interface types 1`] = `
+Object {
+  "ICustom": Object {
+    "fields": Array [
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "firstName",
+        "parameters": Array [],
+        "type": "String",
+      },
+      Object {
+        "baseType": "String",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": true,
+        "name": "lastName",
+        "parameters": Array [],
+        "type": "String",
+      },
+      Object {
+        "baseType": "INestedCustom",
+        "directives": Array [],
+        "isList": true,
+        "isListNullable": false,
+        "isNullable": false,
+        "name": "birthdays",
+        "parameters": Array [],
+        "type": "INestedCustom",
+      },
+    ],
+    "name": "ICustom",
+    "type": "interface",
+  },
+  "INestedCustom": Object {
+    "fields": Array [
+      Object {
+        "baseType": "AWSDate",
+        "directives": Array [],
+        "isList": false,
+        "isNullable": false,
+        "name": "birthDay",
+        "parameters": Array [],
+        "type": "AWSDate",
+      },
+    ],
+    "name": "INestedCustom",
+    "type": "interface",
+  },
+}
+`;
+
+exports[`AppSyncModelVisitor Other GraphQL types should support union types 1`] = `
+Object {
+  "CustomUnion": Object {
+    "name": "CustomUnion",
+    "type": "union",
+    "typeNames": Array [
+      "Todo",
+      "Phone",
+    ],
+  },
+}
+`;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -54,6 +54,10 @@ describe('Model Introspection Visitor', () => {
     input SimpleInput {
       name: String
     }
+    interface SimpleInterface {
+      firstName: String!
+    }
+    union SimpleUnion = SimpleModel | SimpleEnum | SimpleNonModelType | SimpleInput | SimpleInterface
   `;
   const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema);
   describe('getType', () => {
@@ -71,6 +75,14 @@ describe('Model Introspection Visitor', () => {
 
     it('should return input type for Input', () => {
       expect((visitor as any).getType('SimpleInput')).toEqual({ input: 'SimpleInput' });
+    });
+
+    it('should return union type for Union', () => {
+      expect((visitor as any).getType('SimpleUnion')).toEqual({ union: 'SimpleUnion' });
+    });
+
+    it('should return interface type for Interface', () => {
+      expect((visitor as any).getType('SimpleInterface')).toEqual({ interface: 'SimpleInterface' });
     });
 
     it('should throw error for unknown type', () => {
@@ -283,11 +295,13 @@ describe('schemas with pk on a belongsTo fk', () => {
 
 describe('Custom queries/mutations/subscriptions & input type tests', () => {
   const schema = /* GraphQL */ `
-    input AMPLIFY { globalAuthRule: AuthRule = { allow: public } }
+    input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!
+
     type Todo @model {
       id: ID!
       name: String!
       description: String
+      phone: Phone
     }
     type Phone {
       number: String
@@ -298,22 +312,32 @@ describe('Custom queries/mutations/subscriptions & input type tests', () => {
     }
     input CustomInput {
       customField1: String!
-      customField2: BillingSource!
+      customField2: Int
       customField3: NestedInput!
     }
     input NestedInput {
       content: String! = "hello"
     }
-    input EchoInput {
-      msg: String
+    interface ICustom {
+      firstName: String!
+      lastName: String
+      birthdays: [INestedCustom!]!
     }
+    interface INestedCustom {
+      birthDay: AWSDate!
+    }
+    # The member types of a Union type must all be Object base types.
+    union CustomUnion = Todo | Phone
+    
     type Query {
+      getAllTodo(msg: String, input: CustomInput): String
       echo(msg: String): String
       echo2(todoId: ID!): Todo
-      echo3: [Todo]
+      echo3: [Todo!]!
       echo4(number: String): Phone
-      echo5(input: [EchoInput]): String
+      echo5: [CustomUnion!]!
       echo6(customInput: CustomInput): String!
+      echo7: [ICustom]!
     }
     type Mutation {
       mutate(msg: [String!]!): Todo

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -51,6 +51,9 @@ describe('Model Introspection Visitor', () => {
       id: ID!
       names: [String]
     }
+    input SimpleInput {
+      name: String
+    }
   `;
   const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema);
   describe('getType', () => {
@@ -64,6 +67,10 @@ describe('Model Introspection Visitor', () => {
 
     it('should return NonModel type for Non-model', () => {
       expect((visitor as any).getType('SimpleNonModelType')).toEqual({ nonModel: 'SimpleNonModelType' });
+    });
+
+    it('should return input type for Input', () => {
+      expect((visitor as any).getType('SimpleInput')).toEqual({ input: 'SimpleInput' });
     });
 
     it('should throw error for unknown type', () => {
@@ -274,8 +281,9 @@ describe('schemas with pk on a belongsTo fk', () => {
   });
 });
 
-describe('Custom queries/mutations/subscriptions tests', () => {
+describe('Custom queries/mutations/subscriptions & input type tests', () => {
   const schema = /* GraphQL */ `
+    input AMPLIFY { globalAuthRule: AuthRule = { allow: public } }
     type Todo @model {
       id: ID!
       name: String!
@@ -284,11 +292,28 @@ describe('Custom queries/mutations/subscriptions tests', () => {
     type Phone {
       number: String
     }
+    enum BillingSource {
+      CLIENT
+      PROJECT
+    }
+    input CustomInput {
+      customField1: String!
+      customField2: BillingSource!
+      customField3: NestedInput!
+    }
+    input NestedInput {
+      content: String! = "hello"
+    }
+    input EchoInput {
+      msg: String
+    }
     type Query {
       echo(msg: String): String
       echo2(todoId: ID!): Todo
       echo3: [Todo]
       echo4(number: String): Phone
+      echo5(input: [EchoInput]): String
+      echo6(customInput: CustomInput): String!
     }
     type Mutation {
       mutate(msg: [String!]!): Todo

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -341,9 +341,13 @@ describe('Custom queries/mutations/subscriptions & input type tests', () => {
     }
     type Mutation {
       mutate(msg: [String!]!): Todo
+      mutate2: [CustomUnion!]!
+      mutate3: [ICustom]!
     }
     type Subscription {
       onMutate(msg: String): [Todo!]
+      onMutate2: CustomUnion
+      onMutate3: ICustom
     }
   `;
   it('should generate correct metadata for custom queries/mutations/subscriptions in model introspection schema', () => {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -338,6 +338,8 @@ describe('Custom queries/mutations/subscriptions & input type tests', () => {
       echo5: [CustomUnion!]!
       echo6(customInput: CustomInput): String!
       echo7: [ICustom]!
+      echo8(msg: [Float], msg2: [Int!], enumType: BillingSource, enumList: [BillingSource], inputType: [CustomInput]): [String]
+      echo9(msg: [Float]!, msg2: [Int!]!, enumType: BillingSource!, enumList: [BillingSource!]!, inputType: [CustomInput!]!): [String!]!    
     }
     type Mutation {
       mutate(msg: [String!]!): Todo

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-visitor.test.ts
@@ -1322,4 +1322,75 @@ describe('AppSyncModelVisitor', () => {
       expect(projectTeamNameField.type).toBe('String');
     });
   });
+  
+  describe('Other GraphQL types', () => {
+    const schema = /* GraphQL*/ `
+      input AMPLIFY { globalAuthRule: AuthRule = { allow: public } } # FOR TESTING ONLY!
+
+      type Todo @model {
+        id: ID!
+        name: String!
+        description: String
+        phone: Phone
+      }
+      type Phone {
+        number: String
+      }
+      enum BillingSource {
+        CLIENT
+        PROJECT
+      }
+      input CustomInput {
+        customField1: String!
+        customField2: BillingSource
+        customField3: NestedInput!
+      }
+      input NestedInput {
+        content: String! = "hello"
+      }
+      interface ICustom {
+        firstName: String!
+        lastName: String
+        birthdays: [INestedCustom!]!
+      }
+      interface INestedCustom {
+        birthDay: AWSDate!
+      }
+      # The member types of a Union type must all be Object base types.
+      union CustomUnion = Todo | Phone
+      
+      type Query {
+        getAllTodo(msg: String, input: CustomInput): String
+        echo(msg: String): String
+        echo2(todoId: ID!): Todo
+        echo3: [Todo!]!
+        echo4(number: String): Phone
+        echo5: [CustomUnion!]!
+        echo6(customInput: CustomInput): String!
+        echo7: [ICustom]!
+      }
+      type Mutation {
+        mutate(msg: [String!]!): Todo
+      }
+      type Subscription {
+        onMutate(msg: String): [Todo!]
+      }
+    `;
+    const { queries, mutations, subscriptions, inputs, unions, interfaces }
+      = createAndGenerateVisitor(schema, { usePipelinedTransformer: true, respectPrimaryKeyAttributesOnConnectionField: true, transformerVersion: 2 });
+    it('shoud support query, mutation and subscription types', () => {
+      expect(queries).toMatchSnapshot();
+      expect(mutations).toMatchSnapshot();
+      expect(subscriptions).toMatchSnapshot();
+    });
+    it('should support input types', () => {
+      expect(inputs).toMatchSnapshot();
+    });
+    it('should support union types', () => {
+      expect(unions).toMatchSnapshot();
+    });
+    it('should support interface types', () => {
+      expect(interfaces).toMatchSnapshot();
+    });
+  })
 });

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -10,8 +10,6 @@
   mutations?: SchemaMutations;
   subscriptions?: SchemaSubscriptions;
   inputs?: SchemaInputs;
-  unions?: SchemaUnions;
-  interfaces?: SchemaInterfaces;
 };
 /**
  * Top-level Entities on a Schema
@@ -23,8 +21,6 @@ export type SchemaQueries = Record<string, SchemaQuery>;
 export type SchemaMutations = Record<string, SchemaMutation>;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 export type SchemaInputs = Record<string, Input>;
-export type SchemaUnions = Record<string, Union>;
-export type SchemaInterfaces = Record<string, Interface>;
 
 export type SchemaModel = {
   name: string;
@@ -91,22 +87,6 @@ export type Input = {
   name: string;
   attributes: Arguments;
 }
-/**
- * Interface Definition
- */
-export type Interface = {
-  name: string;
-  fields: Fields;
-}
-export type InterfaceFieldType = { interface: string }
-/**
- * Union Definition
- */
-export type Union = {
-  name: string;
-  typeNames: string[];
-}
-export type UnionFieldType = { union: string }
 /**
  * Field-level Relationship Definitions
  */

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -62,7 +62,7 @@ export type Field = {
   association?: AssociationType;
   arguments?: Arguments;
 };
-export type FieldType = 'ID'
+export type ScalarType = 'ID'
   | 'String'
   | 'Int'
   | 'Float'
@@ -75,7 +75,11 @@ export type FieldType = 'ID'
   | 'AWSIPAddress'
   | 'Boolean'
   | 'AWSJSON'
-  | 'AWSPhone'
+  | 'AWSPhone';
+export type InputFieldType = ScalarType
+  | { enum: string }
+  | { input: string };
+export type FieldType = ScalarType
   | { enum: string }
   | { model: string }
   | { nonModel: string }
@@ -142,7 +146,7 @@ export type PrimaryKeyInfo = {
 export type Arguments = Record<string, Argument>;
 export type Argument = {
   name: string;
-  type: FieldType;
+  type: InputFieldType;
   isArray: boolean;
   isRequired: boolean;
   isArrayNullable?: boolean;

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -9,6 +9,7 @@
   queries?: SchemaQueries;
   mutations?: SchemaMutations;
   subscriptions?: SchemaSubscriptions;
+  inputs?: SchemaInputs;
 };
 /**
  * Top-level Entities on a Schema
@@ -19,6 +20,7 @@ export type SchemaEnums = Record<string, SchemaEnum>;
 export type SchemaQueries = Record<string, SchemaQuery>;
 export type SchemaMutations = Record<string, SchemaMutation>;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
+export type SchemaInputs = Record<string, Input>
 
 export type SchemaModel = {
   name: string;
@@ -72,8 +74,16 @@ export type FieldType = 'ID'
   | 'AWSPhone'
   | { enum: string }
   | { model: string }
-  | { nonModel: string };
+  | { nonModel: string }
+  | { input: string };
 export type FieldAttribute = ModelAttribute;
+/**
+ * Input Definition
+ */
+export type Input = {
+  name: string;
+  arguments: Arguments;
+}
 /**
  * Field-level Relationship Definitions
  */

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -10,6 +10,8 @@
   mutations?: SchemaMutations;
   subscriptions?: SchemaSubscriptions;
   inputs?: SchemaInputs;
+  unions?: SchemaUnions;
+  interfaces?: SchemaInterfaces;
 };
 /**
  * Top-level Entities on a Schema
@@ -20,7 +22,9 @@ export type SchemaEnums = Record<string, SchemaEnum>;
 export type SchemaQueries = Record<string, SchemaQuery>;
 export type SchemaMutations = Record<string, SchemaMutation>;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
-export type SchemaInputs = Record<string, Input>
+export type SchemaInputs = Record<string, Input>;
+export type SchemaUnions = Record<string, Union>;
+export type SchemaInterfaces = Record<string, Interface>
 
 export type SchemaModel = {
   name: string;
@@ -75,7 +79,9 @@ export type FieldType = 'ID'
   | { enum: string }
   | { model: string }
   | { nonModel: string }
-  | { input: string };
+  | { input: string }
+  | { union: string }
+  | { interface: string };
 export type FieldAttribute = ModelAttribute;
 /**
  * Input Definition
@@ -83,6 +89,20 @@ export type FieldAttribute = ModelAttribute;
 export type Input = {
   name: string;
   arguments: Arguments;
+}
+/**
+ * Interface Definition
+ */
+export type Interface = {
+  name: string;
+  fields: Fields;
+}
+/**
+ * Union Definition
+ */
+export type Union = {
+  name: string;
+  typeNames: string[];
 }
 /**
  * Field-level Relationship Definitions

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -82,10 +82,7 @@ export type InputFieldType = ScalarType
 export type FieldType = ScalarType
   | { enum: string }
   | { model: string }
-  | { nonModel: string }
-  | { input: string }
-  | { union: string }
-  | { interface: string };
+  | { nonModel: string };
 export type FieldAttribute = ModelAttribute;
 /**
  * Input Definition
@@ -101,6 +98,7 @@ export type Interface = {
   name: string;
   fields: Fields;
 }
+export type InterfaceFieldType = { interface: string }
 /**
  * Union Definition
  */
@@ -108,6 +106,7 @@ export type Union = {
   name: string;
   typeNames: string[];
 }
+export type UnionFieldType = { union: string }
 /**
  * Field-level Relationship Definitions
  */

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -24,7 +24,7 @@ export type SchemaMutations = Record<string, SchemaMutation>;
 export type SchemaSubscriptions = Record<string, SchemaSubscription>;
 export type SchemaInputs = Record<string, Input>;
 export type SchemaUnions = Record<string, Union>;
-export type SchemaInterfaces = Record<string, Interface>
+export type SchemaInterfaces = Record<string, Interface>;
 
 export type SchemaModel = {
   name: string;

--- a/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
+++ b/packages/appsync-modelgen-plugin/src/interfaces/introspection/model-schema.ts
@@ -89,7 +89,7 @@ export type FieldAttribute = ModelAttribute;
  */
 export type Input = {
   name: string;
-  arguments: Arguments;
+  attributes: Arguments;
 }
 /**
  * Interface Definition

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -203,7 +203,7 @@ export class AppSyncModelIntrospectionVisitor<
   private generateGraphQLInputMetadata(inputObj: CodeGenInputObject): Input {
     return {
       name: inputObj.name,
-      arguments: inputObj.inputValues.reduce((acc, param ) => {
+      attributes: inputObj.inputValues.reduce((acc, param ) => {
         const arg: Argument = {
           name: param.name,
           isArray: param.isList,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SCALARS, NormalizedScalarsMap } from "@graphql-codegen/visitor-plugin-common";
 import { GraphQLSchema } from "graphql";
-import { Argument, AssociationType, Field, Fields, FieldType, ModelAttribute, ModelIntrospectionSchema, PrimaryKeyInfo, SchemaEnum, SchemaModel, SchemaMutation, SchemaNonModel, SchemaQuery, SchemaSubscription, Input, Union, Interface } from "../interfaces/introspection";
+import { Argument, AssociationType, Field, Fields, FieldType, ModelAttribute, ModelIntrospectionSchema, PrimaryKeyInfo, SchemaEnum, SchemaModel, SchemaMutation, SchemaNonModel, SchemaQuery, SchemaSubscription, Input, Union, Interface, InputFieldType } from "../interfaces/introspection";
 import { METADATA_SCALAR_MAP } from "../scalars";
 import { CodeGenConnectionType } from "../utils/process-connections";
 import { RawAppSyncModelConfig, ParsedAppSyncModelConfig, AppSyncModelVisitor, CodeGenEnum, CodeGenField, CodeGenModel, CodeGenPrimaryKeyType, CodeGenQuery, CodeGenSubscription, CodeGenMutation, CodeGenInputObject, CodeGenUnion, CodeGenInterface } from "./appsync-visitor";
@@ -183,7 +183,7 @@ export class AppSyncModelIntrospectionVisitor<
         const arg: Argument = {
           name: param.name,
           isArray: param.isList,
-          type: this.getType(param.type),
+          type: this.getType(param.type) as InputFieldType,
           isRequired: !param.isNullable
         };
         if (param.isListNullable !== undefined) {
@@ -256,7 +256,7 @@ export class AppSyncModelIntrospectionVisitor<
         const arg: Argument = {
           name: param.name,
           isArray: param.isList,
-          type: this.getType(param.type),
+          type: this.getType(param.type) as InputFieldType,
           isRequired: !param.isNullable
         };
         if (param.isListNullable !== undefined) {
@@ -268,7 +268,7 @@ export class AppSyncModelIntrospectionVisitor<
     return operationMeta as V;
   }
 
-  protected getType(gqlType: string): FieldType {
+  protected getType(gqlType: string): FieldType | InputFieldType {
     // Todo: Handle unlisted scalars
     if (gqlType in METADATA_SCALAR_MAP) {
       return METADATA_SCALAR_MAP[gqlType] as FieldType;
@@ -291,8 +291,7 @@ export class AppSyncModelIntrospectionVisitor<
     if (gqlType in this.interfaceMap) {
       return { interface: gqlType }
     }
-
-    throw new Error(`Unknown type ${gqlType}`);
+    throw new Error(`Unknown type ${gqlType} found during model introspection schema generation`);
   }
 
   private generateModelPrimaryKeyInfo(model: CodeGenModel): PrimaryKeyInfo {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -280,8 +280,7 @@ export class AppSyncModelVisitor<
   protected mutationMap: CodeGenMutationMap = {};
   protected subscriptionMap: CodeGenSubscriptionMap = {};
   protected inputObjectMap: CodeGenInputObjectMap = {};
-  protected typesToSkip: string[] = [];
-  protected inputTypesToSkip: string[] = ['AMPLIFY'];
+  protected typesToSkip: string[] = ['AMPLIFY'];
   constructor(
     protected _schema: GraphQLSchema,
     rawConfig: TRawConfig,
@@ -313,7 +312,6 @@ export class AppSyncModelVisitor<
       });
     }
 
-    this.typesToSkip = [];
     this.typesToSkip.push(...typesUsedInDirectives);
   }
 
@@ -391,7 +389,7 @@ export class AppSyncModelVisitor<
   }
 
   InputObjectTypeDefinition(node: InputObjectTypeDefinitionNode) {
-    if (this.inputTypesToSkip.includes(node.name.value)) {
+    if (this.typesToSkip.includes(node.name.value)) {
       return;
     }
     const inputValues = (node.fields as unknown) as CodeGenInputValue[];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->
#### Description of changes
The `input`, `union` and `interface` types are correctly processed by the base visitor when it is defined in the GQL schema. The union and interface IR, however, will not be processed into the output of MIS 

### Codegen Parameters Changed or Added
The type of model schema is changed
```TypeScript
export type ModelIntrospectionSchema = {
  version: 1;
  models: SchemaModels;
  nonModels: SchemaNonModels;
  enums: SchemaEnums;
  queries?: SchemaQueries;
  mutations?: SchemaMutations;
  subscriptions?: SchemaSubscriptions;
  // new root level optional attribute
  inputs?: SchemaInputs 
};

// New type definitions
export type SchemaInputs = Record<string, Input>;

export type Input = {
   name: string;
   arguments: Arguments
}

// Fine-grained field type
export type ScalarType = 'ID'
  | 'String'
  | 'Int'
  | 'Float'
  | 'AWSDate'
  | 'AWSTime'
  | 'AWSDateTime'
  | 'AWSTimestamp'
  | 'AWSEmail'
  | 'AWSURL'
  | 'AWSIPAddress'
  | 'Boolean'
  | 'AWSJSON'
  | 'AWSPhone';

export type InputFieldType = ScalarType
  | { enum: string }
  | { input: string };

export type FieldType = ScalarType
  | { enum: string }
  | { model: string }
  | { nonModel: string };

// Change argument field type
export Argument = {
  ...,
  type: InputFieldType
}
```

### `Input` Example
Given the GraphQL schema in SDL
```GraphQL
input CustomInput {
    customField1: String!
    customField2: BillingSource!
    customField3: NestedInput!
}
input NestedInput {
    content: String!
}
enum BillingSource {
    CLIENT
    PROJECT
}
type Query {
  echo(myInput: CustomInput): String!
}
```
The corresponding part will be generated in model introspection schema
```JSON
{
    "queries": {
        "echo": {
            "name": "echo",
            "isArray": false,
            "type": "String",
            "isRequired": true,
            "arguments": {
                "myInput": {
                    "name": "myInput",
                    "isArray": false,
                    "type": {
                        "input": "CustomInput"
                    },
                    "isRequired": false
                }
            }
        }
    },
    "inputs": {
        "CustomInput": {
            "name": "CustomInput",
            "arguments": {
                "customField1": {
                    "name": "customField1",
                    "isArray": false,
                    "type": "String",
                    "isRequired": true
                },
                "customField2": {
                    "name": "customField2",
                    "isArray": false,
                    "type": {
                        "enum": "BillingSource"
                    },
                    "isRequired": true
                },
                "customField3": {
                    "name": "customField3",
                    "isArray": false,
                    "type": {
                        "input": "NestedInput"
                    },
                    "isRequired": true
                }
            }
        },
        "NestedInput": {
            "name": "NestedInput",
            "arguments": {
                "content": {
                    "name": "content",
                    "isArray": false,
                    "type": "String",
                    "isRequired": true
                }
            }
        }
    },
    "enums": {
        "BillingSource": {
            "name": "BillingSource",
            "values": [
                "CLIENT",
                "PROJECT"
            ]
        }
    },
}
```

### `Union` & `Interface` 
Union and Interface types will not be generated in the MIS json file. The fields with these types will be omitted when they present in type definition. They can still be recognized as it is being processed in the base visitor

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->


<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
Fix https://github.com/aws-amplify/amplify-codegen/issues/794
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
