### PR TITLE
fix: use correct hasOne on swift references

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1388,8 +1388,8 @@ extension Foo {
     
     model.fields(
       .field(foo.id, is: .required, ofType: .string),
-      .field(foo.bar1, is: .optional, ofType: .model(Bar.self)),
-      .field(foo.bar2, is: .optional, ofType: .model(Bar.self)),
+      .hasOne(foo.bar1, is: .optional, ofType: Bar.self, associatedWith: Bar.keys.bar1Id),
+      .hasOne(foo.bar2, is: .optional, ofType: Bar.self, associatedWith: Bar.keys.bar2Id),
       .field(foo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(foo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1973,7 +1973,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .field(primary.related, is: .optional, ofType: .model(Related.self)),
+      .hasOne(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primaryTenantId),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2507,7 +2507,7 @@ extension Primary {
     model.fields(
       .field(primary.id, is: .required, ofType: .string),
       .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedWith: RelatedMany.keys.primaryId),
-      .field(primary.relatedOne, is: .optional, ofType: .model(RelatedOne.self)),
+      .hasOne(primary.relatedOne, is: .optional, ofType: RelatedOne.self, associatedWith: RelatedOne.keys.primaryId),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2879,7 +2879,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .field(sqlPrimary.related, is: .optional, ofType: .model(SqlRelated.self)),
+      .hasOne(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primaryId),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -624,13 +624,19 @@ export class AppSyncSwiftVisitor<
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
       }
-      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE && (connectionInfo.targetNames || connectionInfo.targetName)) {
-        const targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
-          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
-          : `targetName: "${connectionInfo.targetName}"`;
-        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
-          connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        if (connectionInfo.targetNames || connectionInfo.targetName) {
+          const targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
+            ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
+            : `targetName: "${connectionInfo.targetName}"`;
+          return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+            connectionInfo.connectedModel,
+          )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
+        } else {
+          return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+            connectionInfo.connectedModel,
+          )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        }
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         const targetNameAttrStr = this.isCustomPKEnabled()


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Include the `.hasOne` on `model` for swift when using references.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

Unit test

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
