### PR TITLE
fix!: use transformer version 2 by default

### DIFF
--- a/packages/graphql-generator/API.md
+++ b/packages/graphql-generator/API.md
@@ -25,7 +25,7 @@ export type GenerateModelsOptions = {
     generateIndexRules?: boolean;
     emitAuthProvider?: boolean;
     useExperimentalPipelinedTransformer?: boolean;
-    transformerVersion?: boolean;
+    transformerVersion?: number;
     respectPrimaryKeyAttributesOnConnectionField?: boolean;
     improvePluralization?: boolean;
     generateModelsForLazyLoadAndCustomSelectionSet?: boolean;

--- a/packages/graphql-generator/src/__tests__/__snapshots__/models.test.ts.snap
+++ b/packages/graphql-generator/src/__tests__/__snapshots__/models.test.ts.snap
@@ -2259,7 +2259,8 @@ extension Blog {
   public static let schema = defineSchema { model in
     let blog = Blog.keys
     
-    model.pluralName = \\"Blogs\\"
+    model.listPluralName = \\"Blogs\\"
+    model.syncPluralName = \\"Blogs\\"
     
     model.attributes(
       .primaryKey(fields: [blog.id])
@@ -2351,7 +2352,8 @@ extension Comment {
   public static let schema = defineSchema { model in
     let comment = Comment.keys
     
-    model.pluralName = \\"Comments\\"
+    model.listPluralName = \\"Comments\\"
+    model.syncPluralName = \\"Comments\\"
     
     model.attributes(
       .primaryKey(fields: [comment.id])
@@ -2468,7 +2470,8 @@ extension Post {
   public static let schema = defineSchema { model in
     let post = Post.keys
     
-    model.pluralName = \\"Posts\\"
+    model.listPluralName = \\"Posts\\"
+    model.syncPluralName = \\"Posts\\"
     
     model.attributes(
       .primaryKey(fields: [post.id])

--- a/packages/graphql-generator/src/models.ts
+++ b/packages/graphql-generator/src/models.ts
@@ -19,7 +19,7 @@ export async function generateModels(options: GenerateModelsOptions): Promise<Ge
     generateIndexRules = true,
     emitAuthProvider = true,
     useExperimentalPipelinedTransformer = true,
-    transformerVersion = true,
+    transformerVersion = 2,
     respectPrimaryKeyAttributesOnConnectionField = true,
     improvePluralization = false,
     generateModelsForLazyLoadAndCustomSelectionSet = true,

--- a/packages/graphql-generator/src/typescript.ts
+++ b/packages/graphql-generator/src/typescript.ts
@@ -27,7 +27,7 @@ export type GenerateModelsOptions = {
   generateIndexRules?: boolean;
   emitAuthProvider?: boolean;
   useExperimentalPipelinedTransformer?: boolean;
-  transformerVersion?: boolean;
+  transformerVersion?: number;
   respectPrimaryKeyAttributesOnConnectionField?: boolean;
   improvePluralization?: boolean;
   generateModelsForLazyLoadAndCustomSelectionSet?: boolean;


### PR DESCRIPTION
BREAKING CHANGE: use transformer version 2 by default in graphql-generator package

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

`transformerVersion` parameter had the wrong type. It was boolean instead of number. With the current default `true` the transformer version 1 was being used by default.

This means that gen 2 model generation is using has `transformerVersion` set to 1. Gen 1 is still using the cli.json feature flag which has explicitly set the version.

The parameter is used here: 
1. https://github.com/aws-amplify/amplify-codegen/blob/9f559413621dcc4a4a5158a129e575371c6d8c35/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts#L394
2. https://github.com/aws-amplify/amplify-codegen/blob/9f559413621dcc4a4a5158a129e575371c6d8c35/packages/appsync-modelgen-plugin/src/preset.ts#L325

This is a breaking change for the graphql-generator. This package is intended for internal use only.

We will still need to upgrade the package version in gen 1 and gen 2 CLI.

Gen 1 behavior will not change with this upgrade.

Gen 2 behavior will be breaking, but it is still pre-GA.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

* `transformerVersion` type changed to number.
* `transformerVersion` default changed to 2.

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* E2E tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
