### PR TITLE
fix: use associated fields for references on swift

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1388,8 +1388,8 @@ extension Foo {
     
     model.fields(
       .field(foo.id, is: .required, ofType: .string),
-      .field(foo.bar1, is: .optional, ofType: .model(Bar.self)),
-      .field(foo.bar2, is: .optional, ofType: .model(Bar.self)),
+      .hasOne(foo.bar1, is: .optional, ofType: Bar.self, associatedFields: [Bar.keys.bar1Id]),
+      .hasOne(foo.bar2, is: .optional, ofType: Bar.self, associatedFields: [Bar.keys.bar2Id]),
       .field(foo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(foo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1658,7 +1658,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primaryTenantId),
+      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primaryTenantId, Related.keys.primaryInstanceId, Related.keys.primaryRecordId],
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1973,7 +1973,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .field(primary.related, is: .optional, ofType: .model(Related.self)),
+      .hasOne(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primaryTenantId, Related.keys.primaryInstanceId, Related.keys.primaryRecordId]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2246,7 +2246,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primaryId),
+      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primaryId],
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2506,8 +2506,8 @@ extension Primary {
     
     model.fields(
       .field(primary.id, is: .required, ofType: .string),
-      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedWith: RelatedMany.keys.primaryId),
-      .field(primary.relatedOne, is: .optional, ofType: .model(RelatedOne.self)),
+      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedFields: [RelatedMany.keys.primaryId],
+      .hasOne(primary.relatedOne, is: .optional, ofType: RelatedOne.self, associatedFields: [RelatedOne.keys.primaryId]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2879,7 +2879,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .field(sqlPrimary.related, is: .optional, ofType: .model(SqlRelated.self)),
+      .hasOne(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primaryId]),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -25,12 +25,14 @@ export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
   targetName?: string; // Legacy field remained for backward compatability
   targetNames?: string[]; // New attribute for v2 custom pk support
+  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_MANY;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
+  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnection = CodeGenFieldConnectionBelongsTo | CodeGenFieldConnectionHasOne | CodeGenFieldConnectionHasMany;

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -41,6 +41,7 @@ export function processHasManyConnection(
       associatedWithFields,
       isConnectingFieldAutoCreated: false,
       connectedModel: otherSide,
+      isUsingReferences: true,
     };
   }
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -41,6 +41,7 @@ export function processHasOneConnection(
       associatedWithFields,
       connectedModel: otherSide,
       isConnectingFieldAutoCreated: false,
+      isUsingReferences: true,
     };
   } else if (isCustomPKEnabled) {
     associatedWithFields = getConnectedFieldsForHasOne(otherSideBelongsToField, otherSide, shouldUseFieldsInAssociatedWithInHasOne);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -620,17 +620,29 @@ export class AppSyncSwiftVisitor<
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
-        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+        let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        if (connectionInfo.isUsingReferences) {
+          association = `associatedFields: [${connectionInfo.associatedWithFields.map(field => this.getCodingKey(connectionInfo.connectedModel, field)).join(', ')}]`
+        }
+        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}`;
       }
-      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE && (connectionInfo.targetNames || connectionInfo.targetName)) {
-        const targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
-          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
-          : `targetName: "${connectionInfo.targetName}"`;
-        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
+        if (connectionInfo.isUsingReferences) {
+          association = `associatedFields: [${connectionInfo.associatedWithFields.map(field => this.getCodingKey(connectionInfo.connectedModel, field)).join(', ')}]`
+        }
+
+        let targetNameAttrStr = '';
+        if (connectionInfo.targetNames || connectionInfo.targetName) {
+          targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
+            ? `, targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
+            : `, targetName: "${connectionInfo.targetName}"`;
+        }
+        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}${targetNameAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         const targetNameAttrStr = this.isCustomPKEnabled()
@@ -814,5 +826,9 @@ export class AppSyncSwiftVisitor<
 
   protected hasReadOnlyFields(model: CodeGenModel): boolean {
     return model.fields.filter(f => f.isReadOnly).length !== 0;
+  }
+
+  private getCodingKey(model: CodeGenModel, field: CodeGenField): string {
+    return `${this.getModelName(model)}.keys.${this.getFieldName(field)}`;
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* Add `.hasOne` to relationships that use references on Swift.
* Fix relationship that use references to use `associatedFields` on Swift.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* Test in sample app

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
