### PR TITLE
fix: use associated fields for references for java and dart

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -11759,14 +11759,14 @@ class Foo extends amplify_core.Model {
       key: Foo.BAR1,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.BAR1ID
+      associatedKeys: [Bar.BAR1ID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Foo.BAR2,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.BAR2ID
+      associatedKeys: [Bar.BAR2ID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -12386,7 +12386,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: true,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARYTENANTID
+      associatedKeys: [Related.PRIMARYTENANTID, Related.PRIMARYINSTANCEID, Related.PRIMARYRECORDID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -13057,7 +13057,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: false,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARYTENANTID
+      associatedKeys: [Related.PRIMARYTENANTID, Related.PRIMARYINSTANCEID, Related.PRIMARYRECORDID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -13648,7 +13648,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: true,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARYID
+      associatedKeys: [SqlRelated.PRIMARYID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14170,14 +14170,14 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATEDMANY,
       isRequired: false,
       ofModelName: 'RelatedMany',
-      associatedKey: RelatedMany.PRIMARYID
+      associatedKeys: [RelatedMany.PRIMARYID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Primary.RELATEDONE,
       isRequired: false,
       ofModelName: 'RelatedOne',
-      associatedKey: RelatedOne.PRIMARYID
+      associatedKeys: [RelatedOne.PRIMARYID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14932,7 +14932,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: false,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARYID
+      associatedKeys: [SqlRelated.PRIMARYID]
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -7872,8 +7872,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Foo implements Model {
   public static final QueryField ID = field(\\"Foo\\", \\"id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar1Id\\", type = Bar.class) Bar bar1 = null;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar2Id\\", type = Bar.class) Bar bar2 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedFields = [\\"bar1Id\\"], type = Bar.class) Bar bar1 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedFields = [\\"bar2Id\\"], type = Bar.class) Bar bar2 = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -8319,7 +8319,7 @@ public final class Primary implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedWith = \\"primaryTenantId\\", type = Related.class) List<Related> related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedFields = [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"], type = Related.class) List<Related> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   private PrimaryIdentifier primaryIdentifier;
@@ -8885,7 +8885,7 @@ public final class Primary implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedWith = \\"primaryTenantId\\", type = Related.class) Related related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedFields = [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"], type = Related.class) Related related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   private PrimaryIdentifier primaryIdentifier;
@@ -9447,7 +9447,7 @@ public final class SqlPrimary implements Model {
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedWith = \\"primaryId\\", type = SqlRelated.class) List<SqlRelated> related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedFields = [\\"primaryId\\"], type = SqlRelated.class) List<SqlRelated> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -9889,8 +9889,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Primary implements Model {
   public static final QueryField ID = field(\\"Primary\\", \\"id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedWith = \\"primaryId\\", type = RelatedMany.class) List<RelatedMany> relatedMany = null;
-  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedWith = \\"primaryId\\", type = RelatedOne.class) RelatedOne relatedOne = null;
+  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedFields = [\\"primaryId\\"], type = RelatedMany.class) List<RelatedMany> relatedMany = null;
+  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedFields = [\\"primaryId\\"], type = RelatedOne.class) RelatedOne relatedOne = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -10505,7 +10505,7 @@ public final class SqlPrimary implements Model {
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedWith = \\"primaryId\\", type = SqlRelated.class) SqlRelated related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedFields = [\\"primaryId\\"], type = SqlRelated.class) SqlRelated related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -1006,24 +1006,36 @@ export class AppSyncModelDartVisitor<
         else if (field.connectionInfo) {
           const connectedModelName = this.getNativeType({ ...field, isList: false });
           switch (field.connectionInfo.kind) {
-            case CodeGenConnectionType.HAS_ONE:
+            case CodeGenConnectionType.HAS_ONE: {
+              let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
+              if (field.connectionInfo.isUsingReferences) {
+                const associatedFieldsString = field.connectionInfo.associatedWithFields.map(field => `${connectedModelName}.${this.getQueryFieldName(field)}`).join(', ')
+                associatedString = `associatedKeys: [${associatedFieldsString}]`
+              }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,
                 `isRequired: ${!field.isNullable}`,
                 `ofModelName: '${connectedModelName}'`,
-                `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`,
+                associatedString,
               ].join(',\n');
               fieldsToAdd.push([`${DART_AMPLIFY_CORE_TYPES.ModelFieldDefinition}.hasOne(`, indentMultiline(fieldParam), ')'].join('\n'));
               break;
-            case CodeGenConnectionType.HAS_MANY:
+            }
+            case CodeGenConnectionType.HAS_MANY: {
+              let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
+              if (field.connectionInfo.isUsingReferences) {
+                const associatedFieldsString = field.connectionInfo.associatedWithFields.map(field => `${connectedModelName}.${this.getQueryFieldName(field)}`).join(', ')
+                associatedString = `associatedKeys: [${associatedFieldsString}]`
+              }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,
                 `isRequired: ${!field.isNullable}`,
                 `ofModelName: '${connectedModelName}'`,
-                `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`,
+                associatedString,
               ].join(',\n');
               fieldsToAdd.push([`${DART_AMPLIFY_CORE_TYPES.ModelFieldDefinition}.hasMany(`, indentMultiline(fieldParam), ')'].join('\n'));
               break;
+            }
             case CodeGenConnectionType.BELONGS_TO:
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -1110,7 +1110,12 @@ export class AppSyncModelJavaVisitor<
     switch (connectionInfo.kind) {
       case CodeGenConnectionType.HAS_ONE:
         connectionDirectiveName = 'HasOne';
-        connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        if (connectionInfo.isUsingReferences) {
+          const associatedFieldString = connectionInfo.associatedWithFields.map(field => `"${this.getFieldName(field)}"`).join(', ')
+          connectionArguments.push(`associatedFields = [${associatedFieldString}]`);
+        } else {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        }
         if (this.isCustomPKEnabled() && this.isGenerateModelsForLazyLoadAndCustomSelectionSet() && connectionInfo.targetNames) {
           const hasOneTargetNamesArgs = `targetNames = {${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}}`;
           connectionArguments.push(hasOneTargetNamesArgs);
@@ -1118,7 +1123,12 @@ export class AppSyncModelJavaVisitor<
         break;
       case CodeGenConnectionType.HAS_MANY:
         connectionDirectiveName = 'HasMany';
-        connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        if (connectionInfo.isUsingReferences) {
+          const associatedFieldString = connectionInfo.associatedWithFields.map(field => `"${this.getFieldName(field)}"`).join(', ')
+          connectionArguments.push(`associatedFields = [${associatedFieldString}]`);
+        } else {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        }
         break;
       case CodeGenConnectionType.BELONGS_TO:
         connectionDirectiveName = 'BelongsTo';


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* use associated fields for references for java and dart

TODO: argument names may change based on discussion with native teams.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
