### PR TITLE
feat: use a different associated field for references on native

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -11742,8 +11742,6 @@ class Foo extends amplify_core.Model {
   final Bar? _bar2;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
-  final String? _fooBar1Id;
-  final String? _fooBar2Id;
 
   @override
   getInstanceType() => classType;
@@ -11774,23 +11772,13 @@ class Foo extends amplify_core.Model {
     return _updatedAt;
   }
   
-  String? get fooBar1Id {
-    return _fooBar1Id;
-  }
+  const Foo._internal({required this.id, bar1, bar2, createdAt, updatedAt}): _bar1 = bar1, _bar2 = bar2, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  String? get fooBar2Id {
-    return _fooBar2Id;
-  }
-  
-  const Foo._internal({required this.id, bar1, bar2, createdAt, updatedAt, fooBar1Id, fooBar2Id}): _bar1 = bar1, _bar2 = bar2, _createdAt = createdAt, _updatedAt = updatedAt, _fooBar1Id = fooBar1Id, _fooBar2Id = fooBar2Id;
-  
-  factory Foo({String? id, Bar? bar1, Bar? bar2, String? fooBar1Id, String? fooBar2Id}) {
+  factory Foo({String? id, Bar? bar1, Bar? bar2}) {
     return Foo._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       bar1: bar1,
-      bar2: bar2,
-      fooBar1Id: fooBar1Id,
-      fooBar2Id: fooBar2Id);
+      bar2: bar2);
   }
   
   bool equals(Object other) {
@@ -11803,9 +11791,7 @@ class Foo extends amplify_core.Model {
     return other is Foo &&
       id == other.id &&
       _bar1 == other._bar1 &&
-      _bar2 == other._bar2 &&
-      _fooBar1Id == other._fooBar1Id &&
-      _fooBar2Id == other._fooBar2Id;
+      _bar2 == other._bar2;
   }
   
   @override
@@ -11818,35 +11804,27 @@ class Foo extends amplify_core.Model {
     buffer.write(\\"Foo {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"fooBar1Id=\\" + \\"$_fooBar1Id\\" + \\", \\");
-    buffer.write(\\"fooBar2Id=\\" + \\"$_fooBar2Id\\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
     buffer.write(\\"}\\");
     
     return buffer.toString();
   }
   
-  Foo copyWith({Bar? bar1, Bar? bar2, String? fooBar1Id, String? fooBar2Id}) {
+  Foo copyWith({Bar? bar1, Bar? bar2}) {
     return Foo._internal(
       id: id,
       bar1: bar1 ?? this.bar1,
-      bar2: bar2 ?? this.bar2,
-      fooBar1Id: fooBar1Id ?? this.fooBar1Id,
-      fooBar2Id: fooBar2Id ?? this.fooBar2Id);
+      bar2: bar2 ?? this.bar2);
   }
   
   Foo copyWithModelFieldValues({
     ModelFieldValue<Bar?>? bar1,
-    ModelFieldValue<Bar?>? bar2,
-    ModelFieldValue<String?>? fooBar1Id,
-    ModelFieldValue<String?>? fooBar2Id
+    ModelFieldValue<Bar?>? bar2
   }) {
     return Foo._internal(
       id: id,
       bar1: bar1 == null ? this.bar1 : bar1.value,
-      bar2: bar2 == null ? this.bar2 : bar2.value,
-      fooBar1Id: fooBar1Id == null ? this.fooBar1Id : fooBar1Id.value,
-      fooBar2Id: fooBar2Id == null ? this.fooBar2Id : fooBar2Id.value
+      bar2: bar2 == null ? this.bar2 : bar2.value
     );
   }
   
@@ -11863,12 +11841,10 @@ class Foo extends amplify_core.Model {
           : Bar.fromJson(new Map<String, dynamic>.from(json['bar2']))
         : null,
       _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null,
-      _fooBar1Id = json['fooBar1Id'],
-      _fooBar2Id = json['fooBar2Id'];
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'bar1': _bar1?.toJson(), 'bar2': _bar2?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'fooBar1Id': _fooBar1Id, 'fooBar2Id': _fooBar2Id
+    'id': id, 'bar1': _bar1?.toJson(), 'bar2': _bar2?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
@@ -11876,9 +11852,7 @@ class Foo extends amplify_core.Model {
     'bar1': _bar1,
     'bar2': _bar2,
     'createdAt': _createdAt,
-    'updatedAt': _updatedAt,
-    'fooBar1Id': _fooBar1Id,
-    'fooBar2Id': _fooBar2Id
+    'updatedAt': _updatedAt
   };
 
   static final amplify_core.QueryModelIdentifier<FooModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<FooModelIdentifier>();
@@ -11889,8 +11863,6 @@ class Foo extends amplify_core.Model {
   static final BAR2 = amplify_core.QueryField(
     fieldName: \\"bar2\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Bar'));
-  static final FOOBAR1ID = amplify_core.QueryField(fieldName: \\"fooBar1Id\\");
-  static final FOOBAR2ID = amplify_core.QueryField(fieldName: \\"fooBar2Id\\");
   static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Foo\\";
     modelSchemaDefinition.pluralName = \\"Foos\\";
@@ -11901,14 +11873,14 @@ class Foo extends amplify_core.Model {
       key: Foo.BAR1,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.FOO1
+      associatedKey: Bar.BAR1ID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Foo.BAR2,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.FOO1
+      associatedKey: Bar.BAR2ID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -11923,18 +11895,6 @@ class Foo extends amplify_core.Model {
       isRequired: false,
       isReadOnly: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Foo.FOOBAR1ID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Foo.FOOBAR2ID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
     ));
   });
 }
@@ -12203,14 +12163,14 @@ class Bar extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: Bar.FOO1,
       isRequired: false,
-      targetNames: ['barFoo1Id'],
+      targetNames: ['bar1Id'],
       ofModelName: 'Foo'
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: Bar.FOO2,
       isRequired: false,
-      targetNames: ['barFoo2Id'],
+      targetNames: ['bar2Id'],
       ofModelName: 'Foo'
     ));
     
@@ -12551,7 +12511,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: true,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARY
+      associatedKey: Related.PRIMARYTENANTID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -12894,7 +12854,7 @@ class Related extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: Related.PRIMARY,
       isRequired: false,
-      targetNames: ['primaryRelatedTenantId', 'primaryRelatedInstanceId', 'primaryRelatedRecordId'],
+      targetNames: ['primaryTenantId', 'primaryInstanceId', 'primaryRecordId'],
       ofModelName: 'Primary'
     ));
     
@@ -13008,7 +12968,6 @@ class Primary extends amplify_core.Model {
   final Related? _related;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
-  final String? _primaryRelatedId;
 
   @override
   getInstanceType() => classType;
@@ -13089,20 +13048,15 @@ class Primary extends amplify_core.Model {
     return _updatedAt;
   }
   
-  String? get primaryRelatedId {
-    return _primaryRelatedId;
-  }
+  const Primary._internal({required tenantId, required instanceId, required recordId, content, related, createdAt, updatedAt}): _tenantId = tenantId, _instanceId = instanceId, _recordId = recordId, _content = content, _related = related, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  const Primary._internal({required tenantId, required instanceId, required recordId, content, related, createdAt, updatedAt, primaryRelatedId}): _tenantId = tenantId, _instanceId = instanceId, _recordId = recordId, _content = content, _related = related, _createdAt = createdAt, _updatedAt = updatedAt, _primaryRelatedId = primaryRelatedId;
-  
-  factory Primary({required String tenantId, required String instanceId, required String recordId, String? content, Related? related, String? primaryRelatedId}) {
+  factory Primary({required String tenantId, required String instanceId, required String recordId, String? content, Related? related}) {
     return Primary._internal(
       tenantId: tenantId,
       instanceId: instanceId,
       recordId: recordId,
       content: content,
-      related: related,
-      primaryRelatedId: primaryRelatedId);
+      related: related);
   }
   
   bool equals(Object other) {
@@ -13117,8 +13071,7 @@ class Primary extends amplify_core.Model {
       _instanceId == other._instanceId &&
       _recordId == other._recordId &&
       _content == other._content &&
-      _related == other._related &&
-      _primaryRelatedId == other._primaryRelatedId;
+      _related == other._related;
   }
   
   @override
@@ -13134,35 +13087,31 @@ class Primary extends amplify_core.Model {
     buffer.write(\\"recordId=\\" + \\"$_recordId\\" + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"primaryRelatedId=\\" + \\"$_primaryRelatedId\\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
     buffer.write(\\"}\\");
     
     return buffer.toString();
   }
   
-  Primary copyWith({String? content, Related? related, String? primaryRelatedId}) {
+  Primary copyWith({String? content, Related? related}) {
     return Primary._internal(
       tenantId: tenantId,
       instanceId: instanceId,
       recordId: recordId,
       content: content ?? this.content,
-      related: related ?? this.related,
-      primaryRelatedId: primaryRelatedId ?? this.primaryRelatedId);
+      related: related ?? this.related);
   }
   
   Primary copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<Related?>? related,
-    ModelFieldValue<String?>? primaryRelatedId
+    ModelFieldValue<Related?>? related
   }) {
     return Primary._internal(
       tenantId: tenantId,
       instanceId: instanceId,
       recordId: recordId,
       content: content == null ? this.content : content.value,
-      related: related == null ? this.related : related.value,
-      primaryRelatedId: primaryRelatedId == null ? this.primaryRelatedId : primaryRelatedId.value
+      related: related == null ? this.related : related.value
     );
   }
   
@@ -13177,11 +13126,10 @@ class Primary extends amplify_core.Model {
           : Related.fromJson(new Map<String, dynamic>.from(json['related']))
         : null,
       _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null,
-      _primaryRelatedId = json['primaryRelatedId'];
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'tenantId': _tenantId, 'instanceId': _instanceId, 'recordId': _recordId, 'content': _content, 'related': _related?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'primaryRelatedId': _primaryRelatedId
+    'tenantId': _tenantId, 'instanceId': _instanceId, 'recordId': _recordId, 'content': _content, 'related': _related?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
@@ -13191,8 +13139,7 @@ class Primary extends amplify_core.Model {
     'content': _content,
     'related': _related,
     'createdAt': _createdAt,
-    'updatedAt': _updatedAt,
-    'primaryRelatedId': _primaryRelatedId
+    'updatedAt': _updatedAt
   };
 
   static final amplify_core.QueryModelIdentifier<PrimaryModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<PrimaryModelIdentifier>();
@@ -13203,7 +13150,6 @@ class Primary extends amplify_core.Model {
   static final RELATED = amplify_core.QueryField(
     fieldName: \\"related\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Related'));
-  static final PRIMARYRELATEDID = amplify_core.QueryField(fieldName: \\"primaryRelatedId\\");
   static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Primary\\";
     modelSchemaDefinition.pluralName = \\"Primaries\\";
@@ -13240,7 +13186,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: false,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARY
+      associatedKey: Related.PRIMARYTENANTID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -13255,12 +13201,6 @@ class Primary extends amplify_core.Model {
       isRequired: false,
       isReadOnly: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Primary.PRIMARYRELATEDID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
     ));
   });
 }
@@ -13589,7 +13529,7 @@ class Related extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: Related.PRIMARY,
       isRequired: false,
-      targetNames: ['relatedPrimaryTenantId', 'relatedPrimaryInstanceId', 'relatedPrimaryRecordId'],
+      targetNames: ['primaryTenantId', 'primaryInstanceId', 'primaryRecordId'],
       ofModelName: 'Primary'
     ));
     
@@ -13846,7 +13786,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: true,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARY
+      associatedKey: SqlRelated.PRIMARYID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14123,7 +14063,7 @@ class SqlRelated extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: SqlRelated.PRIMARY,
       isRequired: false,
-      targetNames: ['sqlPrimaryRelatedId'],
+      targetNames: ['primaryId'],
       ofModelName: 'SqlPrimary'
     ));
     
@@ -14236,7 +14176,6 @@ class Primary extends amplify_core.Model {
   final RelatedOne? _relatedOne;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
-  final String? _primaryRelatedOneId;
 
   @override
   getInstanceType() => classType;
@@ -14267,18 +14206,13 @@ class Primary extends amplify_core.Model {
     return _updatedAt;
   }
   
-  String? get primaryRelatedOneId {
-    return _primaryRelatedOneId;
-  }
+  const Primary._internal({required this.id, relatedMany, relatedOne, createdAt, updatedAt}): _relatedMany = relatedMany, _relatedOne = relatedOne, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  const Primary._internal({required this.id, relatedMany, relatedOne, createdAt, updatedAt, primaryRelatedOneId}): _relatedMany = relatedMany, _relatedOne = relatedOne, _createdAt = createdAt, _updatedAt = updatedAt, _primaryRelatedOneId = primaryRelatedOneId;
-  
-  factory Primary({String? id, List<RelatedMany>? relatedMany, RelatedOne? relatedOne, String? primaryRelatedOneId}) {
+  factory Primary({String? id, List<RelatedMany>? relatedMany, RelatedOne? relatedOne}) {
     return Primary._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       relatedMany: relatedMany != null ? List<RelatedMany>.unmodifiable(relatedMany) : relatedMany,
-      relatedOne: relatedOne,
-      primaryRelatedOneId: primaryRelatedOneId);
+      relatedOne: relatedOne);
   }
   
   bool equals(Object other) {
@@ -14291,8 +14225,7 @@ class Primary extends amplify_core.Model {
     return other is Primary &&
       id == other.id &&
       DeepCollectionEquality().equals(_relatedMany, other._relatedMany) &&
-      _relatedOne == other._relatedOne &&
-      _primaryRelatedOneId == other._primaryRelatedOneId;
+      _relatedOne == other._relatedOne;
   }
   
   @override
@@ -14305,31 +14238,27 @@ class Primary extends amplify_core.Model {
     buffer.write(\\"Primary {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"primaryRelatedOneId=\\" + \\"$_primaryRelatedOneId\\");
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
     buffer.write(\\"}\\");
     
     return buffer.toString();
   }
   
-  Primary copyWith({List<RelatedMany>? relatedMany, RelatedOne? relatedOne, String? primaryRelatedOneId}) {
+  Primary copyWith({List<RelatedMany>? relatedMany, RelatedOne? relatedOne}) {
     return Primary._internal(
       id: id,
       relatedMany: relatedMany ?? this.relatedMany,
-      relatedOne: relatedOne ?? this.relatedOne,
-      primaryRelatedOneId: primaryRelatedOneId ?? this.primaryRelatedOneId);
+      relatedOne: relatedOne ?? this.relatedOne);
   }
   
   Primary copyWithModelFieldValues({
     ModelFieldValue<List<RelatedMany>?>? relatedMany,
-    ModelFieldValue<RelatedOne?>? relatedOne,
-    ModelFieldValue<String?>? primaryRelatedOneId
+    ModelFieldValue<RelatedOne?>? relatedOne
   }) {
     return Primary._internal(
       id: id,
       relatedMany: relatedMany == null ? this.relatedMany : relatedMany.value,
-      relatedOne: relatedOne == null ? this.relatedOne : relatedOne.value,
-      primaryRelatedOneId: primaryRelatedOneId == null ? this.primaryRelatedOneId : primaryRelatedOneId.value
+      relatedOne: relatedOne == null ? this.relatedOne : relatedOne.value
     );
   }
   
@@ -14354,11 +14283,10 @@ class Primary extends amplify_core.Model {
           : RelatedOne.fromJson(new Map<String, dynamic>.from(json['relatedOne']))
         : null,
       _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null,
-      _primaryRelatedOneId = json['primaryRelatedOneId'];
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'relatedMany': _relatedMany?.map((RelatedMany? e) => e?.toJson()).toList(), 'relatedOne': _relatedOne?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'primaryRelatedOneId': _primaryRelatedOneId
+    'id': id, 'relatedMany': _relatedMany?.map((RelatedMany? e) => e?.toJson()).toList(), 'relatedOne': _relatedOne?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
@@ -14366,8 +14294,7 @@ class Primary extends amplify_core.Model {
     'relatedMany': _relatedMany,
     'relatedOne': _relatedOne,
     'createdAt': _createdAt,
-    'updatedAt': _updatedAt,
-    'primaryRelatedOneId': _primaryRelatedOneId
+    'updatedAt': _updatedAt
   };
 
   static final amplify_core.QueryModelIdentifier<PrimaryModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<PrimaryModelIdentifier>();
@@ -14378,7 +14305,6 @@ class Primary extends amplify_core.Model {
   static final RELATEDONE = amplify_core.QueryField(
     fieldName: \\"relatedOne\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'RelatedOne'));
-  static final PRIMARYRELATEDONEID = amplify_core.QueryField(fieldName: \\"primaryRelatedOneId\\");
   static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"Primary\\";
     modelSchemaDefinition.pluralName = \\"Primaries\\";
@@ -14393,14 +14319,14 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATEDMANY,
       isRequired: false,
       ofModelName: 'RelatedMany',
-      associatedKey: RelatedMany.PRIMARY
+      associatedKey: RelatedMany.PRIMARYID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Primary.RELATEDONE,
       isRequired: false,
       ofModelName: 'RelatedOne',
-      associatedKey: RelatedOne.PRIMARY
+      associatedKey: RelatedOne.PRIMARYID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14415,12 +14341,6 @@ class Primary extends amplify_core.Model {
       isRequired: false,
       isReadOnly: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Primary.PRIMARYRELATEDONEID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
     ));
   });
 }
@@ -14662,7 +14582,7 @@ class RelatedOne extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: RelatedOne.PRIMARY,
       isRequired: false,
-      targetNames: ['relatedOnePrimaryId'],
+      targetNames: ['primaryId'],
       ofModelName: 'Primary'
     ));
     
@@ -14919,7 +14839,7 @@ class RelatedMany extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: RelatedMany.PRIMARY,
       isRequired: false,
-      targetNames: ['primaryRelatedManyId'],
+      targetNames: ['primaryId'],
       ofModelName: 'Primary'
     ));
     
@@ -15031,7 +14951,6 @@ class SqlPrimary extends amplify_core.Model {
   final SqlRelated? _related;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
-  final int? _sqlPrimaryRelatedId;
 
   @override
   getInstanceType() => classType;
@@ -15062,18 +14981,13 @@ class SqlPrimary extends amplify_core.Model {
     return _updatedAt;
   }
   
-  int? get sqlPrimaryRelatedId {
-    return _sqlPrimaryRelatedId;
-  }
+  const SqlPrimary._internal({required this.id, content, related, createdAt, updatedAt}): _content = content, _related = related, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  const SqlPrimary._internal({required this.id, content, related, createdAt, updatedAt, sqlPrimaryRelatedId}): _content = content, _related = related, _createdAt = createdAt, _updatedAt = updatedAt, _sqlPrimaryRelatedId = sqlPrimaryRelatedId;
-  
-  factory SqlPrimary({int? id, String? content, SqlRelated? related, int? sqlPrimaryRelatedId}) {
+  factory SqlPrimary({int? id, String? content, SqlRelated? related}) {
     return SqlPrimary._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       content: content,
-      related: related,
-      sqlPrimaryRelatedId: sqlPrimaryRelatedId);
+      related: related);
   }
   
   bool equals(Object other) {
@@ -15086,8 +15000,7 @@ class SqlPrimary extends amplify_core.Model {
     return other is SqlPrimary &&
       id == other.id &&
       _content == other._content &&
-      _related == other._related &&
-      _sqlPrimaryRelatedId == other._sqlPrimaryRelatedId;
+      _related == other._related;
   }
   
   @override
@@ -15101,31 +15014,27 @@ class SqlPrimary extends amplify_core.Model {
     buffer.write(\\"id=\\" + (id != null ? id!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\") + \\", \\");
-    buffer.write(\\"sqlPrimaryRelatedId=\\" + (_sqlPrimaryRelatedId != null ? _sqlPrimaryRelatedId!.toString() : \\"null\\"));
+    buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
     buffer.write(\\"}\\");
     
     return buffer.toString();
   }
   
-  SqlPrimary copyWith({String? content, SqlRelated? related, int? sqlPrimaryRelatedId}) {
+  SqlPrimary copyWith({String? content, SqlRelated? related}) {
     return SqlPrimary._internal(
       id: id,
       content: content ?? this.content,
-      related: related ?? this.related,
-      sqlPrimaryRelatedId: sqlPrimaryRelatedId ?? this.sqlPrimaryRelatedId);
+      related: related ?? this.related);
   }
   
   SqlPrimary copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<SqlRelated?>? related,
-    ModelFieldValue<int?>? sqlPrimaryRelatedId
+    ModelFieldValue<SqlRelated?>? related
   }) {
     return SqlPrimary._internal(
       id: id,
       content: content == null ? this.content : content.value,
-      related: related == null ? this.related : related.value,
-      sqlPrimaryRelatedId: sqlPrimaryRelatedId == null ? this.sqlPrimaryRelatedId : sqlPrimaryRelatedId.value
+      related: related == null ? this.related : related.value
     );
   }
   
@@ -15138,11 +15047,10 @@ class SqlPrimary extends amplify_core.Model {
           : SqlRelated.fromJson(new Map<String, dynamic>.from(json['related']))
         : null,
       _createdAt = json['createdAt'] != null ? amplify_core.TemporalDateTime.fromString(json['createdAt']) : null,
-      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null,
-      _sqlPrimaryRelatedId = (json['sqlPrimaryRelatedId'] as num?)?.toInt();
+      _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'content': _content, 'related': _related?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format(), 'sqlPrimaryRelatedId': _sqlPrimaryRelatedId
+    'id': id, 'content': _content, 'related': _related?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
@@ -15150,8 +15058,7 @@ class SqlPrimary extends amplify_core.Model {
     'content': _content,
     'related': _related,
     'createdAt': _createdAt,
-    'updatedAt': _updatedAt,
-    'sqlPrimaryRelatedId': _sqlPrimaryRelatedId
+    'updatedAt': _updatedAt
   };
 
   static final amplify_core.QueryModelIdentifier<SqlPrimaryModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<SqlPrimaryModelIdentifier>();
@@ -15160,7 +15067,6 @@ class SqlPrimary extends amplify_core.Model {
   static final RELATED = amplify_core.QueryField(
     fieldName: \\"related\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'SqlRelated'));
-  static final SQLPRIMARYRELATEDID = amplify_core.QueryField(fieldName: \\"sqlPrimaryRelatedId\\");
   static var schema = amplify_core.Model.defineSchema(define: (amplify_core.ModelSchemaDefinition modelSchemaDefinition) {
     modelSchemaDefinition.name = \\"SqlPrimary\\";
     modelSchemaDefinition.pluralName = \\"SqlPrimaries\\";
@@ -15181,7 +15087,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: false,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARY
+      associatedKey: SqlRelated.PRIMARYID
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -15196,12 +15102,6 @@ class SqlPrimary extends amplify_core.Model {
       isRequired: false,
       isReadOnly: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.dateTime)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: SqlPrimary.SQLPRIMARYRELATEDID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.int)
     ));
   });
 }
@@ -15464,7 +15364,7 @@ class SqlRelated extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: SqlRelated.PRIMARY,
       isRequired: false,
-      targetNames: ['sqlRelatedPrimaryId'],
+      targetNames: ['primaryId'],
       ofModelName: 'SqlPrimary'
     ));
     

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -11873,14 +11873,14 @@ class Foo extends amplify_core.Model {
       key: Foo.BAR1,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.BAR1ID
+      associatedKey: Bar.FOO1
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Foo.BAR2,
       isRequired: false,
       ofModelName: 'Bar',
-      associatedKey: Bar.BAR2ID
+      associatedKey: Bar.FOO2
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -12471,7 +12471,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: true,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARYTENANTID
+      associatedKey: Related.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -13059,7 +13059,7 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATED,
       isRequired: false,
       ofModelName: 'Related',
-      associatedKey: Related.PRIMARYTENANTID
+      associatedKey: Related.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -13572,7 +13572,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: true,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARYID
+      associatedKey: SqlRelated.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14076,14 +14076,14 @@ class Primary extends amplify_core.Model {
       key: Primary.RELATEDMANY,
       isRequired: false,
       ofModelName: 'RelatedMany',
-      associatedKey: RelatedMany.PRIMARYID
+      associatedKey: RelatedMany.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.hasOne(
       key: Primary.RELATEDONE,
       isRequired: false,
       ofModelName: 'RelatedOne',
-      associatedKey: RelatedOne.PRIMARYID
+      associatedKey: RelatedOne.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(
@@ -14786,7 +14786,7 @@ class SqlPrimary extends amplify_core.Model {
       key: SqlPrimary.RELATED,
       isRequired: false,
       ofModelName: 'SqlRelated',
-      associatedKey: SqlRelated.PRIMARYID
+      associatedKey: SqlRelated.PRIMARY
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.nonQueryField(

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -11987,8 +11987,6 @@ import 'package:amplify_core/amplify_core.dart' as amplify_core;
 class Bar extends amplify_core.Model {
   static const classType = const _BarModelType();
   final String id;
-  final String? _bar1Id;
-  final String? _bar2Id;
   final Foo? _foo1;
   final Foo? _foo2;
   final amplify_core.TemporalDateTime? _createdAt;
@@ -12007,14 +12005,6 @@ class Bar extends amplify_core.Model {
       );
   }
   
-  String? get bar1Id {
-    return _bar1Id;
-  }
-  
-  String? get bar2Id {
-    return _bar2Id;
-  }
-  
   Foo? get foo1 {
     return _foo1;
   }
@@ -12031,13 +12021,11 @@ class Bar extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const Bar._internal({required this.id, bar1Id, bar2Id, foo1, foo2, createdAt, updatedAt}): _bar1Id = bar1Id, _bar2Id = bar2Id, _foo1 = foo1, _foo2 = foo2, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Bar._internal({required this.id, foo1, foo2, createdAt, updatedAt}): _foo1 = foo1, _foo2 = foo2, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory Bar({String? id, String? bar1Id, String? bar2Id, Foo? foo1, Foo? foo2}) {
+  factory Bar({String? id, Foo? foo1, Foo? foo2}) {
     return Bar._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
-      bar1Id: bar1Id,
-      bar2Id: bar2Id,
       foo1: foo1,
       foo2: foo2);
   }
@@ -12051,8 +12039,6 @@ class Bar extends amplify_core.Model {
     if (identical(other, this)) return true;
     return other is Bar &&
       id == other.id &&
-      _bar1Id == other._bar1Id &&
-      _bar2Id == other._bar2Id &&
       _foo1 == other._foo1 &&
       _foo2 == other._foo2;
   }
@@ -12066,8 +12052,6 @@ class Bar extends amplify_core.Model {
     
     buffer.write(\\"Bar {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"bar1Id=\\" + \\"$_bar1Id\\" + \\", \\");
-    buffer.write(\\"bar2Id=\\" + \\"$_bar2Id\\" + \\", \\");
     buffer.write(\\"foo1=\\" + (_foo1 != null ? _foo1!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"foo2=\\" + (_foo2 != null ? _foo2!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
@@ -12077,25 +12061,19 @@ class Bar extends amplify_core.Model {
     return buffer.toString();
   }
   
-  Bar copyWith({String? bar1Id, String? bar2Id, Foo? foo1, Foo? foo2}) {
+  Bar copyWith({Foo? foo1, Foo? foo2}) {
     return Bar._internal(
       id: id,
-      bar1Id: bar1Id ?? this.bar1Id,
-      bar2Id: bar2Id ?? this.bar2Id,
       foo1: foo1 ?? this.foo1,
       foo2: foo2 ?? this.foo2);
   }
   
   Bar copyWithModelFieldValues({
-    ModelFieldValue<String?>? bar1Id,
-    ModelFieldValue<String?>? bar2Id,
     ModelFieldValue<Foo?>? foo1,
     ModelFieldValue<Foo?>? foo2
   }) {
     return Bar._internal(
       id: id,
-      bar1Id: bar1Id == null ? this.bar1Id : bar1Id.value,
-      bar2Id: bar2Id == null ? this.bar2Id : bar2Id.value,
       foo1: foo1 == null ? this.foo1 : foo1.value,
       foo2: foo2 == null ? this.foo2 : foo2.value
     );
@@ -12103,8 +12081,6 @@ class Bar extends amplify_core.Model {
   
   Bar.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
-      _bar1Id = json['bar1Id'],
-      _bar2Id = json['bar2Id'],
       _foo1 = json['foo1'] != null
         ? json['foo1']['serializedData'] != null
           ? Foo.fromJson(new Map<String, dynamic>.from(json['foo1']['serializedData']))
@@ -12119,13 +12095,11 @@ class Bar extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'bar1Id': _bar1Id, 'bar2Id': _bar2Id, 'foo1': _foo1?.toJson(), 'foo2': _foo2?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'foo1': _foo1?.toJson(), 'foo2': _foo2?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
-    'bar1Id': _bar1Id,
-    'bar2Id': _bar2Id,
     'foo1': _foo1,
     'foo2': _foo2,
     'createdAt': _createdAt,
@@ -12134,8 +12108,6 @@ class Bar extends amplify_core.Model {
 
   static final amplify_core.QueryModelIdentifier<BarModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<BarModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
-  static final BAR1ID = amplify_core.QueryField(fieldName: \\"bar1Id\\");
-  static final BAR2ID = amplify_core.QueryField(fieldName: \\"bar2Id\\");
   static final FOO1 = amplify_core.QueryField(
     fieldName: \\"foo1\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Foo'));
@@ -12147,18 +12119,6 @@ class Bar extends amplify_core.Model {
     modelSchemaDefinition.pluralName = \\"Bars\\";
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Bar.BAR1ID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Bar.BAR2ID,
-      isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: Bar.FOO1,
@@ -12632,9 +12592,6 @@ class Related extends amplify_core.Model {
   static const classType = const _RelatedModelType();
   final String id;
   final String? _content;
-  final String? _primaryTenantId;
-  final String? _primaryInstanceId;
-  final String? _primaryRecordId;
   final Primary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -12656,45 +12613,6 @@ class Related extends amplify_core.Model {
     return _content;
   }
   
-  String get primaryTenantId {
-    try {
-      return _primaryTenantId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
-  String get primaryInstanceId {
-    try {
-      return _primaryInstanceId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
-  String get primaryRecordId {
-    try {
-      return _primaryRecordId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   Primary? get primary {
     return _primary;
   }
@@ -12707,15 +12625,12 @@ class Related extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const Related._internal({required this.id, content, required primaryTenantId, required primaryInstanceId, required primaryRecordId, primary, createdAt, updatedAt}): _content = content, _primaryTenantId = primaryTenantId, _primaryInstanceId = primaryInstanceId, _primaryRecordId = primaryRecordId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Related._internal({required this.id, content, primary, createdAt, updatedAt}): _content = content, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory Related({String? id, String? content, required String primaryTenantId, required String primaryInstanceId, required String primaryRecordId, Primary? primary}) {
+  factory Related({String? id, String? content, Primary? primary}) {
     return Related._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       content: content,
-      primaryTenantId: primaryTenantId,
-      primaryInstanceId: primaryInstanceId,
-      primaryRecordId: primaryRecordId,
       primary: primary);
   }
   
@@ -12729,9 +12644,6 @@ class Related extends amplify_core.Model {
     return other is Related &&
       id == other.id &&
       _content == other._content &&
-      _primaryTenantId == other._primaryTenantId &&
-      _primaryInstanceId == other._primaryInstanceId &&
-      _primaryRecordId == other._primaryRecordId &&
       _primary == other._primary;
   }
   
@@ -12745,9 +12657,6 @@ class Related extends amplify_core.Model {
     buffer.write(\\"Related {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
-    buffer.write(\\"primaryTenantId=\\" + \\"$_primaryTenantId\\" + \\", \\");
-    buffer.write(\\"primaryInstanceId=\\" + \\"$_primaryInstanceId\\" + \\", \\");
-    buffer.write(\\"primaryRecordId=\\" + \\"$_primaryRecordId\\" + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -12756,29 +12665,20 @@ class Related extends amplify_core.Model {
     return buffer.toString();
   }
   
-  Related copyWith({String? content, String? primaryTenantId, String? primaryInstanceId, String? primaryRecordId, Primary? primary}) {
+  Related copyWith({String? content, Primary? primary}) {
     return Related._internal(
       id: id,
       content: content ?? this.content,
-      primaryTenantId: primaryTenantId ?? this.primaryTenantId,
-      primaryInstanceId: primaryInstanceId ?? this.primaryInstanceId,
-      primaryRecordId: primaryRecordId ?? this.primaryRecordId,
       primary: primary ?? this.primary);
   }
   
   Related copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<String>? primaryTenantId,
-    ModelFieldValue<String>? primaryInstanceId,
-    ModelFieldValue<String>? primaryRecordId,
     ModelFieldValue<Primary?>? primary
   }) {
     return Related._internal(
       id: id,
       content: content == null ? this.content : content.value,
-      primaryTenantId: primaryTenantId == null ? this.primaryTenantId : primaryTenantId.value,
-      primaryInstanceId: primaryInstanceId == null ? this.primaryInstanceId : primaryInstanceId.value,
-      primaryRecordId: primaryRecordId == null ? this.primaryRecordId : primaryRecordId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
@@ -12786,9 +12686,6 @@ class Related extends amplify_core.Model {
   Related.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
       _content = json['content'],
-      _primaryTenantId = json['primaryTenantId'],
-      _primaryInstanceId = json['primaryInstanceId'],
-      _primaryRecordId = json['primaryRecordId'],
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? Primary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -12798,15 +12695,12 @@ class Related extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'content': _content, 'primaryTenantId': _primaryTenantId, 'primaryInstanceId': _primaryInstanceId, 'primaryRecordId': _primaryRecordId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'content': _content, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
     'content': _content,
-    'primaryTenantId': _primaryTenantId,
-    'primaryInstanceId': _primaryInstanceId,
-    'primaryRecordId': _primaryRecordId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -12815,9 +12709,6 @@ class Related extends amplify_core.Model {
   static final amplify_core.QueryModelIdentifier<RelatedModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<RelatedModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
   static final CONTENT = amplify_core.QueryField(fieldName: \\"content\\");
-  static final PRIMARYTENANTID = amplify_core.QueryField(fieldName: \\"primaryTenantId\\");
-  static final PRIMARYINSTANCEID = amplify_core.QueryField(fieldName: \\"primaryInstanceId\\");
-  static final PRIMARYRECORDID = amplify_core.QueryField(fieldName: \\"primaryRecordId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Primary'));
@@ -12830,24 +12721,6 @@ class Related extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
       key: Related.CONTENT,
       isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYTENANTID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYINSTANCEID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYRECORDID,
-      isRequired: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
     ));
     
@@ -13307,9 +13180,6 @@ class Related extends amplify_core.Model {
   static const classType = const _RelatedModelType();
   final String id;
   final String? _content;
-  final String? _primaryTenantId;
-  final String? _primaryInstanceId;
-  final String? _primaryRecordId;
   final Primary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -13331,45 +13201,6 @@ class Related extends amplify_core.Model {
     return _content;
   }
   
-  String get primaryTenantId {
-    try {
-      return _primaryTenantId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
-  String get primaryInstanceId {
-    try {
-      return _primaryInstanceId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
-  String get primaryRecordId {
-    try {
-      return _primaryRecordId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   Primary? get primary {
     return _primary;
   }
@@ -13382,15 +13213,12 @@ class Related extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const Related._internal({required this.id, content, required primaryTenantId, required primaryInstanceId, required primaryRecordId, primary, createdAt, updatedAt}): _content = content, _primaryTenantId = primaryTenantId, _primaryInstanceId = primaryInstanceId, _primaryRecordId = primaryRecordId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const Related._internal({required this.id, content, primary, createdAt, updatedAt}): _content = content, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory Related({String? id, String? content, required String primaryTenantId, required String primaryInstanceId, required String primaryRecordId, Primary? primary}) {
+  factory Related({String? id, String? content, Primary? primary}) {
     return Related._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       content: content,
-      primaryTenantId: primaryTenantId,
-      primaryInstanceId: primaryInstanceId,
-      primaryRecordId: primaryRecordId,
       primary: primary);
   }
   
@@ -13404,9 +13232,6 @@ class Related extends amplify_core.Model {
     return other is Related &&
       id == other.id &&
       _content == other._content &&
-      _primaryTenantId == other._primaryTenantId &&
-      _primaryInstanceId == other._primaryInstanceId &&
-      _primaryRecordId == other._primaryRecordId &&
       _primary == other._primary;
   }
   
@@ -13420,9 +13245,6 @@ class Related extends amplify_core.Model {
     buffer.write(\\"Related {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
-    buffer.write(\\"primaryTenantId=\\" + \\"$_primaryTenantId\\" + \\", \\");
-    buffer.write(\\"primaryInstanceId=\\" + \\"$_primaryInstanceId\\" + \\", \\");
-    buffer.write(\\"primaryRecordId=\\" + \\"$_primaryRecordId\\" + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -13431,29 +13253,20 @@ class Related extends amplify_core.Model {
     return buffer.toString();
   }
   
-  Related copyWith({String? content, String? primaryTenantId, String? primaryInstanceId, String? primaryRecordId, Primary? primary}) {
+  Related copyWith({String? content, Primary? primary}) {
     return Related._internal(
       id: id,
       content: content ?? this.content,
-      primaryTenantId: primaryTenantId ?? this.primaryTenantId,
-      primaryInstanceId: primaryInstanceId ?? this.primaryInstanceId,
-      primaryRecordId: primaryRecordId ?? this.primaryRecordId,
       primary: primary ?? this.primary);
   }
   
   Related copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<String>? primaryTenantId,
-    ModelFieldValue<String>? primaryInstanceId,
-    ModelFieldValue<String>? primaryRecordId,
     ModelFieldValue<Primary?>? primary
   }) {
     return Related._internal(
       id: id,
       content: content == null ? this.content : content.value,
-      primaryTenantId: primaryTenantId == null ? this.primaryTenantId : primaryTenantId.value,
-      primaryInstanceId: primaryInstanceId == null ? this.primaryInstanceId : primaryInstanceId.value,
-      primaryRecordId: primaryRecordId == null ? this.primaryRecordId : primaryRecordId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
@@ -13461,9 +13274,6 @@ class Related extends amplify_core.Model {
   Related.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
       _content = json['content'],
-      _primaryTenantId = json['primaryTenantId'],
-      _primaryInstanceId = json['primaryInstanceId'],
-      _primaryRecordId = json['primaryRecordId'],
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? Primary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -13473,15 +13283,12 @@ class Related extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'content': _content, 'primaryTenantId': _primaryTenantId, 'primaryInstanceId': _primaryInstanceId, 'primaryRecordId': _primaryRecordId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'content': _content, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
     'content': _content,
-    'primaryTenantId': _primaryTenantId,
-    'primaryInstanceId': _primaryInstanceId,
-    'primaryRecordId': _primaryRecordId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -13490,9 +13297,6 @@ class Related extends amplify_core.Model {
   static final amplify_core.QueryModelIdentifier<RelatedModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<RelatedModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
   static final CONTENT = amplify_core.QueryField(fieldName: \\"content\\");
-  static final PRIMARYTENANTID = amplify_core.QueryField(fieldName: \\"primaryTenantId\\");
-  static final PRIMARYINSTANCEID = amplify_core.QueryField(fieldName: \\"primaryInstanceId\\");
-  static final PRIMARYRECORDID = amplify_core.QueryField(fieldName: \\"primaryRecordId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Primary'));
@@ -13505,24 +13309,6 @@ class Related extends amplify_core.Model {
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
       key: Related.CONTENT,
       isRequired: false,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYTENANTID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYINSTANCEID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: Related.PRIMARYRECORDID,
-      isRequired: true,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
     ));
     
@@ -13894,7 +13680,6 @@ class SqlRelated extends amplify_core.Model {
   static const classType = const _SqlRelatedModelType();
   final int id;
   final String? _content;
-  final int? _primaryId;
   final SqlPrimary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -13916,19 +13701,6 @@ class SqlRelated extends amplify_core.Model {
     return _content;
   }
   
-  int get primaryId {
-    try {
-      return _primaryId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   SqlPrimary? get primary {
     return _primary;
   }
@@ -13941,13 +13713,12 @@ class SqlRelated extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const SqlRelated._internal({required this.id, content, required primaryId, primary, createdAt, updatedAt}): _content = content, _primaryId = primaryId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const SqlRelated._internal({required this.id, content, primary, createdAt, updatedAt}): _content = content, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory SqlRelated({int? id, String? content, required int primaryId, SqlPrimary? primary}) {
+  factory SqlRelated({int? id, String? content, SqlPrimary? primary}) {
     return SqlRelated._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       content: content,
-      primaryId: primaryId,
       primary: primary);
   }
   
@@ -13961,7 +13732,6 @@ class SqlRelated extends amplify_core.Model {
     return other is SqlRelated &&
       id == other.id &&
       _content == other._content &&
-      _primaryId == other._primaryId &&
       _primary == other._primary;
   }
   
@@ -13975,7 +13745,6 @@ class SqlRelated extends amplify_core.Model {
     buffer.write(\\"SqlRelated {\\");
     buffer.write(\\"id=\\" + (id != null ? id!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
-    buffer.write(\\"primaryId=\\" + (_primaryId != null ? _primaryId!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -13984,23 +13753,20 @@ class SqlRelated extends amplify_core.Model {
     return buffer.toString();
   }
   
-  SqlRelated copyWith({String? content, int? primaryId, SqlPrimary? primary}) {
+  SqlRelated copyWith({String? content, SqlPrimary? primary}) {
     return SqlRelated._internal(
       id: id,
       content: content ?? this.content,
-      primaryId: primaryId ?? this.primaryId,
       primary: primary ?? this.primary);
   }
   
   SqlRelated copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<int>? primaryId,
     ModelFieldValue<SqlPrimary?>? primary
   }) {
     return SqlRelated._internal(
       id: id,
       content: content == null ? this.content : content.value,
-      primaryId: primaryId == null ? this.primaryId : primaryId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
@@ -14008,7 +13774,6 @@ class SqlRelated extends amplify_core.Model {
   SqlRelated.fromJson(Map<String, dynamic> json)  
     : id = (json['id'] as num?)?.toInt(),
       _content = json['content'],
-      _primaryId = (json['primaryId'] as num?)?.toInt(),
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? SqlPrimary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -14018,13 +13783,12 @@ class SqlRelated extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'content': _content, 'primaryId': _primaryId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'content': _content, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
     'content': _content,
-    'primaryId': _primaryId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -14033,7 +13797,6 @@ class SqlRelated extends amplify_core.Model {
   static final amplify_core.QueryModelIdentifier<SqlRelatedModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<SqlRelatedModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
   static final CONTENT = amplify_core.QueryField(fieldName: \\"content\\");
-  static final PRIMARYID = amplify_core.QueryField(fieldName: \\"primaryId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'SqlPrimary'));
@@ -14052,12 +13815,6 @@ class SqlRelated extends amplify_core.Model {
       key: SqlRelated.CONTENT,
       isRequired: false,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: SqlRelated.PRIMARYID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.int)
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
@@ -14433,7 +14190,6 @@ import 'package:amplify_core/amplify_core.dart' as amplify_core;
 class RelatedOne extends amplify_core.Model {
   static const classType = const _RelatedOneModelType();
   final String id;
-  final String? _primaryId;
   final Primary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -14451,19 +14207,6 @@ class RelatedOne extends amplify_core.Model {
       );
   }
   
-  String get primaryId {
-    try {
-      return _primaryId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   Primary? get primary {
     return _primary;
   }
@@ -14476,12 +14219,11 @@ class RelatedOne extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const RelatedOne._internal({required this.id, required primaryId, primary, createdAt, updatedAt}): _primaryId = primaryId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const RelatedOne._internal({required this.id, primary, createdAt, updatedAt}): _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory RelatedOne({String? id, required String primaryId, Primary? primary}) {
+  factory RelatedOne({String? id, Primary? primary}) {
     return RelatedOne._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
-      primaryId: primaryId,
       primary: primary);
   }
   
@@ -14494,7 +14236,6 @@ class RelatedOne extends amplify_core.Model {
     if (identical(other, this)) return true;
     return other is RelatedOne &&
       id == other.id &&
-      _primaryId == other._primaryId &&
       _primary == other._primary;
   }
   
@@ -14507,7 +14248,6 @@ class RelatedOne extends amplify_core.Model {
     
     buffer.write(\\"RelatedOne {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"primaryId=\\" + \\"$_primaryId\\" + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -14516,27 +14256,23 @@ class RelatedOne extends amplify_core.Model {
     return buffer.toString();
   }
   
-  RelatedOne copyWith({String? primaryId, Primary? primary}) {
+  RelatedOne copyWith({Primary? primary}) {
     return RelatedOne._internal(
       id: id,
-      primaryId: primaryId ?? this.primaryId,
       primary: primary ?? this.primary);
   }
   
   RelatedOne copyWithModelFieldValues({
-    ModelFieldValue<String>? primaryId,
     ModelFieldValue<Primary?>? primary
   }) {
     return RelatedOne._internal(
       id: id,
-      primaryId: primaryId == null ? this.primaryId : primaryId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
   
   RelatedOne.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
-      _primaryId = json['primaryId'],
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? Primary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -14546,12 +14282,11 @@ class RelatedOne extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'primaryId': _primaryId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
-    'primaryId': _primaryId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -14559,7 +14294,6 @@ class RelatedOne extends amplify_core.Model {
 
   static final amplify_core.QueryModelIdentifier<RelatedOneModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<RelatedOneModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
-  static final PRIMARYID = amplify_core.QueryField(fieldName: \\"primaryId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Primary'));
@@ -14572,12 +14306,6 @@ class RelatedOne extends amplify_core.Model {
     ];
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: RelatedOne.PRIMARYID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: RelatedOne.PRIMARY,
@@ -14690,7 +14418,6 @@ import 'package:amplify_core/amplify_core.dart' as amplify_core;
 class RelatedMany extends amplify_core.Model {
   static const classType = const _RelatedManyModelType();
   final String id;
-  final String? _primaryId;
   final Primary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -14708,19 +14435,6 @@ class RelatedMany extends amplify_core.Model {
       );
   }
   
-  String get primaryId {
-    try {
-      return _primaryId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   Primary? get primary {
     return _primary;
   }
@@ -14733,12 +14447,11 @@ class RelatedMany extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const RelatedMany._internal({required this.id, required primaryId, primary, createdAt, updatedAt}): _primaryId = primaryId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const RelatedMany._internal({required this.id, primary, createdAt, updatedAt}): _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory RelatedMany({String? id, required String primaryId, Primary? primary}) {
+  factory RelatedMany({String? id, Primary? primary}) {
     return RelatedMany._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
-      primaryId: primaryId,
       primary: primary);
   }
   
@@ -14751,7 +14464,6 @@ class RelatedMany extends amplify_core.Model {
     if (identical(other, this)) return true;
     return other is RelatedMany &&
       id == other.id &&
-      _primaryId == other._primaryId &&
       _primary == other._primary;
   }
   
@@ -14764,7 +14476,6 @@ class RelatedMany extends amplify_core.Model {
     
     buffer.write(\\"RelatedMany {\\");
     buffer.write(\\"id=\\" + \\"$id\\" + \\", \\");
-    buffer.write(\\"primaryId=\\" + \\"$_primaryId\\" + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -14773,27 +14484,23 @@ class RelatedMany extends amplify_core.Model {
     return buffer.toString();
   }
   
-  RelatedMany copyWith({String? primaryId, Primary? primary}) {
+  RelatedMany copyWith({Primary? primary}) {
     return RelatedMany._internal(
       id: id,
-      primaryId: primaryId ?? this.primaryId,
       primary: primary ?? this.primary);
   }
   
   RelatedMany copyWithModelFieldValues({
-    ModelFieldValue<String>? primaryId,
     ModelFieldValue<Primary?>? primary
   }) {
     return RelatedMany._internal(
       id: id,
-      primaryId: primaryId == null ? this.primaryId : primaryId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
   
   RelatedMany.fromJson(Map<String, dynamic> json)  
     : id = json['id'],
-      _primaryId = json['primaryId'],
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? Primary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -14803,12 +14510,11 @@ class RelatedMany extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'primaryId': _primaryId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
-    'primaryId': _primaryId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -14816,7 +14522,6 @@ class RelatedMany extends amplify_core.Model {
 
   static final amplify_core.QueryModelIdentifier<RelatedManyModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<RelatedManyModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
-  static final PRIMARYID = amplify_core.QueryField(fieldName: \\"primaryId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'Primary'));
@@ -14829,12 +14534,6 @@ class RelatedMany extends amplify_core.Model {
     ];
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.id());
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: RelatedMany.PRIMARYID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: RelatedMany.PRIMARY,
@@ -15195,7 +14894,6 @@ class SqlRelated extends amplify_core.Model {
   static const classType = const _SqlRelatedModelType();
   final int id;
   final String? _content;
-  final int? _primaryId;
   final SqlPrimary? _primary;
   final amplify_core.TemporalDateTime? _createdAt;
   final amplify_core.TemporalDateTime? _updatedAt;
@@ -15217,19 +14915,6 @@ class SqlRelated extends amplify_core.Model {
     return _content;
   }
   
-  int get primaryId {
-    try {
-      return _primaryId!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
-  }
-  
   SqlPrimary? get primary {
     return _primary;
   }
@@ -15242,13 +14927,12 @@ class SqlRelated extends amplify_core.Model {
     return _updatedAt;
   }
   
-  const SqlRelated._internal({required this.id, content, required primaryId, primary, createdAt, updatedAt}): _content = content, _primaryId = primaryId, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
+  const SqlRelated._internal({required this.id, content, primary, createdAt, updatedAt}): _content = content, _primary = primary, _createdAt = createdAt, _updatedAt = updatedAt;
   
-  factory SqlRelated({int? id, String? content, required int primaryId, SqlPrimary? primary}) {
+  factory SqlRelated({int? id, String? content, SqlPrimary? primary}) {
     return SqlRelated._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       content: content,
-      primaryId: primaryId,
       primary: primary);
   }
   
@@ -15262,7 +14946,6 @@ class SqlRelated extends amplify_core.Model {
     return other is SqlRelated &&
       id == other.id &&
       _content == other._content &&
-      _primaryId == other._primaryId &&
       _primary == other._primary;
   }
   
@@ -15276,7 +14959,6 @@ class SqlRelated extends amplify_core.Model {
     buffer.write(\\"SqlRelated {\\");
     buffer.write(\\"id=\\" + (id != null ? id!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"content=\\" + \\"$_content\\" + \\", \\");
-    buffer.write(\\"primaryId=\\" + (_primaryId != null ? _primaryId!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"primary=\\" + (_primary != null ? _primary!.toString() : \\"null\\") + \\", \\");
     buffer.write(\\"createdAt=\\" + (_createdAt != null ? _createdAt!.format() : \\"null\\") + \\", \\");
     buffer.write(\\"updatedAt=\\" + (_updatedAt != null ? _updatedAt!.format() : \\"null\\"));
@@ -15285,23 +14967,20 @@ class SqlRelated extends amplify_core.Model {
     return buffer.toString();
   }
   
-  SqlRelated copyWith({String? content, int? primaryId, SqlPrimary? primary}) {
+  SqlRelated copyWith({String? content, SqlPrimary? primary}) {
     return SqlRelated._internal(
       id: id,
       content: content ?? this.content,
-      primaryId: primaryId ?? this.primaryId,
       primary: primary ?? this.primary);
   }
   
   SqlRelated copyWithModelFieldValues({
     ModelFieldValue<String?>? content,
-    ModelFieldValue<int>? primaryId,
     ModelFieldValue<SqlPrimary?>? primary
   }) {
     return SqlRelated._internal(
       id: id,
       content: content == null ? this.content : content.value,
-      primaryId: primaryId == null ? this.primaryId : primaryId.value,
       primary: primary == null ? this.primary : primary.value
     );
   }
@@ -15309,7 +14988,6 @@ class SqlRelated extends amplify_core.Model {
   SqlRelated.fromJson(Map<String, dynamic> json)  
     : id = (json['id'] as num?)?.toInt(),
       _content = json['content'],
-      _primaryId = (json['primaryId'] as num?)?.toInt(),
       _primary = json['primary'] != null
         ? json['primary']['serializedData'] != null
           ? SqlPrimary.fromJson(new Map<String, dynamic>.from(json['primary']['serializedData']))
@@ -15319,13 +14997,12 @@ class SqlRelated extends amplify_core.Model {
       _updatedAt = json['updatedAt'] != null ? amplify_core.TemporalDateTime.fromString(json['updatedAt']) : null;
   
   Map<String, dynamic> toJson() => {
-    'id': id, 'content': _content, 'primaryId': _primaryId, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
+    'id': id, 'content': _content, 'primary': _primary?.toJson(), 'createdAt': _createdAt?.format(), 'updatedAt': _updatedAt?.format()
   };
   
   Map<String, Object?> toMap() => {
     'id': id,
     'content': _content,
-    'primaryId': _primaryId,
     'primary': _primary,
     'createdAt': _createdAt,
     'updatedAt': _updatedAt
@@ -15334,7 +15011,6 @@ class SqlRelated extends amplify_core.Model {
   static final amplify_core.QueryModelIdentifier<SqlRelatedModelIdentifier> MODEL_IDENTIFIER = amplify_core.QueryModelIdentifier<SqlRelatedModelIdentifier>();
   static final ID = amplify_core.QueryField(fieldName: \\"id\\");
   static final CONTENT = amplify_core.QueryField(fieldName: \\"content\\");
-  static final PRIMARYID = amplify_core.QueryField(fieldName: \\"primaryId\\");
   static final PRIMARY = amplify_core.QueryField(
     fieldName: \\"primary\\",
     fieldType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.model, ofModelName: 'SqlPrimary'));
@@ -15353,12 +15029,6 @@ class SqlRelated extends amplify_core.Model {
       key: SqlRelated.CONTENT,
       isRequired: false,
       ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.string)
-    ));
-    
-    modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.field(
-      key: SqlRelated.PRIMARYID,
-      isRequired: true,
-      ofType: amplify_core.ModelFieldType(amplify_core.ModelFieldTypeEnum.int)
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -7872,8 +7872,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Foo implements Model {
   public static final QueryField ID = field(\\"Foo\\", \\"id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar1Id\\", type = Bar.class) Bar bar1 = null;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar2Id\\", type = Bar.class) Bar bar2 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"foo1\\", type = Bar.class) Bar bar1 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"foo2\\", type = Bar.class) Bar bar2 = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -8265,7 +8265,7 @@ public final class Primary implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedWith = \\"primaryTenantId\\", type = Related.class) List<Related> related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedWith = \\"primary\\", type = Related.class) List<Related> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   private PrimaryIdentifier primaryIdentifier;
@@ -8733,7 +8733,7 @@ public final class Primary implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedWith = \\"primaryTenantId\\", type = Related.class) Related related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedWith = \\"primary\\", type = Related.class) Related related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   private PrimaryIdentifier primaryIdentifier;
@@ -9197,7 +9197,7 @@ public final class SqlPrimary implements Model {
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedWith = \\"primaryId\\", type = SqlRelated.class) List<SqlRelated> related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedWith = \\"primary\\", type = SqlRelated.class) List<SqlRelated> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -9607,8 +9607,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Primary implements Model {
   public static final QueryField ID = field(\\"Primary\\", \\"id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedWith = \\"primaryId\\", type = RelatedMany.class) List<RelatedMany> relatedMany = null;
-  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedWith = \\"primaryId\\", type = RelatedOne.class) RelatedOne relatedOne = null;
+  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedWith = \\"primary\\", type = RelatedMany.class) List<RelatedMany> relatedMany = null;
+  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedWith = \\"primary\\", type = RelatedOne.class) RelatedOne relatedOne = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -10159,7 +10159,7 @@ public final class SqlPrimary implements Model {
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedWith = \\"primaryId\\", type = SqlRelated.class) SqlRelated related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedWith = \\"primary\\", type = SqlRelated.class) SqlRelated related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -8042,13 +8042,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @ModelConfig(pluralName = \\"Bars\\", type = Model.Type.USER, version = 1)
 public final class Bar implements Model {
   public static final QueryField ID = field(\\"Bar\\", \\"id\\");
-  public static final QueryField BAR1_ID = field(\\"Bar\\", \\"bar1Id\\");
-  public static final QueryField BAR2_ID = field(\\"Bar\\", \\"bar2Id\\");
   public static final QueryField FOO1 = field(\\"Bar\\", \\"bar1Id\\");
   public static final QueryField FOO2 = field(\\"Bar\\", \\"bar2Id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"ID\\") String bar1Id;
-  private final @ModelField(targetType=\\"ID\\") String bar2Id;
   private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"bar1Id\\", targetNames = {\\"bar1Id\\"}, type = Foo.class) Foo foo1;
   private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"bar2Id\\", targetNames = {\\"bar2Id\\"}, type = Foo.class) Foo foo2;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
@@ -8061,14 +8057,6 @@ public final class Bar implements Model {
   
   public String getId() {
       return id;
-  }
-  
-  public String getBar1Id() {
-      return bar1Id;
-  }
-  
-  public String getBar2Id() {
-      return bar2Id;
   }
   
   public Foo getFoo1() {
@@ -8087,10 +8075,8 @@ public final class Bar implements Model {
       return updatedAt;
   }
   
-  private Bar(String id, String bar1Id, String bar2Id, Foo foo1, Foo foo2) {
+  private Bar(String id, Foo foo1, Foo foo2) {
     this.id = id;
-    this.bar1Id = bar1Id;
-    this.bar2Id = bar2Id;
     this.foo1 = foo1;
     this.foo2 = foo2;
   }
@@ -8104,8 +8090,6 @@ public final class Bar implements Model {
       } else {
       Bar bar = (Bar) obj;
       return ObjectsCompat.equals(getId(), bar.getId()) &&
-              ObjectsCompat.equals(getBar1Id(), bar.getBar1Id()) &&
-              ObjectsCompat.equals(getBar2Id(), bar.getBar2Id()) &&
               ObjectsCompat.equals(getFoo1(), bar.getFoo1()) &&
               ObjectsCompat.equals(getFoo2(), bar.getFoo2()) &&
               ObjectsCompat.equals(getCreatedAt(), bar.getCreatedAt()) &&
@@ -8117,8 +8101,6 @@ public final class Bar implements Model {
    public int hashCode() {
     return new StringBuilder()
       .append(getId())
-      .append(getBar1Id())
-      .append(getBar2Id())
       .append(getFoo1())
       .append(getFoo2())
       .append(getCreatedAt())
@@ -8132,8 +8114,6 @@ public final class Bar implements Model {
     return new StringBuilder()
       .append(\\"Bar {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"bar1Id=\\" + String.valueOf(getBar1Id()) + \\", \\")
-      .append(\\"bar2Id=\\" + String.valueOf(getBar2Id()) + \\", \\")
       .append(\\"foo1=\\" + String.valueOf(getFoo1()) + \\", \\")
       .append(\\"foo2=\\" + String.valueOf(getFoo2()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
@@ -8158,24 +8138,18 @@ public final class Bar implements Model {
     return new Bar(
       id,
       null,
-      null,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      bar1Id,
-      bar2Id,
       foo1,
       foo2);
   }
   public interface BuildStep {
     Bar build();
     BuildStep id(String id);
-    BuildStep bar1Id(String bar1Id);
-    BuildStep bar2Id(String bar2Id);
     BuildStep foo1(Foo foo1);
     BuildStep foo2(Foo foo2);
   }
@@ -8183,18 +8157,14 @@ public final class Bar implements Model {
 
   public static class Builder implements BuildStep {
     private String id;
-    private String bar1Id;
-    private String bar2Id;
     private Foo foo1;
     private Foo foo2;
     public Builder() {
       
     }
     
-    private Builder(String id, String bar1Id, String bar2Id, Foo foo1, Foo foo2) {
+    private Builder(String id, Foo foo1, Foo foo2) {
       this.id = id;
-      this.bar1Id = bar1Id;
-      this.bar2Id = bar2Id;
       this.foo1 = foo1;
       this.foo2 = foo2;
     }
@@ -8205,22 +8175,8 @@ public final class Bar implements Model {
         
         return new Bar(
           id,
-          bar1Id,
-          bar2Id,
           foo1,
           foo2);
-    }
-    
-    @Override
-     public BuildStep bar1Id(String bar1Id) {
-        this.bar1Id = bar1Id;
-        return this;
-    }
-    
-    @Override
-     public BuildStep bar2Id(String bar2Id) {
-        this.bar2Id = bar2Id;
-        return this;
     }
     
     @Override
@@ -8247,19 +8203,9 @@ public final class Bar implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String bar1Id, String bar2Id, Foo foo1, Foo foo2) {
-      super(id, bar1Id, bar2Id, foo1, foo2);
+    private CopyOfBuilder(String id, Foo foo1, Foo foo2) {
+      super(id, foo1, foo2);
       
-    }
-    
-    @Override
-     public CopyOfBuilder bar1Id(String bar1Id) {
-      return (CopyOfBuilder) super.bar1Id(bar1Id);
-    }
-    
-    @Override
-     public CopyOfBuilder bar2Id(String bar2Id) {
-      return (CopyOfBuilder) super.bar2Id(bar2Id);
     }
     
     @Override
@@ -8565,15 +8511,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Related implements Model {
   public static final QueryField ID = field(\\"Related\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"Related\\", \\"content\\");
-  public static final QueryField PRIMARY_TENANT_ID = field(\\"Related\\", \\"primaryTenantId\\");
-  public static final QueryField PRIMARY_INSTANCE_ID = field(\\"Related\\", \\"primaryInstanceId\\");
-  public static final QueryField PRIMARY_RECORD_ID = field(\\"Related\\", \\"primaryRecordId\\");
   public static final QueryField PRIMARY = field(\\"Related\\", \\"primaryTenantId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryTenantId;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryInstanceId;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryRecordId;
   private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryTenantId\\", targetNames = {\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -8591,18 +8531,6 @@ public final class Related implements Model {
       return content;
   }
   
-  public String getPrimaryTenantId() {
-      return primaryTenantId;
-  }
-  
-  public String getPrimaryInstanceId() {
-      return primaryInstanceId;
-  }
-  
-  public String getPrimaryRecordId() {
-      return primaryRecordId;
-  }
-  
   public Primary getPrimary() {
       return primary;
   }
@@ -8615,12 +8543,9 @@ public final class Related implements Model {
       return updatedAt;
   }
   
-  private Related(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
+  private Related(String id, String content, Primary primary) {
     this.id = id;
     this.content = content;
-    this.primaryTenantId = primaryTenantId;
-    this.primaryInstanceId = primaryInstanceId;
-    this.primaryRecordId = primaryRecordId;
     this.primary = primary;
   }
   
@@ -8634,9 +8559,6 @@ public final class Related implements Model {
       Related related = (Related) obj;
       return ObjectsCompat.equals(getId(), related.getId()) &&
               ObjectsCompat.equals(getContent(), related.getContent()) &&
-              ObjectsCompat.equals(getPrimaryTenantId(), related.getPrimaryTenantId()) &&
-              ObjectsCompat.equals(getPrimaryInstanceId(), related.getPrimaryInstanceId()) &&
-              ObjectsCompat.equals(getPrimaryRecordId(), related.getPrimaryRecordId()) &&
               ObjectsCompat.equals(getPrimary(), related.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), related.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), related.getUpdatedAt());
@@ -8648,9 +8570,6 @@ public final class Related implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getContent())
-      .append(getPrimaryTenantId())
-      .append(getPrimaryInstanceId())
-      .append(getPrimaryRecordId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -8664,9 +8583,6 @@ public final class Related implements Model {
       .append(\\"Related {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
-      .append(\\"primaryTenantId=\\" + String.valueOf(getPrimaryTenantId()) + \\", \\")
-      .append(\\"primaryInstanceId=\\" + String.valueOf(getPrimaryInstanceId()) + \\", \\")
-      .append(\\"primaryRecordId=\\" + String.valueOf(getPrimaryRecordId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -8674,7 +8590,7 @@ public final class Related implements Model {
       .toString();
   }
   
-  public static PrimaryTenantIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -8690,9 +8606,6 @@ public final class Related implements Model {
     return new Related(
       id,
       null,
-      null,
-      null,
-      null,
       null
     );
   }
@@ -8700,26 +8613,8 @@ public final class Related implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       content,
-      primaryTenantId,
-      primaryInstanceId,
-      primaryRecordId,
       primary);
   }
-  public interface PrimaryTenantIdStep {
-    PrimaryInstanceIdStep primaryTenantId(String primaryTenantId);
-  }
-  
-
-  public interface PrimaryInstanceIdStep {
-    PrimaryRecordIdStep primaryInstanceId(String primaryInstanceId);
-  }
-  
-
-  public interface PrimaryRecordIdStep {
-    BuildStep primaryRecordId(String primaryRecordId);
-  }
-  
-
   public interface BuildStep {
     Related build();
     BuildStep id(String id);
@@ -8728,23 +8623,17 @@ public final class Related implements Model {
   }
   
 
-  public static class Builder implements PrimaryTenantIdStep, PrimaryInstanceIdStep, PrimaryRecordIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private String id;
-    private String primaryTenantId;
-    private String primaryInstanceId;
-    private String primaryRecordId;
     private String content;
     private Primary primary;
     public Builder() {
       
     }
     
-    private Builder(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
+    private Builder(String id, String content, Primary primary) {
       this.id = id;
       this.content = content;
-      this.primaryTenantId = primaryTenantId;
-      this.primaryInstanceId = primaryInstanceId;
-      this.primaryRecordId = primaryRecordId;
       this.primary = primary;
     }
     
@@ -8755,31 +8644,7 @@ public final class Related implements Model {
         return new Related(
           id,
           content,
-          primaryTenantId,
-          primaryInstanceId,
-          primaryRecordId,
           primary);
-    }
-    
-    @Override
-     public PrimaryInstanceIdStep primaryTenantId(String primaryTenantId) {
-        Objects.requireNonNull(primaryTenantId);
-        this.primaryTenantId = primaryTenantId;
-        return this;
-    }
-    
-    @Override
-     public PrimaryRecordIdStep primaryInstanceId(String primaryInstanceId) {
-        Objects.requireNonNull(primaryInstanceId);
-        this.primaryInstanceId = primaryInstanceId;
-        return this;
-    }
-    
-    @Override
-     public BuildStep primaryRecordId(String primaryRecordId) {
-        Objects.requireNonNull(primaryRecordId);
-        this.primaryRecordId = primaryRecordId;
-        return this;
     }
     
     @Override
@@ -8806,26 +8671,9 @@ public final class Related implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
-      super(id, content, primaryTenantId, primaryInstanceId, primaryRecordId, primary);
-      Objects.requireNonNull(primaryTenantId);
-      Objects.requireNonNull(primaryInstanceId);
-      Objects.requireNonNull(primaryRecordId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryTenantId(String primaryTenantId) {
-      return (CopyOfBuilder) super.primaryTenantId(primaryTenantId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryInstanceId(String primaryInstanceId) {
-      return (CopyOfBuilder) super.primaryInstanceId(primaryInstanceId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryRecordId(String primaryRecordId) {
-      return (CopyOfBuilder) super.primaryRecordId(primaryRecordId);
+    private CopyOfBuilder(String id, String content, Primary primary) {
+      super(id, content, primary);
+      
     }
     
     @Override
@@ -9131,15 +8979,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class Related implements Model {
   public static final QueryField ID = field(\\"Related\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"Related\\", \\"content\\");
-  public static final QueryField PRIMARY_TENANT_ID = field(\\"Related\\", \\"primaryTenantId\\");
-  public static final QueryField PRIMARY_INSTANCE_ID = field(\\"Related\\", \\"primaryInstanceId\\");
-  public static final QueryField PRIMARY_RECORD_ID = field(\\"Related\\", \\"primaryRecordId\\");
   public static final QueryField PRIMARY = field(\\"Related\\", \\"primaryTenantId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryTenantId;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryInstanceId;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryRecordId;
   private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryTenantId\\", targetNames = {\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -9157,18 +8999,6 @@ public final class Related implements Model {
       return content;
   }
   
-  public String getPrimaryTenantId() {
-      return primaryTenantId;
-  }
-  
-  public String getPrimaryInstanceId() {
-      return primaryInstanceId;
-  }
-  
-  public String getPrimaryRecordId() {
-      return primaryRecordId;
-  }
-  
   public Primary getPrimary() {
       return primary;
   }
@@ -9181,12 +9011,9 @@ public final class Related implements Model {
       return updatedAt;
   }
   
-  private Related(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
+  private Related(String id, String content, Primary primary) {
     this.id = id;
     this.content = content;
-    this.primaryTenantId = primaryTenantId;
-    this.primaryInstanceId = primaryInstanceId;
-    this.primaryRecordId = primaryRecordId;
     this.primary = primary;
   }
   
@@ -9200,9 +9027,6 @@ public final class Related implements Model {
       Related related = (Related) obj;
       return ObjectsCompat.equals(getId(), related.getId()) &&
               ObjectsCompat.equals(getContent(), related.getContent()) &&
-              ObjectsCompat.equals(getPrimaryTenantId(), related.getPrimaryTenantId()) &&
-              ObjectsCompat.equals(getPrimaryInstanceId(), related.getPrimaryInstanceId()) &&
-              ObjectsCompat.equals(getPrimaryRecordId(), related.getPrimaryRecordId()) &&
               ObjectsCompat.equals(getPrimary(), related.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), related.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), related.getUpdatedAt());
@@ -9214,9 +9038,6 @@ public final class Related implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getContent())
-      .append(getPrimaryTenantId())
-      .append(getPrimaryInstanceId())
-      .append(getPrimaryRecordId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -9230,9 +9051,6 @@ public final class Related implements Model {
       .append(\\"Related {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
-      .append(\\"primaryTenantId=\\" + String.valueOf(getPrimaryTenantId()) + \\", \\")
-      .append(\\"primaryInstanceId=\\" + String.valueOf(getPrimaryInstanceId()) + \\", \\")
-      .append(\\"primaryRecordId=\\" + String.valueOf(getPrimaryRecordId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -9240,7 +9058,7 @@ public final class Related implements Model {
       .toString();
   }
   
-  public static PrimaryTenantIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -9256,9 +9074,6 @@ public final class Related implements Model {
     return new Related(
       id,
       null,
-      null,
-      null,
-      null,
       null
     );
   }
@@ -9266,26 +9081,8 @@ public final class Related implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       content,
-      primaryTenantId,
-      primaryInstanceId,
-      primaryRecordId,
       primary);
   }
-  public interface PrimaryTenantIdStep {
-    PrimaryInstanceIdStep primaryTenantId(String primaryTenantId);
-  }
-  
-
-  public interface PrimaryInstanceIdStep {
-    PrimaryRecordIdStep primaryInstanceId(String primaryInstanceId);
-  }
-  
-
-  public interface PrimaryRecordIdStep {
-    BuildStep primaryRecordId(String primaryRecordId);
-  }
-  
-
   public interface BuildStep {
     Related build();
     BuildStep id(String id);
@@ -9294,23 +9091,17 @@ public final class Related implements Model {
   }
   
 
-  public static class Builder implements PrimaryTenantIdStep, PrimaryInstanceIdStep, PrimaryRecordIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private String id;
-    private String primaryTenantId;
-    private String primaryInstanceId;
-    private String primaryRecordId;
     private String content;
     private Primary primary;
     public Builder() {
       
     }
     
-    private Builder(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
+    private Builder(String id, String content, Primary primary) {
       this.id = id;
       this.content = content;
-      this.primaryTenantId = primaryTenantId;
-      this.primaryInstanceId = primaryInstanceId;
-      this.primaryRecordId = primaryRecordId;
       this.primary = primary;
     }
     
@@ -9321,31 +9112,7 @@ public final class Related implements Model {
         return new Related(
           id,
           content,
-          primaryTenantId,
-          primaryInstanceId,
-          primaryRecordId,
           primary);
-    }
-    
-    @Override
-     public PrimaryInstanceIdStep primaryTenantId(String primaryTenantId) {
-        Objects.requireNonNull(primaryTenantId);
-        this.primaryTenantId = primaryTenantId;
-        return this;
-    }
-    
-    @Override
-     public PrimaryRecordIdStep primaryInstanceId(String primaryInstanceId) {
-        Objects.requireNonNull(primaryInstanceId);
-        this.primaryInstanceId = primaryInstanceId;
-        return this;
-    }
-    
-    @Override
-     public BuildStep primaryRecordId(String primaryRecordId) {
-        Objects.requireNonNull(primaryRecordId);
-        this.primaryRecordId = primaryRecordId;
-        return this;
     }
     
     @Override
@@ -9372,26 +9139,9 @@ public final class Related implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String content, String primaryTenantId, String primaryInstanceId, String primaryRecordId, Primary primary) {
-      super(id, content, primaryTenantId, primaryInstanceId, primaryRecordId, primary);
-      Objects.requireNonNull(primaryTenantId);
-      Objects.requireNonNull(primaryInstanceId);
-      Objects.requireNonNull(primaryRecordId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryTenantId(String primaryTenantId) {
-      return (CopyOfBuilder) super.primaryTenantId(primaryTenantId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryInstanceId(String primaryInstanceId) {
-      return (CopyOfBuilder) super.primaryInstanceId(primaryInstanceId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryRecordId(String primaryRecordId) {
-      return (CopyOfBuilder) super.primaryRecordId(primaryRecordId);
+    private CopyOfBuilder(String id, String content, Primary primary) {
+      super(id, content, primary);
+      
     }
     
     @Override
@@ -9640,11 +9390,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class SqlRelated implements Model {
   public static final QueryField ID = field(\\"SqlRelated\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"SqlRelated\\", \\"content\\");
-  public static final QueryField PRIMARY_ID = field(\\"SqlRelated\\", \\"primaryId\\");
   public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer primaryId;
   private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = SqlPrimary.class) SqlPrimary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -9662,10 +9410,6 @@ public final class SqlRelated implements Model {
       return content;
   }
   
-  public Integer getPrimaryId() {
-      return primaryId;
-  }
-  
   public SqlPrimary getPrimary() {
       return primary;
   }
@@ -9678,10 +9422,9 @@ public final class SqlRelated implements Model {
       return updatedAt;
   }
   
-  private SqlRelated(Integer id, String content, Integer primaryId, SqlPrimary primary) {
+  private SqlRelated(Integer id, String content, SqlPrimary primary) {
     this.id = id;
     this.content = content;
-    this.primaryId = primaryId;
     this.primary = primary;
   }
   
@@ -9695,7 +9438,6 @@ public final class SqlRelated implements Model {
       SqlRelated sqlRelated = (SqlRelated) obj;
       return ObjectsCompat.equals(getId(), sqlRelated.getId()) &&
               ObjectsCompat.equals(getContent(), sqlRelated.getContent()) &&
-              ObjectsCompat.equals(getPrimaryId(), sqlRelated.getPrimaryId()) &&
               ObjectsCompat.equals(getPrimary(), sqlRelated.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), sqlRelated.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), sqlRelated.getUpdatedAt());
@@ -9707,7 +9449,6 @@ public final class SqlRelated implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getContent())
-      .append(getPrimaryId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -9721,7 +9462,6 @@ public final class SqlRelated implements Model {
       .append(\\"SqlRelated {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
-      .append(\\"primaryId=\\" + String.valueOf(getPrimaryId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -9729,7 +9469,7 @@ public final class SqlRelated implements Model {
       .toString();
   }
   
-  public static PrimaryIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -9745,7 +9485,6 @@ public final class SqlRelated implements Model {
     return new SqlRelated(
       id,
       null,
-      null,
       null
     );
   }
@@ -9753,14 +9492,8 @@ public final class SqlRelated implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       content,
-      primaryId,
       primary);
   }
-  public interface PrimaryIdStep {
-    BuildStep primaryId(Integer primaryId);
-  }
-  
-
   public interface BuildStep {
     SqlRelated build();
     BuildStep id(String id);
@@ -9769,19 +9502,17 @@ public final class SqlRelated implements Model {
   }
   
 
-  public static class Builder implements PrimaryIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private Integer id;
-    private Integer primaryId;
     private String content;
     private SqlPrimary primary;
     public Builder() {
       
     }
     
-    private Builder(Integer id, String content, Integer primaryId, SqlPrimary primary) {
+    private Builder(Integer id, String content, SqlPrimary primary) {
       this.id = id;
       this.content = content;
-      this.primaryId = primaryId;
       this.primary = primary;
     }
     
@@ -9792,15 +9523,7 @@ public final class SqlRelated implements Model {
         return new SqlRelated(
           id,
           content,
-          primaryId,
           primary);
-    }
-    
-    @Override
-     public BuildStep primaryId(Integer primaryId) {
-        Objects.requireNonNull(primaryId);
-        this.primaryId = primaryId;
-        return this;
     }
     
     @Override
@@ -9827,14 +9550,9 @@ public final class SqlRelated implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(Integer id, String content, Integer primaryId, SqlPrimary primary) {
-      super(id, content, primaryId, primary);
-      Objects.requireNonNull(primaryId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryId(Integer primaryId) {
-      return (CopyOfBuilder) super.primaryId(primaryId);
+    private CopyOfBuilder(Integer id, String content, SqlPrimary primary) {
+      super(id, content, primary);
+      
     }
     
     @Override
@@ -10060,10 +9778,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @Index(name = \\"undefined\\", fields = {\\"id\\"})
 public final class RelatedMany implements Model {
   public static final QueryField ID = field(\\"RelatedMany\\", \\"id\\");
-  public static final QueryField PRIMARY_ID = field(\\"RelatedMany\\", \\"primaryId\\");
   public static final QueryField PRIMARY = field(\\"RelatedMany\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryId;
   private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -10075,10 +9791,6 @@ public final class RelatedMany implements Model {
   
   public String getId() {
       return id;
-  }
-  
-  public String getPrimaryId() {
-      return primaryId;
   }
   
   public Primary getPrimary() {
@@ -10093,9 +9805,8 @@ public final class RelatedMany implements Model {
       return updatedAt;
   }
   
-  private RelatedMany(String id, String primaryId, Primary primary) {
+  private RelatedMany(String id, Primary primary) {
     this.id = id;
-    this.primaryId = primaryId;
     this.primary = primary;
   }
   
@@ -10108,7 +9819,6 @@ public final class RelatedMany implements Model {
       } else {
       RelatedMany relatedMany = (RelatedMany) obj;
       return ObjectsCompat.equals(getId(), relatedMany.getId()) &&
-              ObjectsCompat.equals(getPrimaryId(), relatedMany.getPrimaryId()) &&
               ObjectsCompat.equals(getPrimary(), relatedMany.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), relatedMany.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), relatedMany.getUpdatedAt());
@@ -10119,7 +9829,6 @@ public final class RelatedMany implements Model {
    public int hashCode() {
     return new StringBuilder()
       .append(getId())
-      .append(getPrimaryId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -10132,7 +9841,6 @@ public final class RelatedMany implements Model {
     return new StringBuilder()
       .append(\\"RelatedMany {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"primaryId=\\" + String.valueOf(getPrimaryId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -10140,7 +9848,7 @@ public final class RelatedMany implements Model {
       .toString();
   }
   
-  public static PrimaryIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -10155,21 +9863,14 @@ public final class RelatedMany implements Model {
   public static RelatedMany justId(String id) {
     return new RelatedMany(
       id,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      primaryId,
       primary);
   }
-  public interface PrimaryIdStep {
-    BuildStep primaryId(String primaryId);
-  }
-  
-
   public interface BuildStep {
     RelatedMany build();
     BuildStep id(String id);
@@ -10177,17 +9878,15 @@ public final class RelatedMany implements Model {
   }
   
 
-  public static class Builder implements PrimaryIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private String id;
-    private String primaryId;
     private Primary primary;
     public Builder() {
       
     }
     
-    private Builder(String id, String primaryId, Primary primary) {
+    private Builder(String id, Primary primary) {
       this.id = id;
-      this.primaryId = primaryId;
       this.primary = primary;
     }
     
@@ -10197,15 +9896,7 @@ public final class RelatedMany implements Model {
         
         return new RelatedMany(
           id,
-          primaryId,
           primary);
-    }
-    
-    @Override
-     public BuildStep primaryId(String primaryId) {
-        Objects.requireNonNull(primaryId);
-        this.primaryId = primaryId;
-        return this;
     }
     
     @Override
@@ -10226,14 +9917,9 @@ public final class RelatedMany implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String primaryId, Primary primary) {
-      super(id, primaryId, primary);
-      Objects.requireNonNull(primaryId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryId(String primaryId) {
-      return (CopyOfBuilder) super.primaryId(primaryId);
+    private CopyOfBuilder(String id, Primary primary) {
+      super(id, primary);
+      
     }
     
     @Override
@@ -10281,10 +9967,8 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @Index(name = \\"undefined\\", fields = {\\"id\\"})
 public final class RelatedOne implements Model {
   public static final QueryField ID = field(\\"RelatedOne\\", \\"id\\");
-  public static final QueryField PRIMARY_ID = field(\\"RelatedOne\\", \\"primaryId\\");
   public static final QueryField PRIMARY = field(\\"RelatedOne\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryId;
   private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -10296,10 +9980,6 @@ public final class RelatedOne implements Model {
   
   public String getId() {
       return id;
-  }
-  
-  public String getPrimaryId() {
-      return primaryId;
   }
   
   public Primary getPrimary() {
@@ -10314,9 +9994,8 @@ public final class RelatedOne implements Model {
       return updatedAt;
   }
   
-  private RelatedOne(String id, String primaryId, Primary primary) {
+  private RelatedOne(String id, Primary primary) {
     this.id = id;
-    this.primaryId = primaryId;
     this.primary = primary;
   }
   
@@ -10329,7 +10008,6 @@ public final class RelatedOne implements Model {
       } else {
       RelatedOne relatedOne = (RelatedOne) obj;
       return ObjectsCompat.equals(getId(), relatedOne.getId()) &&
-              ObjectsCompat.equals(getPrimaryId(), relatedOne.getPrimaryId()) &&
               ObjectsCompat.equals(getPrimary(), relatedOne.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), relatedOne.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), relatedOne.getUpdatedAt());
@@ -10340,7 +10018,6 @@ public final class RelatedOne implements Model {
    public int hashCode() {
     return new StringBuilder()
       .append(getId())
-      .append(getPrimaryId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -10353,7 +10030,6 @@ public final class RelatedOne implements Model {
     return new StringBuilder()
       .append(\\"RelatedOne {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
-      .append(\\"primaryId=\\" + String.valueOf(getPrimaryId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -10361,7 +10037,7 @@ public final class RelatedOne implements Model {
       .toString();
   }
   
-  public static PrimaryIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -10376,21 +10052,14 @@ public final class RelatedOne implements Model {
   public static RelatedOne justId(String id) {
     return new RelatedOne(
       id,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      primaryId,
       primary);
   }
-  public interface PrimaryIdStep {
-    BuildStep primaryId(String primaryId);
-  }
-  
-
   public interface BuildStep {
     RelatedOne build();
     BuildStep id(String id);
@@ -10398,17 +10067,15 @@ public final class RelatedOne implements Model {
   }
   
 
-  public static class Builder implements PrimaryIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private String id;
-    private String primaryId;
     private Primary primary;
     public Builder() {
       
     }
     
-    private Builder(String id, String primaryId, Primary primary) {
+    private Builder(String id, Primary primary) {
       this.id = id;
-      this.primaryId = primaryId;
       this.primary = primary;
     }
     
@@ -10418,15 +10085,7 @@ public final class RelatedOne implements Model {
         
         return new RelatedOne(
           id,
-          primaryId,
           primary);
-    }
-    
-    @Override
-     public BuildStep primaryId(String primaryId) {
-        Objects.requireNonNull(primaryId);
-        this.primaryId = primaryId;
-        return this;
     }
     
     @Override
@@ -10447,14 +10106,9 @@ public final class RelatedOne implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String primaryId, Primary primary) {
-      super(id, primaryId, primary);
-      Objects.requireNonNull(primaryId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryId(String primaryId) {
-      return (CopyOfBuilder) super.primaryId(primaryId);
+    private CopyOfBuilder(String id, Primary primary) {
+      super(id, primary);
+      
     }
     
     @Override
@@ -10698,11 +10352,9 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class SqlRelated implements Model {
   public static final QueryField ID = field(\\"SqlRelated\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"SqlRelated\\", \\"content\\");
-  public static final QueryField PRIMARY_ID = field(\\"SqlRelated\\", \\"primaryId\\");
   public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer primaryId;
   private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = SqlPrimary.class) SqlPrimary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
@@ -10720,10 +10372,6 @@ public final class SqlRelated implements Model {
       return content;
   }
   
-  public Integer getPrimaryId() {
-      return primaryId;
-  }
-  
   public SqlPrimary getPrimary() {
       return primary;
   }
@@ -10736,10 +10384,9 @@ public final class SqlRelated implements Model {
       return updatedAt;
   }
   
-  private SqlRelated(Integer id, String content, Integer primaryId, SqlPrimary primary) {
+  private SqlRelated(Integer id, String content, SqlPrimary primary) {
     this.id = id;
     this.content = content;
-    this.primaryId = primaryId;
     this.primary = primary;
   }
   
@@ -10753,7 +10400,6 @@ public final class SqlRelated implements Model {
       SqlRelated sqlRelated = (SqlRelated) obj;
       return ObjectsCompat.equals(getId(), sqlRelated.getId()) &&
               ObjectsCompat.equals(getContent(), sqlRelated.getContent()) &&
-              ObjectsCompat.equals(getPrimaryId(), sqlRelated.getPrimaryId()) &&
               ObjectsCompat.equals(getPrimary(), sqlRelated.getPrimary()) &&
               ObjectsCompat.equals(getCreatedAt(), sqlRelated.getCreatedAt()) &&
               ObjectsCompat.equals(getUpdatedAt(), sqlRelated.getUpdatedAt());
@@ -10765,7 +10411,6 @@ public final class SqlRelated implements Model {
     return new StringBuilder()
       .append(getId())
       .append(getContent())
-      .append(getPrimaryId())
       .append(getPrimary())
       .append(getCreatedAt())
       .append(getUpdatedAt())
@@ -10779,7 +10424,6 @@ public final class SqlRelated implements Model {
       .append(\\"SqlRelated {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
-      .append(\\"primaryId=\\" + String.valueOf(getPrimaryId()) + \\", \\")
       .append(\\"primary=\\" + String.valueOf(getPrimary()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
       .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
@@ -10787,7 +10431,7 @@ public final class SqlRelated implements Model {
       .toString();
   }
   
-  public static PrimaryIdStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -10803,7 +10447,6 @@ public final class SqlRelated implements Model {
     return new SqlRelated(
       id,
       null,
-      null,
       null
     );
   }
@@ -10811,14 +10454,8 @@ public final class SqlRelated implements Model {
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
       content,
-      primaryId,
       primary);
   }
-  public interface PrimaryIdStep {
-    BuildStep primaryId(Integer primaryId);
-  }
-  
-
   public interface BuildStep {
     SqlRelated build();
     BuildStep id(String id);
@@ -10827,19 +10464,17 @@ public final class SqlRelated implements Model {
   }
   
 
-  public static class Builder implements PrimaryIdStep, BuildStep {
+  public static class Builder implements BuildStep {
     private Integer id;
-    private Integer primaryId;
     private String content;
     private SqlPrimary primary;
     public Builder() {
       
     }
     
-    private Builder(Integer id, String content, Integer primaryId, SqlPrimary primary) {
+    private Builder(Integer id, String content, SqlPrimary primary) {
       this.id = id;
       this.content = content;
-      this.primaryId = primaryId;
       this.primary = primary;
     }
     
@@ -10850,15 +10485,7 @@ public final class SqlRelated implements Model {
         return new SqlRelated(
           id,
           content,
-          primaryId,
           primary);
-    }
-    
-    @Override
-     public BuildStep primaryId(Integer primaryId) {
-        Objects.requireNonNull(primaryId);
-        this.primaryId = primaryId;
-        return this;
     }
     
     @Override
@@ -10885,14 +10512,9 @@ public final class SqlRelated implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(Integer id, String content, Integer primaryId, SqlPrimary primary) {
-      super(id, content, primaryId, primary);
-      Objects.requireNonNull(primaryId);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryId(Integer primaryId) {
-      return (CopyOfBuilder) super.primaryId(primaryId);
+    private CopyOfBuilder(Integer id, String content, SqlPrimary primary) {
+      super(id, content, primary);
+      
     }
     
     @Override

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -7871,15 +7871,11 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @ModelConfig(pluralName = \\"Foos\\", type = Model.Type.USER, version = 1)
 public final class Foo implements Model {
   public static final QueryField ID = field(\\"Foo\\", \\"id\\");
-  public static final QueryField FOO_BAR1_ID = field(\\"Foo\\", \\"fooBar1Id\\");
-  public static final QueryField FOO_BAR2_ID = field(\\"Foo\\", \\"fooBar2Id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"foo1\\", type = Bar.class) Bar bar1 = null;
-  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"foo1\\", type = Bar.class) Bar bar2 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar1Id\\", type = Bar.class) Bar bar1 = null;
+  private final @ModelField(targetType=\\"Bar\\") @HasOne(associatedWith = \\"bar2Id\\", type = Bar.class) Bar bar2 = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType=\\"ID\\") String fooBar1Id;
-  private final @ModelField(targetType=\\"ID\\") String fooBar2Id;
   /** @deprecated This API is internal to Amplify and should not be used. */
   @Deprecated
    public String resolveIdentifier() {
@@ -7906,18 +7902,8 @@ public final class Foo implements Model {
       return updatedAt;
   }
   
-  public String getFooBar1Id() {
-      return fooBar1Id;
-  }
-  
-  public String getFooBar2Id() {
-      return fooBar2Id;
-  }
-  
-  private Foo(String id, String fooBar1Id, String fooBar2Id) {
+  private Foo(String id) {
     this.id = id;
-    this.fooBar1Id = fooBar1Id;
-    this.fooBar2Id = fooBar2Id;
   }
   
   @Override
@@ -7930,9 +7916,7 @@ public final class Foo implements Model {
       Foo foo = (Foo) obj;
       return ObjectsCompat.equals(getId(), foo.getId()) &&
               ObjectsCompat.equals(getCreatedAt(), foo.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), foo.getUpdatedAt()) &&
-              ObjectsCompat.equals(getFooBar1Id(), foo.getFooBar1Id()) &&
-              ObjectsCompat.equals(getFooBar2Id(), foo.getFooBar2Id());
+              ObjectsCompat.equals(getUpdatedAt(), foo.getUpdatedAt());
       }
   }
   
@@ -7942,8 +7926,6 @@ public final class Foo implements Model {
       .append(getId())
       .append(getCreatedAt())
       .append(getUpdatedAt())
-      .append(getFooBar1Id())
-      .append(getFooBar2Id())
       .toString()
       .hashCode();
   }
@@ -7954,9 +7936,7 @@ public final class Foo implements Model {
       .append(\\"Foo {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
-      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()) + \\", \\")
-      .append(\\"fooBar1Id=\\" + String.valueOf(getFooBar1Id()) + \\", \\")
-      .append(\\"fooBar2Id=\\" + String.valueOf(getFooBar2Id()))
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -7975,37 +7955,27 @@ public final class Foo implements Model {
    */
   public static Foo justId(String id) {
     return new Foo(
-      id,
-      null,
-      null
+      id
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      fooBar1Id,
-      fooBar2Id);
+    return new CopyOfBuilder(id);
   }
   public interface BuildStep {
     Foo build();
     BuildStep id(String id);
-    BuildStep fooBar1Id(String fooBar1Id);
-    BuildStep fooBar2Id(String fooBar2Id);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
-    private String fooBar1Id;
-    private String fooBar2Id;
     public Builder() {
       
     }
     
-    private Builder(String id, String fooBar1Id, String fooBar2Id) {
+    private Builder(String id) {
       this.id = id;
-      this.fooBar1Id = fooBar1Id;
-      this.fooBar2Id = fooBar2Id;
     }
     
     @Override
@@ -8013,21 +7983,7 @@ public final class Foo implements Model {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new Foo(
-          id,
-          fooBar1Id,
-          fooBar2Id);
-    }
-    
-    @Override
-     public BuildStep fooBar1Id(String fooBar1Id) {
-        this.fooBar1Id = fooBar1Id;
-        return this;
-    }
-    
-    @Override
-     public BuildStep fooBar2Id(String fooBar2Id) {
-        this.fooBar2Id = fooBar2Id;
-        return this;
+          id);
     }
     
     /**
@@ -8042,19 +7998,9 @@ public final class Foo implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String fooBar1Id, String fooBar2Id) {
-      super(id, fooBar1Id, fooBar2Id);
+    private CopyOfBuilder(String id) {
+      super(id);
       
-    }
-    
-    @Override
-     public CopyOfBuilder fooBar1Id(String fooBar1Id) {
-      return (CopyOfBuilder) super.fooBar1Id(fooBar1Id);
-    }
-    
-    @Override
-     public CopyOfBuilder fooBar2Id(String fooBar2Id) {
-      return (CopyOfBuilder) super.fooBar2Id(fooBar2Id);
     }
   }
   
@@ -8098,13 +8044,13 @@ public final class Bar implements Model {
   public static final QueryField ID = field(\\"Bar\\", \\"id\\");
   public static final QueryField BAR1_ID = field(\\"Bar\\", \\"bar1Id\\");
   public static final QueryField BAR2_ID = field(\\"Bar\\", \\"bar2Id\\");
-  public static final QueryField FOO1 = field(\\"Bar\\", \\"barFoo1Id\\");
-  public static final QueryField FOO2 = field(\\"Bar\\", \\"barFoo2Id\\");
+  public static final QueryField FOO1 = field(\\"Bar\\", \\"bar1Id\\");
+  public static final QueryField FOO2 = field(\\"Bar\\", \\"bar2Id\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"ID\\") String bar1Id;
   private final @ModelField(targetType=\\"ID\\") String bar2Id;
-  private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"barFoo1Id\\", targetNames = {\\"barFoo1Id\\"}, type = Foo.class) Foo foo1;
-  private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"barFoo2Id\\", targetNames = {\\"barFoo2Id\\"}, type = Foo.class) Foo foo2;
+  private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"bar1Id\\", targetNames = {\\"bar1Id\\"}, type = Foo.class) Foo foo1;
+  private final @ModelField(targetType=\\"Foo\\") @BelongsTo(targetName = \\"bar2Id\\", targetNames = {\\"bar2Id\\"}, type = Foo.class) Foo foo2;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -8373,7 +8319,7 @@ public final class Primary implements Model {
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedWith = \\"primary\\", type = Related.class) List<Related> related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasMany(associatedWith = \\"primaryTenantId\\", type = Related.class) List<Related> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   private PrimaryIdentifier primaryIdentifier;
@@ -8622,13 +8568,13 @@ public final class Related implements Model {
   public static final QueryField PRIMARY_TENANT_ID = field(\\"Related\\", \\"primaryTenantId\\");
   public static final QueryField PRIMARY_INSTANCE_ID = field(\\"Related\\", \\"primaryInstanceId\\");
   public static final QueryField PRIMARY_RECORD_ID = field(\\"Related\\", \\"primaryRecordId\\");
-  public static final QueryField PRIMARY = field(\\"Related\\", \\"primaryRelatedTenantId\\");
+  public static final QueryField PRIMARY = field(\\"Related\\", \\"primaryTenantId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String content;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryTenantId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryInstanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryRecordId;
-  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryRelatedTenantId\\", targetNames = {\\"primaryRelatedTenantId\\", \\"primaryRelatedInstanceId\\", \\"primaryRelatedRecordId\\"}, type = Primary.class) Primary primary;
+  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryTenantId\\", targetNames = {\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -8935,15 +8881,13 @@ public final class Primary implements Model {
   public static final QueryField INSTANCE_ID = field(\\"Primary\\", \\"instanceId\\");
   public static final QueryField RECORD_ID = field(\\"Primary\\", \\"recordId\\");
   public static final QueryField CONTENT = field(\\"Primary\\", \\"content\\");
-  public static final QueryField PRIMARY_RELATED_ID = field(\\"Primary\\", \\"primaryRelatedId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String tenantId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String instanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String recordId;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedWith = \\"primary\\", type = Related.class) Related related = null;
+  private final @ModelField(targetType=\\"Related\\") @HasOne(associatedWith = \\"primaryTenantId\\", type = Related.class) Related related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType=\\"ID\\") String primaryRelatedId;
   private PrimaryIdentifier primaryIdentifier;
   /** @deprecated This API is internal to Amplify and should not be used. */
   @Deprecated
@@ -8982,16 +8926,11 @@ public final class Primary implements Model {
       return updatedAt;
   }
   
-  public String getPrimaryRelatedId() {
-      return primaryRelatedId;
-  }
-  
-  private Primary(String tenantId, String instanceId, String recordId, String content, String primaryRelatedId) {
+  private Primary(String tenantId, String instanceId, String recordId, String content) {
     this.tenantId = tenantId;
     this.instanceId = instanceId;
     this.recordId = recordId;
     this.content = content;
-    this.primaryRelatedId = primaryRelatedId;
   }
   
   @Override
@@ -9007,8 +8946,7 @@ public final class Primary implements Model {
               ObjectsCompat.equals(getRecordId(), primary.getRecordId()) &&
               ObjectsCompat.equals(getContent(), primary.getContent()) &&
               ObjectsCompat.equals(getCreatedAt(), primary.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), primary.getUpdatedAt()) &&
-              ObjectsCompat.equals(getPrimaryRelatedId(), primary.getPrimaryRelatedId());
+              ObjectsCompat.equals(getUpdatedAt(), primary.getUpdatedAt());
       }
   }
   
@@ -9021,7 +8959,6 @@ public final class Primary implements Model {
       .append(getContent())
       .append(getCreatedAt())
       .append(getUpdatedAt())
-      .append(getPrimaryRelatedId())
       .toString()
       .hashCode();
   }
@@ -9035,8 +8972,7 @@ public final class Primary implements Model {
       .append(\\"recordId=\\" + String.valueOf(getRecordId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
-      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()) + \\", \\")
-      .append(\\"primaryRelatedId=\\" + String.valueOf(getPrimaryRelatedId()))
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -9049,8 +8985,7 @@ public final class Primary implements Model {
     return new CopyOfBuilder(tenantId,
       instanceId,
       recordId,
-      content,
-      primaryRelatedId);
+      content);
   }
   public interface TenantIdStep {
     InstanceIdStep tenantId(String tenantId);
@@ -9070,7 +9005,6 @@ public final class Primary implements Model {
   public interface BuildStep {
     Primary build();
     BuildStep content(String content);
-    BuildStep primaryRelatedId(String primaryRelatedId);
   }
   
 
@@ -9079,17 +9013,15 @@ public final class Primary implements Model {
     private String instanceId;
     private String recordId;
     private String content;
-    private String primaryRelatedId;
     public Builder() {
       
     }
     
-    private Builder(String tenantId, String instanceId, String recordId, String content, String primaryRelatedId) {
+    private Builder(String tenantId, String instanceId, String recordId, String content) {
       this.tenantId = tenantId;
       this.instanceId = instanceId;
       this.recordId = recordId;
       this.content = content;
-      this.primaryRelatedId = primaryRelatedId;
     }
     
     @Override
@@ -9099,8 +9031,7 @@ public final class Primary implements Model {
           tenantId,
           instanceId,
           recordId,
-          content,
-          primaryRelatedId);
+          content);
     }
     
     @Override
@@ -9129,18 +9060,12 @@ public final class Primary implements Model {
         this.content = content;
         return this;
     }
-    
-    @Override
-     public BuildStep primaryRelatedId(String primaryRelatedId) {
-        this.primaryRelatedId = primaryRelatedId;
-        return this;
-    }
   }
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String tenantId, String instanceId, String recordId, String content, String primaryRelatedId) {
-      super(tenantId, instanceId, recordId, content, primaryRelatedId);
+    private CopyOfBuilder(String tenantId, String instanceId, String recordId, String content) {
+      super(tenantId, instanceId, recordId, content);
       Objects.requireNonNull(tenantId);
       Objects.requireNonNull(instanceId);
       Objects.requireNonNull(recordId);
@@ -9164,11 +9089,6 @@ public final class Primary implements Model {
     @Override
      public CopyOfBuilder content(String content) {
       return (CopyOfBuilder) super.content(content);
-    }
-    
-    @Override
-     public CopyOfBuilder primaryRelatedId(String primaryRelatedId) {
-      return (CopyOfBuilder) super.primaryRelatedId(primaryRelatedId);
     }
   }
   
@@ -9214,13 +9134,13 @@ public final class Related implements Model {
   public static final QueryField PRIMARY_TENANT_ID = field(\\"Related\\", \\"primaryTenantId\\");
   public static final QueryField PRIMARY_INSTANCE_ID = field(\\"Related\\", \\"primaryInstanceId\\");
   public static final QueryField PRIMARY_RECORD_ID = field(\\"Related\\", \\"primaryRecordId\\");
-  public static final QueryField PRIMARY = field(\\"Related\\", \\"relatedPrimaryTenantId\\");
+  public static final QueryField PRIMARY = field(\\"Related\\", \\"primaryTenantId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"String\\") String content;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryTenantId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryInstanceId;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryRecordId;
-  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"relatedPrimaryTenantId\\", targetNames = {\\"relatedPrimaryTenantId\\", \\"relatedPrimaryInstanceId\\", \\"relatedPrimaryRecordId\\"}, type = Primary.class) Primary primary;
+  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryTenantId\\", targetNames = {\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -9527,7 +9447,7 @@ public final class SqlPrimary implements Model {
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedWith = \\"primary\\", type = SqlRelated.class) List<SqlRelated> related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasMany(associatedWith = \\"primaryId\\", type = SqlRelated.class) List<SqlRelated> related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -9721,11 +9641,11 @@ public final class SqlRelated implements Model {
   public static final QueryField ID = field(\\"SqlRelated\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"SqlRelated\\", \\"content\\");
   public static final QueryField PRIMARY_ID = field(\\"SqlRelated\\", \\"primaryId\\");
-  public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"sqlPrimaryRelatedId\\");
+  public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer primaryId;
-  private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"sqlPrimaryRelatedId\\", targetNames = {\\"sqlPrimaryRelatedId\\"}, type = SqlPrimary.class) SqlPrimary primary;
+  private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = SqlPrimary.class) SqlPrimary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -9968,13 +9888,11 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 @Index(name = \\"undefined\\", fields = {\\"id\\"})
 public final class Primary implements Model {
   public static final QueryField ID = field(\\"Primary\\", \\"id\\");
-  public static final QueryField PRIMARY_RELATED_ONE_ID = field(\\"Primary\\", \\"primaryRelatedOneId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedWith = \\"primary\\", type = RelatedMany.class) List<RelatedMany> relatedMany = null;
-  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedWith = \\"primary\\", type = RelatedOne.class) RelatedOne relatedOne = null;
+  private final @ModelField(targetType=\\"RelatedMany\\") @HasMany(associatedWith = \\"primaryId\\", type = RelatedMany.class) List<RelatedMany> relatedMany = null;
+  private final @ModelField(targetType=\\"RelatedOne\\") @HasOne(associatedWith = \\"primaryId\\", type = RelatedOne.class) RelatedOne relatedOne = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType=\\"ID\\") String primaryRelatedOneId;
   /** @deprecated This API is internal to Amplify and should not be used. */
   @Deprecated
    public String resolveIdentifier() {
@@ -10001,13 +9919,8 @@ public final class Primary implements Model {
       return updatedAt;
   }
   
-  public String getPrimaryRelatedOneId() {
-      return primaryRelatedOneId;
-  }
-  
-  private Primary(String id, String primaryRelatedOneId) {
+  private Primary(String id) {
     this.id = id;
-    this.primaryRelatedOneId = primaryRelatedOneId;
   }
   
   @Override
@@ -10020,8 +9933,7 @@ public final class Primary implements Model {
       Primary primary = (Primary) obj;
       return ObjectsCompat.equals(getId(), primary.getId()) &&
               ObjectsCompat.equals(getCreatedAt(), primary.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), primary.getUpdatedAt()) &&
-              ObjectsCompat.equals(getPrimaryRelatedOneId(), primary.getPrimaryRelatedOneId());
+              ObjectsCompat.equals(getUpdatedAt(), primary.getUpdatedAt());
       }
   }
   
@@ -10031,7 +9943,6 @@ public final class Primary implements Model {
       .append(getId())
       .append(getCreatedAt())
       .append(getUpdatedAt())
-      .append(getPrimaryRelatedOneId())
       .toString()
       .hashCode();
   }
@@ -10042,8 +9953,7 @@ public final class Primary implements Model {
       .append(\\"Primary {\\")
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
-      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()) + \\", \\")
-      .append(\\"primaryRelatedOneId=\\" + String.valueOf(getPrimaryRelatedOneId()))
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -10062,32 +9972,27 @@ public final class Primary implements Model {
    */
   public static Primary justId(String id) {
     return new Primary(
-      id,
-      null
+      id
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
-    return new CopyOfBuilder(id,
-      primaryRelatedOneId);
+    return new CopyOfBuilder(id);
   }
   public interface BuildStep {
     Primary build();
     BuildStep id(String id);
-    BuildStep primaryRelatedOneId(String primaryRelatedOneId);
   }
   
 
   public static class Builder implements BuildStep {
     private String id;
-    private String primaryRelatedOneId;
     public Builder() {
       
     }
     
-    private Builder(String id, String primaryRelatedOneId) {
+    private Builder(String id) {
       this.id = id;
-      this.primaryRelatedOneId = primaryRelatedOneId;
     }
     
     @Override
@@ -10095,14 +10000,7 @@ public final class Primary implements Model {
         String id = this.id != null ? this.id : UUID.randomUUID().toString();
         
         return new Primary(
-          id,
-          primaryRelatedOneId);
-    }
-    
-    @Override
-     public BuildStep primaryRelatedOneId(String primaryRelatedOneId) {
-        this.primaryRelatedOneId = primaryRelatedOneId;
-        return this;
+          id);
     }
     
     /**
@@ -10117,14 +10015,9 @@ public final class Primary implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(String id, String primaryRelatedOneId) {
-      super(id, primaryRelatedOneId);
+    private CopyOfBuilder(String id) {
+      super(id);
       
-    }
-    
-    @Override
-     public CopyOfBuilder primaryRelatedOneId(String primaryRelatedOneId) {
-      return (CopyOfBuilder) super.primaryRelatedOneId(primaryRelatedOneId);
     }
   }
   
@@ -10168,10 +10061,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class RelatedMany implements Model {
   public static final QueryField ID = field(\\"RelatedMany\\", \\"id\\");
   public static final QueryField PRIMARY_ID = field(\\"RelatedMany\\", \\"primaryId\\");
-  public static final QueryField PRIMARY = field(\\"RelatedMany\\", \\"primaryRelatedManyId\\");
+  public static final QueryField PRIMARY = field(\\"RelatedMany\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryId;
-  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryRelatedManyId\\", targetNames = {\\"primaryRelatedManyId\\"}, type = Primary.class) Primary primary;
+  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -10389,10 +10282,10 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class RelatedOne implements Model {
   public static final QueryField ID = field(\\"RelatedOne\\", \\"id\\");
   public static final QueryField PRIMARY_ID = field(\\"RelatedOne\\", \\"primaryId\\");
-  public static final QueryField PRIMARY = field(\\"RelatedOne\\", \\"relatedOnePrimaryId\\");
+  public static final QueryField PRIMARY = field(\\"RelatedOne\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String primaryId;
-  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"relatedOnePrimaryId\\", targetNames = {\\"relatedOnePrimaryId\\"}, type = Primary.class) Primary primary;
+  private final @ModelField(targetType=\\"Primary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = Primary.class) Primary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */
@@ -10610,13 +10503,11 @@ import static com.amplifyframework.core.model.query.predicate.QueryField.field;
 public final class SqlPrimary implements Model {
   public static final QueryField ID = field(\\"SqlPrimary\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"SqlPrimary\\", \\"content\\");
-  public static final QueryField SQL_PRIMARY_RELATED_ID = field(\\"SqlPrimary\\", \\"sqlPrimaryRelatedId\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
-  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedWith = \\"primary\\", type = SqlRelated.class) SqlRelated related = null;
+  private final @ModelField(targetType=\\"SqlRelated\\") @HasOne(associatedWith = \\"primaryId\\", type = SqlRelated.class) SqlRelated related = null;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
-  private final @ModelField(targetType=\\"Int\\") Integer sqlPrimaryRelatedId;
   /** @deprecated This API is internal to Amplify and should not be used. */
   @Deprecated
    public Integer resolveIdentifier() {
@@ -10643,14 +10534,9 @@ public final class SqlPrimary implements Model {
       return updatedAt;
   }
   
-  public Integer getSqlPrimaryRelatedId() {
-      return sqlPrimaryRelatedId;
-  }
-  
-  private SqlPrimary(Integer id, String content, Integer sqlPrimaryRelatedId) {
+  private SqlPrimary(Integer id, String content) {
     this.id = id;
     this.content = content;
-    this.sqlPrimaryRelatedId = sqlPrimaryRelatedId;
   }
   
   @Override
@@ -10664,8 +10550,7 @@ public final class SqlPrimary implements Model {
       return ObjectsCompat.equals(getId(), sqlPrimary.getId()) &&
               ObjectsCompat.equals(getContent(), sqlPrimary.getContent()) &&
               ObjectsCompat.equals(getCreatedAt(), sqlPrimary.getCreatedAt()) &&
-              ObjectsCompat.equals(getUpdatedAt(), sqlPrimary.getUpdatedAt()) &&
-              ObjectsCompat.equals(getSqlPrimaryRelatedId(), sqlPrimary.getSqlPrimaryRelatedId());
+              ObjectsCompat.equals(getUpdatedAt(), sqlPrimary.getUpdatedAt());
       }
   }
   
@@ -10676,7 +10561,6 @@ public final class SqlPrimary implements Model {
       .append(getContent())
       .append(getCreatedAt())
       .append(getUpdatedAt())
-      .append(getSqlPrimaryRelatedId())
       .toString()
       .hashCode();
   }
@@ -10688,8 +10572,7 @@ public final class SqlPrimary implements Model {
       .append(\\"id=\\" + String.valueOf(getId()) + \\", \\")
       .append(\\"content=\\" + String.valueOf(getContent()) + \\", \\")
       .append(\\"createdAt=\\" + String.valueOf(getCreatedAt()) + \\", \\")
-      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()) + \\", \\")
-      .append(\\"sqlPrimaryRelatedId=\\" + String.valueOf(getSqlPrimaryRelatedId()))
+      .append(\\"updatedAt=\\" + String.valueOf(getUpdatedAt()))
       .append(\\"}\\")
       .toString();
   }
@@ -10709,36 +10592,31 @@ public final class SqlPrimary implements Model {
   public static SqlPrimary justId(String id) {
     return new SqlPrimary(
       id,
-      null,
       null
     );
   }
   
   public CopyOfBuilder copyOfBuilder() {
     return new CopyOfBuilder(id,
-      content,
-      sqlPrimaryRelatedId);
+      content);
   }
   public interface BuildStep {
     SqlPrimary build();
     BuildStep id(String id);
     BuildStep content(String content);
-    BuildStep sqlPrimaryRelatedId(Integer sqlPrimaryRelatedId);
   }
   
 
   public static class Builder implements BuildStep {
     private Integer id;
     private String content;
-    private Integer sqlPrimaryRelatedId;
     public Builder() {
       
     }
     
-    private Builder(Integer id, String content, Integer sqlPrimaryRelatedId) {
+    private Builder(Integer id, String content) {
       this.id = id;
       this.content = content;
-      this.sqlPrimaryRelatedId = sqlPrimaryRelatedId;
     }
     
     @Override
@@ -10747,19 +10625,12 @@ public final class SqlPrimary implements Model {
         
         return new SqlPrimary(
           id,
-          content,
-          sqlPrimaryRelatedId);
+          content);
     }
     
     @Override
      public BuildStep content(String content) {
         this.content = content;
-        return this;
-    }
-    
-    @Override
-     public BuildStep sqlPrimaryRelatedId(Integer sqlPrimaryRelatedId) {
-        this.sqlPrimaryRelatedId = sqlPrimaryRelatedId;
         return this;
     }
     
@@ -10775,19 +10646,14 @@ public final class SqlPrimary implements Model {
   
 
   public final class CopyOfBuilder extends Builder {
-    private CopyOfBuilder(Integer id, String content, Integer sqlPrimaryRelatedId) {
-      super(id, content, sqlPrimaryRelatedId);
+    private CopyOfBuilder(Integer id, String content) {
+      super(id, content);
       
     }
     
     @Override
      public CopyOfBuilder content(String content) {
       return (CopyOfBuilder) super.content(content);
-    }
-    
-    @Override
-     public CopyOfBuilder sqlPrimaryRelatedId(Integer sqlPrimaryRelatedId) {
-      return (CopyOfBuilder) super.sqlPrimaryRelatedId(sqlPrimaryRelatedId);
     }
   }
   
@@ -10833,11 +10699,11 @@ public final class SqlRelated implements Model {
   public static final QueryField ID = field(\\"SqlRelated\\", \\"id\\");
   public static final QueryField CONTENT = field(\\"SqlRelated\\", \\"content\\");
   public static final QueryField PRIMARY_ID = field(\\"SqlRelated\\", \\"primaryId\\");
-  public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"sqlRelatedPrimaryId\\");
+  public static final QueryField PRIMARY = field(\\"SqlRelated\\", \\"primaryId\\");
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer id;
   private final @ModelField(targetType=\\"String\\") String content;
   private final @ModelField(targetType=\\"Int\\", isRequired = true) Integer primaryId;
-  private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"sqlRelatedPrimaryId\\", targetNames = {\\"sqlRelatedPrimaryId\\"}, type = SqlPrimary.class) SqlPrimary primary;
+  private final @ModelField(targetType=\\"SqlPrimary\\") @BelongsTo(targetName = \\"primaryId\\", targetNames = {\\"primaryId\\"}, type = SqlPrimary.class) SqlPrimary primary;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   /** @deprecated This API is internal to Amplify and should not be used. */

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1312,36 +1312,26 @@ public struct Foo: Model {
     }
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  public var fooBar1Id: String?
-  public var fooBar2Id: String?
   
   public init(id: String = UUID().uuidString,
       bar1: Bar? = nil,
-      bar2: Bar? = nil,
-      fooBar1Id: String? = nil,
-      fooBar2Id: String? = nil) {
+      bar2: Bar? = nil) {
     self.init(id: id,
       bar1: bar1,
       bar2: bar2,
       createdAt: nil,
-      updatedAt: nil,
-      fooBar1Id: fooBar1Id,
-      fooBar2Id: fooBar2Id)
+      updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
       bar1: Bar? = nil,
       bar2: Bar? = nil,
       createdAt: Temporal.DateTime? = nil,
-      updatedAt: Temporal.DateTime? = nil,
-      fooBar1Id: String? = nil,
-      fooBar2Id: String? = nil) {
+      updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self._bar1 = LazyReference(bar1)
       self._bar2 = LazyReference(bar2)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
-      self.fooBar1Id = fooBar1Id
-      self.fooBar2Id = fooBar2Id
   }
   public mutating func setBar1(_ bar1: Bar? = nil) {
     self._bar1 = LazyReference(bar1)
@@ -1356,8 +1346,6 @@ public struct Foo: Model {
       _bar2 = try values.decodeIfPresent(LazyReference<Bar>.self, forKey: .bar2) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
-      fooBar1Id = try? values.decode(String?.self, forKey: .fooBar1Id)
-      fooBar2Id = try? values.decode(String?.self, forKey: .fooBar2Id)
   }
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
@@ -1366,8 +1354,6 @@ public struct Foo: Model {
       try container.encode(_bar2, forKey: .bar2)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
-      try container.encode(fooBar1Id, forKey: .fooBar1Id)
-      try container.encode(fooBar2Id, forKey: .fooBar2Id)
   }
 }"
 `;
@@ -1385,8 +1371,6 @@ extension Foo {
     case bar2
     case createdAt
     case updatedAt
-    case fooBar1Id
-    case fooBar2Id
   }
   
   public static let keys = CodingKeys.self
@@ -1404,12 +1388,10 @@ extension Foo {
     
     model.fields(
       .field(foo.id, is: .required, ofType: .string),
-      .hasOne(foo.bar1, is: .optional, ofType: Bar.self, associatedWith: Bar.keys.foo1, targetNames: [\\"fooBar1Id\\"]),
-      .hasOne(foo.bar2, is: .optional, ofType: Bar.self, associatedWith: Bar.keys.foo1, targetNames: [\\"fooBar2Id\\"]),
+      .field(foo.bar1, is: .optional, ofType: .model(Bar.self)),
+      .field(foo.bar2, is: .optional, ofType: .model(Bar.self)),
       .field(foo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(foo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(foo.fooBar1Id, is: .optional, ofType: .string),
-      .field(foo.fooBar2Id, is: .optional, ofType: .string)
+      .field(foo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
     public class Path: ModelPath<Foo> { }
@@ -1436,12 +1418,6 @@ extension ModelPath where ModelType == Foo {
     }
   public var updatedAt: FieldPath<Temporal.DateTime>   {
       datetime(\\"updatedAt\\") 
-    }
-  public var fooBar1Id: FieldPath<String>   {
-      string(\\"fooBar1Id\\") 
-    }
-  public var fooBar2Id: FieldPath<String>   {
-      string(\\"fooBar2Id\\") 
     }
 }"
 `;
@@ -1561,8 +1537,8 @@ extension Bar {
       .field(bar.id, is: .required, ofType: .string),
       .field(bar.bar1Id, is: .optional, ofType: .string),
       .field(bar.bar2Id, is: .optional, ofType: .string),
-      .belongsTo(bar.foo1, is: .optional, ofType: Foo.self, targetNames: [\\"barFoo1Id\\"]),
-      .belongsTo(bar.foo2, is: .optional, ofType: Foo.self, targetNames: [\\"barFoo2Id\\"]),
+      .belongsTo(bar.foo1, is: .optional, ofType: Foo.self, targetNames: [\\"bar1Id\\"]),
+      .belongsTo(bar.foo2, is: .optional, ofType: Foo.self, targetNames: [\\"bar2Id\\"]),
       .field(bar.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(bar.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1682,7 +1658,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primary),
+      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primaryTenantId),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1846,7 +1822,7 @@ extension Related {
       .field(related.primaryTenantId, is: .required, ofType: .string),
       .field(related.primaryInstanceId, is: .required, ofType: .string),
       .field(related.primaryRecordId, is: .required, ofType: .string),
-      .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryRelatedTenantId\\", \\"primaryRelatedInstanceId\\", \\"primaryRelatedRecordId\\"]),
+      .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"]),
       .field(related.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(related.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1906,22 +1882,19 @@ public struct Primary: Model {
     }
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  public var primaryRelatedId: String?
   
   public init(tenantId: String,
       instanceId: String,
       recordId: String,
       content: String? = nil,
-      related: Related? = nil,
-      primaryRelatedId: String? = nil) {
+      related: Related? = nil) {
     self.init(tenantId: tenantId,
       instanceId: instanceId,
       recordId: recordId,
       content: content,
       related: related,
       createdAt: nil,
-      updatedAt: nil,
-      primaryRelatedId: primaryRelatedId)
+      updatedAt: nil)
   }
   internal init(tenantId: String,
       instanceId: String,
@@ -1929,8 +1902,7 @@ public struct Primary: Model {
       content: String? = nil,
       related: Related? = nil,
       createdAt: Temporal.DateTime? = nil,
-      updatedAt: Temporal.DateTime? = nil,
-      primaryRelatedId: String? = nil) {
+      updatedAt: Temporal.DateTime? = nil) {
       self.tenantId = tenantId
       self.instanceId = instanceId
       self.recordId = recordId
@@ -1938,7 +1910,6 @@ public struct Primary: Model {
       self._related = LazyReference(related)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
-      self.primaryRelatedId = primaryRelatedId
   }
   public mutating func setRelated(_ related: Related? = nil) {
     self._related = LazyReference(related)
@@ -1952,7 +1923,6 @@ public struct Primary: Model {
       _related = try values.decodeIfPresent(LazyReference<Related>.self, forKey: .related) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
-      primaryRelatedId = try? values.decode(String?.self, forKey: .primaryRelatedId)
   }
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
@@ -1963,7 +1933,6 @@ public struct Primary: Model {
       try container.encode(_related, forKey: .related)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
-      try container.encode(primaryRelatedId, forKey: .primaryRelatedId)
   }
 }"
 `;
@@ -1983,7 +1952,6 @@ extension Primary {
     case related
     case createdAt
     case updatedAt
-    case primaryRelatedId
   }
   
   public static let keys = CodingKeys.self
@@ -2005,10 +1973,9 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .hasOne(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primary, targetNames: [\\"primaryRelatedId\\"]),
+      .field(primary.related, is: .optional, ofType: .model(Related.self)),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(primary.primaryRelatedId, is: .optional, ofType: .string)
+      .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
     public class Path: ModelPath<Primary> { }
@@ -2049,9 +2016,6 @@ extension ModelPath where ModelType == Primary {
     }
   public var updatedAt: FieldPath<Temporal.DateTime>   {
       datetime(\\"updatedAt\\") 
-    }
-  public var primaryRelatedId: FieldPath<String>   {
-      string(\\"primaryRelatedId\\") 
     }
 }"
 `;
@@ -2173,7 +2137,7 @@ extension Related {
       .field(related.primaryTenantId, is: .required, ofType: .string),
       .field(related.primaryInstanceId, is: .required, ofType: .string),
       .field(related.primaryRecordId, is: .required, ofType: .string),
-      .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"relatedPrimaryTenantId\\", \\"relatedPrimaryInstanceId\\", \\"relatedPrimaryRecordId\\"]),
+      .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"]),
       .field(related.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(related.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2282,7 +2246,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primary),
+      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primaryId),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2416,7 +2380,7 @@ extension SqlRelated {
       .field(sqlRelated.id, is: .required, ofType: .int),
       .field(sqlRelated.content, is: .optional, ofType: .string),
       .field(sqlRelated.primaryId, is: .required, ofType: .int),
-      .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"sqlPrimaryRelatedId\\"]),
+      .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"primaryId\\"]),
       .field(sqlRelated.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlRelated.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2468,31 +2432,26 @@ public struct Primary: Model {
     }
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  public var primaryRelatedOneId: String?
   
   public init(id: String = UUID().uuidString,
       relatedMany: List<RelatedMany>? = [],
-      relatedOne: RelatedOne? = nil,
-      primaryRelatedOneId: String? = nil) {
+      relatedOne: RelatedOne? = nil) {
     self.init(id: id,
       relatedMany: relatedMany,
       relatedOne: relatedOne,
       createdAt: nil,
-      updatedAt: nil,
-      primaryRelatedOneId: primaryRelatedOneId)
+      updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
       relatedMany: List<RelatedMany>? = [],
       relatedOne: RelatedOne? = nil,
       createdAt: Temporal.DateTime? = nil,
-      updatedAt: Temporal.DateTime? = nil,
-      primaryRelatedOneId: String? = nil) {
+      updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.relatedMany = relatedMany
       self._relatedOne = LazyReference(relatedOne)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
-      self.primaryRelatedOneId = primaryRelatedOneId
   }
   public mutating func setRelatedOne(_ relatedOne: RelatedOne? = nil) {
     self._relatedOne = LazyReference(relatedOne)
@@ -2504,7 +2463,6 @@ public struct Primary: Model {
       _relatedOne = try values.decodeIfPresent(LazyReference<RelatedOne>.self, forKey: .relatedOne) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
-      primaryRelatedOneId = try? values.decode(String?.self, forKey: .primaryRelatedOneId)
   }
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
@@ -2513,7 +2471,6 @@ public struct Primary: Model {
       try container.encode(_relatedOne, forKey: .relatedOne)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
-      try container.encode(primaryRelatedOneId, forKey: .primaryRelatedOneId)
   }
 }"
 `;
@@ -2531,7 +2488,6 @@ extension Primary {
     case relatedOne
     case createdAt
     case updatedAt
-    case primaryRelatedOneId
   }
   
   public static let keys = CodingKeys.self
@@ -2550,11 +2506,10 @@ extension Primary {
     
     model.fields(
       .field(primary.id, is: .required, ofType: .string),
-      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedWith: RelatedMany.keys.primary),
-      .hasOne(primary.relatedOne, is: .optional, ofType: RelatedOne.self, associatedWith: RelatedOne.keys.primary, targetNames: [\\"primaryRelatedOneId\\"]),
+      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedWith: RelatedMany.keys.primaryId),
+      .field(primary.relatedOne, is: .optional, ofType: .model(RelatedOne.self)),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(primary.primaryRelatedOneId, is: .optional, ofType: .string)
+      .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
     public class Path: ModelPath<Primary> { }
@@ -2581,9 +2536,6 @@ extension ModelPath where ModelType == Primary {
     }
   public var updatedAt: FieldPath<Temporal.DateTime>   {
       datetime(\\"updatedAt\\") 
-    }
-  public var primaryRelatedOneId: FieldPath<String>   {
-      string(\\"primaryRelatedOneId\\") 
     }
 }"
 `;
@@ -2679,7 +2631,7 @@ extension RelatedMany {
     model.fields(
       .field(relatedMany.id, is: .required, ofType: .string),
       .field(relatedMany.primaryId, is: .required, ofType: .string),
-      .belongsTo(relatedMany.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryRelatedManyId\\"]),
+      .belongsTo(relatedMany.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryId\\"]),
       .field(relatedMany.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(relatedMany.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2803,7 +2755,7 @@ extension RelatedOne {
     model.fields(
       .field(relatedOne.id, is: .required, ofType: .string),
       .field(relatedOne.primaryId, is: .required, ofType: .string),
-      .belongsTo(relatedOne.primary, is: .optional, ofType: Primary.self, targetNames: [\\"relatedOnePrimaryId\\"]),
+      .belongsTo(relatedOne.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryId\\"]),
       .field(relatedOne.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(relatedOne.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2852,31 +2804,26 @@ public struct SqlPrimary: Model {
     }
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
-  public var sqlPrimaryRelatedId: Int?
   
   public init(id: Int = UUID().uuidString,
       content: String? = nil,
-      related: SqlRelated? = nil,
-      sqlPrimaryRelatedId: Int? = nil) {
+      related: SqlRelated? = nil) {
     self.init(id: id,
       content: content,
       related: related,
       createdAt: nil,
-      updatedAt: nil,
-      sqlPrimaryRelatedId: sqlPrimaryRelatedId)
+      updatedAt: nil)
   }
   internal init(id: Int = UUID().uuidString,
       content: String? = nil,
       related: SqlRelated? = nil,
       createdAt: Temporal.DateTime? = nil,
-      updatedAt: Temporal.DateTime? = nil,
-      sqlPrimaryRelatedId: Int? = nil) {
+      updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.content = content
       self._related = LazyReference(related)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
-      self.sqlPrimaryRelatedId = sqlPrimaryRelatedId
   }
   public mutating func setRelated(_ related: SqlRelated? = nil) {
     self._related = LazyReference(related)
@@ -2888,7 +2835,6 @@ public struct SqlPrimary: Model {
       _related = try values.decodeIfPresent(LazyReference<SqlRelated>.self, forKey: .related) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
-      sqlPrimaryRelatedId = try? values.decode(Int?.self, forKey: .sqlPrimaryRelatedId)
   }
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
@@ -2897,7 +2843,6 @@ public struct SqlPrimary: Model {
       try container.encode(_related, forKey: .related)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
-      try container.encode(sqlPrimaryRelatedId, forKey: .sqlPrimaryRelatedId)
   }
 }"
 `;
@@ -2915,7 +2860,6 @@ extension SqlPrimary {
     case related
     case createdAt
     case updatedAt
-    case sqlPrimaryRelatedId
   }
   
   public static let keys = CodingKeys.self
@@ -2935,10 +2879,9 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .hasOne(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primary, targetNames: [\\"sqlPrimaryRelatedId\\"]),
+      .field(sqlPrimary.related, is: .optional, ofType: .model(SqlRelated.self)),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
-      .field(sqlPrimary.sqlPrimaryRelatedId, is: .optional, ofType: .int)
+      .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
     public class Path: ModelPath<SqlPrimary> { }
@@ -2965,9 +2908,6 @@ extension ModelPath where ModelType == SqlPrimary {
     }
   public var updatedAt: FieldPath<Temporal.DateTime>   {
       datetime(\\"updatedAt\\") 
-    }
-  public var sqlPrimaryRelatedId: FieldPath<Int>   {
-      int(\\"sqlPrimaryRelatedId\\") 
     }
 }"
 `;
@@ -3073,7 +3013,7 @@ extension SqlRelated {
       .field(sqlRelated.id, is: .required, ofType: .int),
       .field(sqlRelated.content, is: .optional, ofType: .string),
       .field(sqlRelated.primaryId, is: .required, ofType: .int),
-      .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"sqlRelatedPrimaryId\\"]),
+      .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"primaryId\\"]),
       .field(sqlRelated.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlRelated.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1388,8 +1388,8 @@ extension Foo {
     
     model.fields(
       .field(foo.id, is: .required, ofType: .string),
-      .field(foo.bar1, is: .optional, ofType: .model(Bar.self)),
-      .field(foo.bar2, is: .optional, ofType: .model(Bar.self)),
+      .hasOne(foo.bar1, is: .optional, ofType: Bar.self, associatedFields: [Bar.keys.foo1]),
+      .hasOne(foo.bar2, is: .optional, ofType: Bar.self, associatedFields: [Bar.keys.foo2]),
       .field(foo.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(foo.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1658,7 +1658,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedWith: Related.keys.primaryTenantId),
+      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primary],
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -1973,7 +1973,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .field(primary.related, is: .optional, ofType: .model(Related.self)),
+      .hasOne(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primary]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2246,7 +2246,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedWith: SqlRelated.keys.primaryId),
+      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primary],
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2506,8 +2506,8 @@ extension Primary {
     
     model.fields(
       .field(primary.id, is: .required, ofType: .string),
-      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedWith: RelatedMany.keys.primaryId),
-      .field(primary.relatedOne, is: .optional, ofType: .model(RelatedOne.self)),
+      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedFields: [RelatedMany.keys.primary],
+      .hasOne(primary.relatedOne, is: .optional, ofType: RelatedOne.self, associatedFields: [RelatedOne.keys.primary]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2879,7 +2879,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .field(sqlPrimary.related, is: .optional, ofType: .model(SqlRelated.self)),
+      .hasOne(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primary]),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1429,8 +1429,6 @@ import Foundation
 
 public struct Bar: Model {
   public let id: String
-  public var bar1Id: String?
-  public var bar2Id: String?
   internal var _foo1: LazyReference<Foo>
   public var foo1: Foo?   {
       get async throws { 
@@ -1447,28 +1445,20 @@ public struct Bar: Model {
   public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
-      bar1Id: String? = nil,
-      bar2Id: String? = nil,
       foo1: Foo? = nil,
       foo2: Foo? = nil) {
     self.init(id: id,
-      bar1Id: bar1Id,
-      bar2Id: bar2Id,
       foo1: foo1,
       foo2: foo2,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
-      bar1Id: String? = nil,
-      bar2Id: String? = nil,
       foo1: Foo? = nil,
       foo2: Foo? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
-      self.bar1Id = bar1Id
-      self.bar2Id = bar2Id
       self._foo1 = LazyReference(foo1)
       self._foo2 = LazyReference(foo2)
       self.createdAt = createdAt
@@ -1483,8 +1473,6 @@ public struct Bar: Model {
   public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(String.self, forKey: .id)
-      bar1Id = try? values.decode(String?.self, forKey: .bar1Id)
-      bar2Id = try? values.decode(String?.self, forKey: .bar2Id)
       _foo1 = try values.decodeIfPresent(LazyReference<Foo>.self, forKey: .foo1) ?? LazyReference(identifiers: nil)
       _foo2 = try values.decodeIfPresent(LazyReference<Foo>.self, forKey: .foo2) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
@@ -1493,8 +1481,6 @@ public struct Bar: Model {
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
-      try container.encode(bar1Id, forKey: .bar1Id)
-      try container.encode(bar2Id, forKey: .bar2Id)
       try container.encode(_foo1, forKey: .foo1)
       try container.encode(_foo2, forKey: .foo2)
       try container.encode(createdAt, forKey: .createdAt)
@@ -1512,8 +1498,6 @@ extension Bar {
   // MARK: - CodingKeys 
    public enum CodingKeys: String, ModelKey {
     case id
-    case bar1Id
-    case bar2Id
     case foo1
     case foo2
     case createdAt
@@ -1535,8 +1519,6 @@ extension Bar {
     
     model.fields(
       .field(bar.id, is: .required, ofType: .string),
-      .field(bar.bar1Id, is: .optional, ofType: .string),
-      .field(bar.bar2Id, is: .optional, ofType: .string),
       .belongsTo(bar.foo1, is: .optional, ofType: Foo.self, targetNames: [\\"bar1Id\\"]),
       .belongsTo(bar.foo2, is: .optional, ofType: Foo.self, targetNames: [\\"bar2Id\\"]),
       .field(bar.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
@@ -1555,12 +1537,6 @@ extension Bar: ModelIdentifiable {
 extension ModelPath where ModelType == Bar {
   public var id: FieldPath<String>   {
       string(\\"id\\") 
-    }
-  public var bar1Id: FieldPath<String>   {
-      string(\\"bar1Id\\") 
-    }
-  public var bar2Id: FieldPath<String>   {
-      string(\\"bar2Id\\") 
     }
   public var foo1: ModelPath<Foo>   {
       Foo.Path(name: \\"foo1\\", parent: self) 
@@ -1713,9 +1689,6 @@ import Foundation
 public struct Related: Model {
   public let id: String
   public var content: String?
-  public var primaryTenantId: String
-  public var primaryInstanceId: String
-  public var primaryRecordId: String
   internal var _primary: LazyReference<Primary>
   public var primary: Primary?   {
       get async throws { 
@@ -1727,32 +1700,20 @@ public struct Related: Model {
   
   public init(id: String = UUID().uuidString,
       content: String? = nil,
-      primaryTenantId: String,
-      primaryInstanceId: String,
-      primaryRecordId: String,
       primary: Primary? = nil) {
     self.init(id: id,
       content: content,
-      primaryTenantId: primaryTenantId,
-      primaryInstanceId: primaryInstanceId,
-      primaryRecordId: primaryRecordId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
       content: String? = nil,
-      primaryTenantId: String,
-      primaryInstanceId: String,
-      primaryRecordId: String,
       primary: Primary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.content = content
-      self.primaryTenantId = primaryTenantId
-      self.primaryInstanceId = primaryInstanceId
-      self.primaryRecordId = primaryRecordId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -1764,9 +1725,6 @@ public struct Related: Model {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(String.self, forKey: .id)
       content = try? values.decode(String?.self, forKey: .content)
-      primaryTenantId = try values.decode(String.self, forKey: .primaryTenantId)
-      primaryInstanceId = try values.decode(String.self, forKey: .primaryInstanceId)
-      primaryRecordId = try values.decode(String.self, forKey: .primaryRecordId)
       _primary = try values.decodeIfPresent(LazyReference<Primary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -1775,9 +1733,6 @@ public struct Related: Model {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
       try container.encode(content, forKey: .content)
-      try container.encode(primaryTenantId, forKey: .primaryTenantId)
-      try container.encode(primaryInstanceId, forKey: .primaryInstanceId)
-      try container.encode(primaryRecordId, forKey: .primaryRecordId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -1795,9 +1750,6 @@ extension Related {
    public enum CodingKeys: String, ModelKey {
     case id
     case content
-    case primaryTenantId
-    case primaryInstanceId
-    case primaryRecordId
     case primary
     case createdAt
     case updatedAt
@@ -1819,9 +1771,6 @@ extension Related {
     model.fields(
       .field(related.id, is: .required, ofType: .string),
       .field(related.content, is: .optional, ofType: .string),
-      .field(related.primaryTenantId, is: .required, ofType: .string),
-      .field(related.primaryInstanceId, is: .required, ofType: .string),
-      .field(related.primaryRecordId, is: .required, ofType: .string),
       .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"]),
       .field(related.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(related.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -1842,15 +1791,6 @@ extension ModelPath where ModelType == Related {
     }
   public var content: FieldPath<String>   {
       string(\\"content\\") 
-    }
-  public var primaryTenantId: FieldPath<String>   {
-      string(\\"primaryTenantId\\") 
-    }
-  public var primaryInstanceId: FieldPath<String>   {
-      string(\\"primaryInstanceId\\") 
-    }
-  public var primaryRecordId: FieldPath<String>   {
-      string(\\"primaryRecordId\\") 
     }
   public var primary: ModelPath<Primary>   {
       Primary.Path(name: \\"primary\\", parent: self) 
@@ -2028,9 +1968,6 @@ import Foundation
 public struct Related: Model {
   public let id: String
   public var content: String?
-  public var primaryTenantId: String
-  public var primaryInstanceId: String
-  public var primaryRecordId: String
   internal var _primary: LazyReference<Primary>
   public var primary: Primary?   {
       get async throws { 
@@ -2042,32 +1979,20 @@ public struct Related: Model {
   
   public init(id: String = UUID().uuidString,
       content: String? = nil,
-      primaryTenantId: String,
-      primaryInstanceId: String,
-      primaryRecordId: String,
       primary: Primary? = nil) {
     self.init(id: id,
       content: content,
-      primaryTenantId: primaryTenantId,
-      primaryInstanceId: primaryInstanceId,
-      primaryRecordId: primaryRecordId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
       content: String? = nil,
-      primaryTenantId: String,
-      primaryInstanceId: String,
-      primaryRecordId: String,
       primary: Primary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.content = content
-      self.primaryTenantId = primaryTenantId
-      self.primaryInstanceId = primaryInstanceId
-      self.primaryRecordId = primaryRecordId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -2079,9 +2004,6 @@ public struct Related: Model {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(String.self, forKey: .id)
       content = try? values.decode(String?.self, forKey: .content)
-      primaryTenantId = try values.decode(String.self, forKey: .primaryTenantId)
-      primaryInstanceId = try values.decode(String.self, forKey: .primaryInstanceId)
-      primaryRecordId = try values.decode(String.self, forKey: .primaryRecordId)
       _primary = try values.decodeIfPresent(LazyReference<Primary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -2090,9 +2012,6 @@ public struct Related: Model {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
       try container.encode(content, forKey: .content)
-      try container.encode(primaryTenantId, forKey: .primaryTenantId)
-      try container.encode(primaryInstanceId, forKey: .primaryInstanceId)
-      try container.encode(primaryRecordId, forKey: .primaryRecordId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -2110,9 +2029,6 @@ extension Related {
    public enum CodingKeys: String, ModelKey {
     case id
     case content
-    case primaryTenantId
-    case primaryInstanceId
-    case primaryRecordId
     case primary
     case createdAt
     case updatedAt
@@ -2134,9 +2050,6 @@ extension Related {
     model.fields(
       .field(related.id, is: .required, ofType: .string),
       .field(related.content, is: .optional, ofType: .string),
-      .field(related.primaryTenantId, is: .required, ofType: .string),
-      .field(related.primaryInstanceId, is: .required, ofType: .string),
-      .field(related.primaryRecordId, is: .required, ofType: .string),
       .belongsTo(related.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryTenantId\\", \\"primaryInstanceId\\", \\"primaryRecordId\\"]),
       .field(related.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(related.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2157,15 +2070,6 @@ extension ModelPath where ModelType == Related {
     }
   public var content: FieldPath<String>   {
       string(\\"content\\") 
-    }
-  public var primaryTenantId: FieldPath<String>   {
-      string(\\"primaryTenantId\\") 
-    }
-  public var primaryInstanceId: FieldPath<String>   {
-      string(\\"primaryInstanceId\\") 
-    }
-  public var primaryRecordId: FieldPath<String>   {
-      string(\\"primaryRecordId\\") 
     }
   public var primary: ModelPath<Primary>   {
       Primary.Path(name: \\"primary\\", parent: self) 
@@ -2287,7 +2191,6 @@ import Foundation
 public struct SqlRelated: Model {
   public let id: Int
   public var content: String?
-  public var primaryId: Int
   internal var _primary: LazyReference<SqlPrimary>
   public var primary: SqlPrimary?   {
       get async throws { 
@@ -2299,24 +2202,20 @@ public struct SqlRelated: Model {
   
   public init(id: Int = UUID().uuidString,
       content: String? = nil,
-      primaryId: Int,
       primary: SqlPrimary? = nil) {
     self.init(id: id,
       content: content,
-      primaryId: primaryId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: Int = UUID().uuidString,
       content: String? = nil,
-      primaryId: Int,
       primary: SqlPrimary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.content = content
-      self.primaryId = primaryId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -2328,7 +2227,6 @@ public struct SqlRelated: Model {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(Int.self, forKey: .id)
       content = try? values.decode(String?.self, forKey: .content)
-      primaryId = try values.decode(Int.self, forKey: .primaryId)
       _primary = try values.decodeIfPresent(LazyReference<SqlPrimary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -2337,7 +2235,6 @@ public struct SqlRelated: Model {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
       try container.encode(content, forKey: .content)
-      try container.encode(primaryId, forKey: .primaryId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -2355,7 +2252,6 @@ extension SqlRelated {
    public enum CodingKeys: String, ModelKey {
     case id
     case content
-    case primaryId
     case primary
     case createdAt
     case updatedAt
@@ -2379,7 +2275,6 @@ extension SqlRelated {
     model.fields(
       .field(sqlRelated.id, is: .required, ofType: .int),
       .field(sqlRelated.content, is: .optional, ofType: .string),
-      .field(sqlRelated.primaryId, is: .required, ofType: .int),
       .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"primaryId\\"]),
       .field(sqlRelated.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlRelated.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2400,9 +2295,6 @@ extension ModelPath where ModelType == SqlRelated {
     }
   public var content: FieldPath<String>   {
       string(\\"content\\") 
-    }
-  public var primaryId: FieldPath<Int>   {
-      int(\\"primaryId\\") 
     }
   public var primary: ModelPath<SqlPrimary>   {
       SqlPrimary.Path(name: \\"primary\\", parent: self) 
@@ -2547,7 +2439,6 @@ import Foundation
 
 public struct RelatedMany: Model {
   public let id: String
-  public var primaryId: String
   internal var _primary: LazyReference<Primary>
   public var primary: Primary?   {
       get async throws { 
@@ -2558,21 +2449,17 @@ public struct RelatedMany: Model {
   public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
-      primaryId: String,
       primary: Primary? = nil) {
     self.init(id: id,
-      primaryId: primaryId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
-      primaryId: String,
       primary: Primary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
-      self.primaryId = primaryId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -2583,7 +2470,6 @@ public struct RelatedMany: Model {
   public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(String.self, forKey: .id)
-      primaryId = try values.decode(String.self, forKey: .primaryId)
       _primary = try values.decodeIfPresent(LazyReference<Primary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -2591,7 +2477,6 @@ public struct RelatedMany: Model {
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
-      try container.encode(primaryId, forKey: .primaryId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -2608,7 +2493,6 @@ extension RelatedMany {
   // MARK: - CodingKeys 
    public enum CodingKeys: String, ModelKey {
     case id
-    case primaryId
     case primary
     case createdAt
     case updatedAt
@@ -2630,7 +2514,6 @@ extension RelatedMany {
     
     model.fields(
       .field(relatedMany.id, is: .required, ofType: .string),
-      .field(relatedMany.primaryId, is: .required, ofType: .string),
       .belongsTo(relatedMany.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryId\\"]),
       .field(relatedMany.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(relatedMany.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2648,9 +2531,6 @@ extension RelatedMany: ModelIdentifiable {
 extension ModelPath where ModelType == RelatedMany {
   public var id: FieldPath<String>   {
       string(\\"id\\") 
-    }
-  public var primaryId: FieldPath<String>   {
-      string(\\"primaryId\\") 
     }
   public var primary: ModelPath<Primary>   {
       Primary.Path(name: \\"primary\\", parent: self) 
@@ -2671,7 +2551,6 @@ import Foundation
 
 public struct RelatedOne: Model {
   public let id: String
-  public var primaryId: String
   internal var _primary: LazyReference<Primary>
   public var primary: Primary?   {
       get async throws { 
@@ -2682,21 +2561,17 @@ public struct RelatedOne: Model {
   public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
-      primaryId: String,
       primary: Primary? = nil) {
     self.init(id: id,
-      primaryId: primaryId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
-      primaryId: String,
       primary: Primary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
-      self.primaryId = primaryId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -2707,7 +2582,6 @@ public struct RelatedOne: Model {
   public init(from decoder: Decoder) throws {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(String.self, forKey: .id)
-      primaryId = try values.decode(String.self, forKey: .primaryId)
       _primary = try values.decodeIfPresent(LazyReference<Primary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -2715,7 +2589,6 @@ public struct RelatedOne: Model {
   public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
-      try container.encode(primaryId, forKey: .primaryId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -2732,7 +2605,6 @@ extension RelatedOne {
   // MARK: - CodingKeys 
    public enum CodingKeys: String, ModelKey {
     case id
-    case primaryId
     case primary
     case createdAt
     case updatedAt
@@ -2754,7 +2626,6 @@ extension RelatedOne {
     
     model.fields(
       .field(relatedOne.id, is: .required, ofType: .string),
-      .field(relatedOne.primaryId, is: .required, ofType: .string),
       .belongsTo(relatedOne.primary, is: .optional, ofType: Primary.self, targetNames: [\\"primaryId\\"]),
       .field(relatedOne.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(relatedOne.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -2772,9 +2643,6 @@ extension RelatedOne: ModelIdentifiable {
 extension ModelPath where ModelType == RelatedOne {
   public var id: FieldPath<String>   {
       string(\\"id\\") 
-    }
-  public var primaryId: FieldPath<String>   {
-      string(\\"primaryId\\") 
     }
   public var primary: ModelPath<Primary>   {
       Primary.Path(name: \\"primary\\", parent: self) 
@@ -2920,7 +2788,6 @@ import Foundation
 public struct SqlRelated: Model {
   public let id: Int
   public var content: String?
-  public var primaryId: Int
   internal var _primary: LazyReference<SqlPrimary>
   public var primary: SqlPrimary?   {
       get async throws { 
@@ -2932,24 +2799,20 @@ public struct SqlRelated: Model {
   
   public init(id: Int = UUID().uuidString,
       content: String? = nil,
-      primaryId: Int,
       primary: SqlPrimary? = nil) {
     self.init(id: id,
       content: content,
-      primaryId: primaryId,
       primary: primary,
       createdAt: nil,
       updatedAt: nil)
   }
   internal init(id: Int = UUID().uuidString,
       content: String? = nil,
-      primaryId: Int,
       primary: SqlPrimary? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
       self.content = content
-      self.primaryId = primaryId
       self._primary = LazyReference(primary)
       self.createdAt = createdAt
       self.updatedAt = updatedAt
@@ -2961,7 +2824,6 @@ public struct SqlRelated: Model {
       let values = try decoder.container(keyedBy: CodingKeys.self)
       id = try values.decode(Int.self, forKey: .id)
       content = try? values.decode(String?.self, forKey: .content)
-      primaryId = try values.decode(Int.self, forKey: .primaryId)
       _primary = try values.decodeIfPresent(LazyReference<SqlPrimary>.self, forKey: .primary) ?? LazyReference(identifiers: nil)
       createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
       updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
@@ -2970,7 +2832,6 @@ public struct SqlRelated: Model {
       var container = encoder.container(keyedBy: CodingKeys.self)
       try container.encode(id, forKey: .id)
       try container.encode(content, forKey: .content)
-      try container.encode(primaryId, forKey: .primaryId)
       try container.encode(_primary, forKey: .primary)
       try container.encode(createdAt, forKey: .createdAt)
       try container.encode(updatedAt, forKey: .updatedAt)
@@ -2988,7 +2849,6 @@ extension SqlRelated {
    public enum CodingKeys: String, ModelKey {
     case id
     case content
-    case primaryId
     case primary
     case createdAt
     case updatedAt
@@ -3012,7 +2872,6 @@ extension SqlRelated {
     model.fields(
       .field(sqlRelated.id, is: .required, ofType: .int),
       .field(sqlRelated.content, is: .optional, ofType: .string),
-      .field(sqlRelated.primaryId, is: .required, ofType: .int),
       .belongsTo(sqlRelated.primary, is: .optional, ofType: SqlPrimary.self, targetNames: [\\"primaryId\\"]),
       .field(sqlRelated.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlRelated.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
@@ -3033,9 +2892,6 @@ extension ModelPath where ModelType == SqlRelated {
     }
   public var content: FieldPath<String>   {
       string(\\"content\\") 
-    }
-  public var primaryId: FieldPath<Int>   {
-      int(\\"primaryId\\") 
     }
   public var primary: ModelPath<SqlPrimary>   {
       SqlPrimary.Path(name: \\"primary\\", parent: self) 

--- a/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-belongs-to.ts
@@ -15,7 +15,6 @@ export function processBelongsToConnection(
   modelMap: CodeGenModelMap,
   connectionDirective: CodeGenDirective,
   isCustomPKEnabled: boolean = false,
-  respectReferences: boolean = false, // remove when enabled references for all targets
 ): CodeGenFieldConnection | undefined {
   if (field.isList) {
     throw new Error(
@@ -29,7 +28,7 @@ export function processBelongsToConnection(
       `A 'belongsTo' field should match to a corresponding 'hasMany' or 'hasOne' field`
     );
   }
-  const otherSideField = isCustomPKEnabled ? otherSideConnectedFields[0] : getConnectedFieldV2(field, model, otherSide, connectionDirective.name, false, respectReferences);
+  const otherSideField = isCustomPKEnabled ? otherSideConnectedFields[0] : getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
   const connectionFields = connectionDirective.arguments.fields || [];
 
   const references = connectionDirective.arguments.references || [];
@@ -42,9 +41,9 @@ export function processBelongsToConnection(
   // but if the field are connected using fields argument in connection directive
   // we are reusing the field and it should be preserved in selection set
   const otherSideHasMany = otherSideField.isList;
-  const isUsingReferences = respectReferences && references.length > 0;
+  const isUsingReferences = references.length > 0;
   // New metada type introduced by custom PK v2 support
-  let targetNames = isUsingReferences ? [ ...connectionFields, ...references ] : [ ...connectionFields ];
+  let targetNames: string[] = [ ...connectionFields, ...references ];
   if (targetNames.length === 0) {
     if (otherSideHasMany) {
       targetNames = isCustomPKEnabled

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections-v2.ts
@@ -13,8 +13,7 @@ export function getConnectedFieldV2(
   model: CodeGenModel,
   connectedModel: CodeGenModel,
   directiveName: string,
-  shouldUseModelNameFieldInHasManyAndBelongsTo: boolean = false,
-  respectReferences: boolean = false,
+  shouldUseModelNameFieldInHasManyAndBelongsTo: boolean = false
 ): CodeGenField {
   const connectionInfo = getDirective(field)(directiveName);
   if (!connectionInfo) {
@@ -24,7 +23,7 @@ export function getConnectedFieldV2(
   const references = connectionInfo.arguments.references;
   if (connectionInfo.name === 'belongsTo') {
     let connectedFieldsBelongsTo = getBelongsToConnectedFields(model, connectedModel);
-    if (respectReferences && references) {
+    if (references) {
       const connectedField = connectedFieldsBelongsTo.find((field) => {
         return field.directives.some((dir) => {
           return (dir.name === 'hasOne' || dir.name === 'hasMany')
@@ -50,7 +49,7 @@ export function getConnectedFieldV2(
   }
   if (references || connectionFields || directiveName === 'hasOne') {
     let connectionDirective;
-    if (respectReferences && references) {
+    if (references) {
       if (connectionInfo) {
         connectionDirective = flattenFieldDirectives(connectedModel).find((dir) => {
           return dir.arguments.references
@@ -162,18 +161,17 @@ export function processConnectionsV2(
   shouldUseModelNameFieldInHasManyAndBelongsTo: boolean = false,
   isCustomPKEnabled: boolean = false,
   shouldUseFieldsInAssociatedWithInHasOne: boolean = false,
-  respectReferences: boolean = false, // remove when enabled references for all targets
 ): CodeGenFieldConnection | undefined {
   const connectionDirective = field.directives.find(d => d.name === 'hasOne' || d.name === 'hasMany' || d.name === 'belongsTo');
 
   if (connectionDirective) {
     switch (connectionDirective.name) {
       case 'hasOne':
-        return processHasOneConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled, shouldUseFieldsInAssociatedWithInHasOne, respectReferences);
+        return processHasOneConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled, shouldUseFieldsInAssociatedWithInHasOne);
       case 'belongsTo':
-        return processBelongsToConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled, respectReferences);
+        return processBelongsToConnection(field, model, modelMap, connectionDirective, isCustomPKEnabled);
       case 'hasMany':
-        return processHasManyConnection(field, model, modelMap, connectionDirective, shouldUseModelNameFieldInHasManyAndBelongsTo, isCustomPKEnabled, respectReferences);
+        return processHasManyConnection(field, model, modelMap, connectionDirective, shouldUseModelNameFieldInHasManyAndBelongsTo, isCustomPKEnabled);
       default:
         break;
     }

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -22,15 +22,19 @@ export type CodeGenFieldConnectionBelongsTo = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_ONE;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
+  associatedWithNative?: CodeGenField;
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
   targetName?: string; // Legacy field remained for backward compatability
   targetNames?: string[]; // New attribute for v2 custom pk support
+  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_MANY;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
+  associatedWithNative?: CodeGenField;
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
+  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnection = CodeGenFieldConnectionBelongsTo | CodeGenFieldConnectionHasOne | CodeGenFieldConnectionHasMany;

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -22,7 +22,7 @@ export type CodeGenFieldConnectionBelongsTo = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_ONE;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
-  associatedWithNative?: CodeGenField;
+  associatedWithNative?: CodeGenField; // native uses the connected field instead of associatedWithFields
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
   targetName?: string; // Legacy field remained for backward compatability
   targetNames?: string[]; // New attribute for v2 custom pk support
@@ -31,7 +31,7 @@ export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_MANY;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
-  associatedWithNative?: CodeGenField;
+  associatedWithNative?: CodeGenField; // native uses the connected field instead of associatedWithFields
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
 };
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -26,7 +26,6 @@ export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
   targetName?: string; // Legacy field remained for backward compatability
   targetNames?: string[]; // New attribute for v2 custom pk support
-  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
@@ -34,7 +33,6 @@ export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
   associatedWithNative?: CodeGenField;
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
-  isUsingReferences?: boolean;
 };
 
 export type CodeGenFieldConnection = CodeGenFieldConnectionBelongsTo | CodeGenFieldConnectionHasOne | CodeGenFieldConnectionHasMany;

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -22,7 +22,7 @@ export type CodeGenFieldConnectionBelongsTo = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_ONE;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
-  associatedWithNative?: CodeGenField; // native uses the connected field instead of associatedWithFields
+  associatedWithNativeReferences?: CodeGenField; // native uses the connected field instead of associatedWithFields
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
   targetName?: string; // Legacy field remained for backward compatability
   targetNames?: string[]; // New attribute for v2 custom pk support
@@ -31,7 +31,7 @@ export type CodeGenFieldConnectionHasOne = CodeGenConnectionTypeBase & {
 export type CodeGenFieldConnectionHasMany = CodeGenConnectionTypeBase & {
   kind: CodeGenConnectionType.HAS_MANY;
   associatedWith: CodeGenField;// Legacy field remained for backward compatability
-  associatedWithNative?: CodeGenField; // native uses the connected field instead of associatedWithFields
+  associatedWithNativeReferences?: CodeGenField; // native uses the connected field instead of associatedWithFields
   associatedWithFields: CodeGenField[]; // New attribute for v2 custom pk support
 };
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -19,7 +19,6 @@ export function processHasManyConnection(
   connectionDirective: CodeGenDirective,
   shouldUseModelNameFieldInHasManyAndBelongsTo: boolean,
   isCustomPKEnabled: boolean = false,
-  respectReferences: boolean = false, // remove when enabled references for all targets
 ): CodeGenFieldConnection | undefined {
   if (!field.isList) {
     throw new Error("A field with hasMany must be a list type");
@@ -32,9 +31,9 @@ export function processHasManyConnection(
     throw new Error(fieldsAndReferencesErrorMessage);
   }
 
-  if (respectReferences && references.length > 0) {
+  if (references.length > 0) {
     // ensure there is a matching belongsTo field with references
-    getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo, respectReferences)
+    getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
     const associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
     return {
       kind: CodeGenConnectionType.HAS_MANY,
@@ -47,7 +46,7 @@ export function processHasManyConnection(
 
   const otherSideFields = isCustomPKEnabled
     ? getConnectedFieldsForHasMany(field, model, otherSide, shouldUseModelNameFieldInHasManyAndBelongsTo)
-    : [getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo, respectReferences)];
+    : [getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)];
   const otherSideField = otherSideFields[0];
 
   // if a type is connected using name, then graphql-connection-transformer adds a field to

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -35,12 +35,21 @@ export function processHasManyConnection(
     // ensure there is a matching belongsTo field with references
     getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
     const associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
+    const associatedWithNative = otherSide.fields.find((field) => {
+      return field.directives.some((dir) => {
+        return (dir.name === 'belongsTo')
+          && dir.arguments.references
+          && JSON.stringify(dir.arguments.references) === JSON.stringify(references);
+      });
+    });
     return {
       kind: CodeGenConnectionType.HAS_MANY,
       associatedWith: associatedWithFields[0],
       associatedWithFields,
+      associatedWithNative,
       isConnectingFieldAutoCreated: false,
       connectedModel: otherSide,
+      isUsingReferences: true,
     };
   }
 
@@ -58,6 +67,7 @@ export function processHasManyConnection(
     kind: CodeGenConnectionType.HAS_MANY,
     associatedWith: otherSideField,
     associatedWithFields: otherSideFields,
+    associatedWithNative: otherSideField,
     isConnectingFieldAutoCreated,
     connectedModel: otherSide,
   }

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -49,7 +49,6 @@ export function processHasManyConnection(
       associatedWithNative,
       isConnectingFieldAutoCreated: false,
       connectedModel: otherSide,
-      isUsingReferences: true,
     };
   }
 
@@ -67,7 +66,6 @@ export function processHasManyConnection(
     kind: CodeGenConnectionType.HAS_MANY,
     associatedWith: otherSideField,
     associatedWithFields: otherSideFields,
-    associatedWithNative: otherSideField,
     isConnectingFieldAutoCreated,
     connectedModel: otherSide,
   }

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -32,16 +32,11 @@ export function processHasManyConnection(
   }
 
   if (references.length > 0) {
-    // ensure there is a matching belongsTo field with references
-    getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
+    // native uses the connected field instead of associatedWithFields
+    // when using references associatedWithFields and associatedWithNative are not the same
+    // getConnectedFieldV2 also ensures there is a matching belongsTo field with references
+    const associatedWithNative = getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
     const associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
-    const associatedWithNative = otherSide.fields.find((field) => {
-      return field.directives.some((dir) => {
-        return (dir.name === 'belongsTo')
-          && dir.arguments.references
-          && JSON.stringify(dir.arguments.references) === JSON.stringify(references);
-      });
-    });
     return {
       kind: CodeGenConnectionType.HAS_MANY,
       associatedWith: associatedWithFields[0],

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-many.ts
@@ -35,13 +35,13 @@ export function processHasManyConnection(
     // native uses the connected field instead of associatedWithFields
     // when using references associatedWithFields and associatedWithNative are not the same
     // getConnectedFieldV2 also ensures there is a matching belongsTo field with references
-    const associatedWithNative = getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
+    const associatedWithNativeReferences = getConnectedFieldV2(field, model, otherSide, connectionDirective.name, shouldUseModelNameFieldInHasManyAndBelongsTo)
     const associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
     return {
       kind: CodeGenConnectionType.HAS_MANY,
       associatedWith: associatedWithFields[0],
       associatedWithFields,
-      associatedWithNative,
+      associatedWithNativeReferences,
       isConnectingFieldAutoCreated: false,
       connectedModel: otherSide,
     };

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -14,8 +14,7 @@ export function processHasOneConnection(
   modelMap: CodeGenModelMap,
   connectionDirective: CodeGenDirective,
   isCustomPKEnabled: boolean = false,
-  shouldUseFieldsInAssociatedWithInHasOne:boolean = false,
-  respectReferences: boolean = false, // remove when enabled references for all targets
+  shouldUseFieldsInAssociatedWithInHasOne:boolean = false
 ): CodeGenFieldConnection | undefined {
   const otherSide = modelMap[field.type];
   // Find other side belongsTo field when in bi direction connection
@@ -32,9 +31,9 @@ export function processHasOneConnection(
   }
 
   let associatedWithFields;
-  if (respectReferences && references.length > 0) {
+  if (references.length > 0) {
     // ensure there is a matching belongsTo field with references
-    getConnectedFieldV2(field, model, otherSide, connectionDirective.name, false, respectReferences);
+    getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
     associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
     return {
       kind: CodeGenConnectionType.HAS_ONE,
@@ -46,7 +45,7 @@ export function processHasOneConnection(
   } else if (isCustomPKEnabled) {
     associatedWithFields = getConnectedFieldsForHasOne(otherSideBelongsToField, otherSide, shouldUseFieldsInAssociatedWithInHasOne);
   } else {
-    const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name, false, respectReferences);
+    const otherSideField = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
     associatedWithFields = [otherSideField];
   }
 

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -35,13 +35,13 @@ export function processHasOneConnection(
     // native uses the connected field instead of associatedWithFields
     // when using references associatedWithFields and associatedWithNative are not the same
     // getConnectedFieldV2 also ensures there is a matching belongsTo field with references
-    const associatedWithNative = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
+    const associatedWithNativeReferences = getConnectedFieldV2(field, model, otherSide, connectionDirective.name);
     associatedWithFields = references.map((reference: string) => otherSide.fields.find((field) => reference === field.name))
     return {
       kind: CodeGenConnectionType.HAS_ONE,
       associatedWith: associatedWithFields[0],
       associatedWithFields,
-      associatedWithNative,
+      associatedWithNativeReferences,
       connectedModel: otherSide,
       isConnectingFieldAutoCreated: false,
     };

--- a/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-has-one.ts
@@ -48,7 +48,6 @@ export function processHasOneConnection(
       associatedWithNative,
       connectedModel: otherSide,
       isConnectingFieldAutoCreated: false,
-      isUsingReferences: true,
     };
   }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -1008,8 +1008,8 @@ export class AppSyncModelDartVisitor<
           switch (field.connectionInfo.kind) {
             case CodeGenConnectionType.HAS_ONE: {
               let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
-              if (field.connectionInfo.associatedWithNative) {
-                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
+              if (field.connectionInfo.associatedWithNativeReferences) {
+                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNativeReferences)}`;
               }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,
@@ -1022,8 +1022,8 @@ export class AppSyncModelDartVisitor<
             }
             case CodeGenConnectionType.HAS_MANY: {
               let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
-              if (field.connectionInfo.associatedWithNative) {
-                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
+              if (field.connectionInfo.associatedWithNativeReferences) {
+                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNativeReferences)}`;
               }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -1006,24 +1006,34 @@ export class AppSyncModelDartVisitor<
         else if (field.connectionInfo) {
           const connectedModelName = this.getNativeType({ ...field, isList: false });
           switch (field.connectionInfo.kind) {
-            case CodeGenConnectionType.HAS_ONE:
+            case CodeGenConnectionType.HAS_ONE: {
+              let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
+              if (field.connectionInfo.isUsingReferences) {
+                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
+              }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,
                 `isRequired: ${!field.isNullable}`,
                 `ofModelName: '${connectedModelName}'`,
-                `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`,
+                associatedString,
               ].join(',\n');
               fieldsToAdd.push([`${DART_AMPLIFY_CORE_TYPES.ModelFieldDefinition}.hasOne(`, indentMultiline(fieldParam), ')'].join('\n'));
               break;
-            case CodeGenConnectionType.HAS_MANY:
+            }
+            case CodeGenConnectionType.HAS_MANY: {
+              let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
+              if (field.connectionInfo.isUsingReferences) {
+                associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
+              }
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,
                 `isRequired: ${!field.isNullable}`,
                 `ofModelName: '${connectedModelName}'`,
-                `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`,
+                associatedString,
               ].join(',\n');
               fieldsToAdd.push([`${DART_AMPLIFY_CORE_TYPES.ModelFieldDefinition}.hasMany(`, indentMultiline(fieldParam), ')'].join('\n'));
               break;
+            }
             case CodeGenConnectionType.BELONGS_TO:
               fieldParam = [
                 `key: ${modelName}.${queryFieldName}`,

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -1008,7 +1008,7 @@ export class AppSyncModelDartVisitor<
           switch (field.connectionInfo.kind) {
             case CodeGenConnectionType.HAS_ONE: {
               let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
-              if (field.connectionInfo.isUsingReferences) {
+              if (field.connectionInfo.associatedWithNative) {
                 associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
               }
               fieldParam = [
@@ -1022,7 +1022,7 @@ export class AppSyncModelDartVisitor<
             }
             case CodeGenConnectionType.HAS_MANY: {
               let associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWith)}`;
-              if (field.connectionInfo.isUsingReferences) {
+              if (field.connectionInfo.associatedWithNative) {
                 associatedString = `associatedKey: ${connectedModelName}.${this.getQueryFieldName(field.connectionInfo.associatedWithNative)}`;
               }
               fieldParam = [

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -1110,7 +1110,7 @@ export class AppSyncModelJavaVisitor<
     switch (connectionInfo.kind) {
       case CodeGenConnectionType.HAS_ONE:
         connectionDirectiveName = 'HasOne';
-        if (connectionInfo.isUsingReferences) {
+        if (connectionInfo.associatedWithNative) {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
         } else {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
@@ -1122,7 +1122,7 @@ export class AppSyncModelJavaVisitor<
         break;
       case CodeGenConnectionType.HAS_MANY:
         connectionDirectiveName = 'HasMany';
-        if (connectionInfo.isUsingReferences) {
+        if (connectionInfo.associatedWithNative) {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
         } else {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -1110,7 +1110,11 @@ export class AppSyncModelJavaVisitor<
     switch (connectionInfo.kind) {
       case CodeGenConnectionType.HAS_ONE:
         connectionDirectiveName = 'HasOne';
-        connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        if (connectionInfo.isUsingReferences) {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
+        } else {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        }
         if (this.isCustomPKEnabled() && this.isGenerateModelsForLazyLoadAndCustomSelectionSet() && connectionInfo.targetNames) {
           const hasOneTargetNamesArgs = `targetNames = {${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}}`;
           connectionArguments.push(hasOneTargetNamesArgs);
@@ -1118,7 +1122,11 @@ export class AppSyncModelJavaVisitor<
         break;
       case CodeGenConnectionType.HAS_MANY:
         connectionDirectiveName = 'HasMany';
-        connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        if (connectionInfo.isUsingReferences) {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
+        } else {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
+        }
         break;
       case CodeGenConnectionType.BELONGS_TO:
         connectionDirectiveName = 'BelongsTo';

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -1110,8 +1110,8 @@ export class AppSyncModelJavaVisitor<
     switch (connectionInfo.kind) {
       case CodeGenConnectionType.HAS_ONE:
         connectionDirectiveName = 'HasOne';
-        if (connectionInfo.associatedWithNative) {
-          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
+        if (connectionInfo.associatedWithNativeReferences) {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNativeReferences)}"`);
         } else {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
         }
@@ -1122,8 +1122,8 @@ export class AppSyncModelJavaVisitor<
         break;
       case CodeGenConnectionType.HAS_MANY:
         connectionDirectiveName = 'HasMany';
-        if (connectionInfo.associatedWithNative) {
-          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNative)}"`);
+        if (connectionInfo.associatedWithNativeReferences) {
+          connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWithNativeReferences)}"`);
         } else {
           connectionArguments.push(`associatedWith = "${this.getFieldName(connectionInfo.associatedWith)}"`);
         }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -623,8 +623,8 @@ export class AppSyncSwiftVisitor<
         let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
-        if (connectionInfo.associatedWithNative) {
-          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
+        if (connectionInfo.associatedWithNativeReferences) {
+          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNativeReferences)}]`
         }
         return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}`;
       }
@@ -632,8 +632,8 @@ export class AppSyncSwiftVisitor<
         let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
-        if (connectionInfo.associatedWithNative) {
-          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
+        if (connectionInfo.associatedWithNativeReferences) {
+          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNativeReferences)}]`
         }
 
         let targetNameAttrStr = '';

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -620,17 +620,29 @@ export class AppSyncSwiftVisitor<
     // connected field
     if (connectionInfo) {
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
-        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+        let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        if (connectionInfo.isUsingReferences) {
+          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
+        }
+        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}`;
       }
-      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE && (connectionInfo.targetNames || connectionInfo.targetName)) {
-        const targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
-          ? `targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
-          : `targetName: "${connectionInfo.targetName}"`;
-        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, associatedWith: ${this.getModelName(
+      if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
+        let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}, ${targetNameAttrStr})`;
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
+        if (connectionInfo.isUsingReferences) {
+          association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
+        }
+
+        let targetNameAttrStr = '';
+        if (connectionInfo.targetNames || connectionInfo.targetName) {
+          targetNameAttrStr = this.isCustomPKEnabled() && connectionInfo.targetNames
+            ? `, targetNames: [${connectionInfo.targetNames.map(target => `"${target}"`).join(', ')}]`
+            : `, targetName: "${connectionInfo.targetName}"`;
+        }
+        return `.hasOne(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}${targetNameAttrStr})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.BELONGS_TO) {
         const targetNameAttrStr = this.isCustomPKEnabled()
@@ -814,5 +826,9 @@ export class AppSyncSwiftVisitor<
 
   protected hasReadOnlyFields(model: CodeGenModel): boolean {
     return model.fields.filter(f => f.isReadOnly).length !== 0;
+  }
+
+  private getCodingKey(model: CodeGenModel, field: CodeGenField): string {
+    return `${this.getModelName(model)}.keys.${this.getFieldName(field)}`;
   }
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -623,7 +623,7 @@ export class AppSyncSwiftVisitor<
         let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
-        if (connectionInfo.isUsingReferences) {
+        if (connectionInfo.associatedWithNative) {
           association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
         }
         return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}`;
@@ -632,7 +632,7 @@ export class AppSyncSwiftVisitor<
         let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
         )}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
-        if (connectionInfo.isUsingReferences) {
+        if (connectionInfo.associatedWithNative) {
           association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNative)}]`
         }
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -1181,8 +1181,7 @@ export class AppSyncModelVisitor<
               connectionInfo.kind !== CodeGenConnectionType.HAS_MANY &&
               connectionInfo.kind !== CodeGenConnectionType.HAS_ONE &&
               connectionInfo.targetNames &&
-              connectionInfo.targetName !== 'id' &&
-              !connectionInfo.isUsingReferences
+              connectionInfo.targetName !== 'id'
             ) {
               // Need to remove the field that is targetName
               connectionInfo.targetNames.forEach(targetName => removeFieldFromModel(model, targetName));

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -1087,8 +1087,7 @@ export class AppSyncModelVisitor<
           this.modelMap,
           shouldUseModelNameFieldInHasManyAndBelongsTo,
           isCustomPKEnabled,
-          shouldUseFieldsInAssociatedWithInHasOne,
-          this.config.target === 'introspection',
+          shouldUseFieldsInAssociatedWithInHasOne
         );
         if (connectionInfo) {
           if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
@@ -1182,7 +1181,8 @@ export class AppSyncModelVisitor<
               connectionInfo.kind !== CodeGenConnectionType.HAS_MANY &&
               connectionInfo.kind !== CodeGenConnectionType.HAS_ONE &&
               connectionInfo.targetNames &&
-              connectionInfo.targetName !== 'id'
+              connectionInfo.targetName !== 'id' &&
+              !connectionInfo.isUsingReferences
             ) {
               // Need to remove the field that is targetName
               connectionInfo.targetNames.forEach(targetName => removeFieldFromModel(model, targetName));


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* remove `respectReferences` and enable references for all platforms
* use the connected field instead of associatedWithFields on native for references

Example:
```
type Primary @model {                                                                                                                
  tenantId: ID! @primaryKey(sortKeyFields: ["instanceId", "recordId"])                                                               
  instanceId: ID!                                                                                                                    
  recordId: ID!                                                                                                                      
  content: String                                                                                                                    
  related: [Related!] @hasMany(references: ["primaryTenantId", "primaryInstanceId", "primaryRecordId"])                              
}                                                                                                                                    
                                                                                                                                     
type Related @model {                                                                                                                
  content: String                                                                                                                    
  primaryTenantId: ID!                                                                                                               
  primaryInstanceId: ID!                                                                                                             
  primaryRecordId: ID!                                                                                                               
  primary: Primary @belongsTo(references: ["primaryTenantId", "primaryInstanceId", "primaryRecordId"])                               
}  
```

The `.hasMany` on the generated model for native platforms will use `associatedWith: primary` instead of `associatedWith: ["primaryTenantId", "primaryInstanceId", "primaryRecordId"]`. This is how composite primary keys work for native currently.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* Verify in native e2e tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
