### PR TITLE
style(amplify-codegen): adds a todo comment

### DIFF
--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -448,6 +448,8 @@ export class AppSyncModelDartVisitor<
 
   protected generateGetters(model: CodeGenModel, declarationBlock: DartDeclarationBlock, includeIdGetter: boolean = true): void {
     if (includeIdGetter) {
+      // TODO: Remove at the next major version.
+      // Amplify Flutter V2 removes all usage of Model.getId() in favor of Model.modelIdentifier
       if (this.isCustomPKEnabled()) {
         const identifierFields = this.getModelIdentifierFields(model);
         const isCustomPK = identifierFields[0].name !== 'id';


### PR DESCRIPTION
Adds todo to clean up Dart codegen in next major version bump

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
Adds a Todo comment to clean up deprecated Dart codgen for `Model.getId()` in the next major version. Amplify Flutter V2 will no longer use this API.  

#### Codegen Paramaters Changed or Added
none

#### Issue #, if available
none


#### Description of how you validated changes
It's just a comment


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
