### PR TITLE
fix: add missing closing parens on swift hasMany

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -1634,7 +1634,7 @@ extension Primary {
       .field(primary.instanceId, is: .required, ofType: .string),
       .field(primary.recordId, is: .required, ofType: .string),
       .field(primary.content, is: .optional, ofType: .string),
-      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primary],
+      .hasMany(primary.related, is: .optional, ofType: Related.self, associatedFields: [Related.keys.primary]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2150,7 +2150,7 @@ extension SqlPrimary {
     model.fields(
       .field(sqlPrimary.id, is: .required, ofType: .int),
       .field(sqlPrimary.content, is: .optional, ofType: .string),
-      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primary],
+      .hasMany(sqlPrimary.related, is: .optional, ofType: SqlRelated.self, associatedFields: [SqlRelated.keys.primary]),
       .field(sqlPrimary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(sqlPrimary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
@@ -2398,7 +2398,7 @@ extension Primary {
     
     model.fields(
       .field(primary.id, is: .required, ofType: .string),
-      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedFields: [RelatedMany.keys.primary],
+      .hasMany(primary.relatedMany, is: .optional, ofType: RelatedMany.self, associatedFields: [RelatedMany.keys.primary]),
       .hasOne(primary.relatedOne, is: .optional, ofType: RelatedOne.self, associatedFields: [RelatedOne.keys.primary]),
       .field(primary.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(primary.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -622,11 +622,11 @@ export class AppSyncSwiftVisitor<
       if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY) {
         let association = `associatedWith: ${this.getModelName(
           connectionInfo.connectedModel,
-        )}.keys.${this.getFieldName(connectionInfo.associatedWith)})`;
+        )}.keys.${this.getFieldName(connectionInfo.associatedWith)}`;
         if (connectionInfo.associatedWithNativeReferences) {
           association = `associatedFields: [${this.getCodingKey(connectionInfo.connectedModel, connectionInfo.associatedWithNativeReferences)}]`
         }
-        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association}`;
+        return `.hasMany(${name}, is: ${isRequired}, ofType: ${typeName}, ${association})`;
       }
       if (connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
         let association = `associatedWith: ${this.getModelName(


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* add missing closing parens on swift hasMany when using references.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit tests
* E2E tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
