### PR TITLE
chore: upgrade test schema library

### DIFF
--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-codegen-e2e-core": "1.6.5",
-    "@aws-amplify/graphql-schema-test-library": "^1.1.18",
+    "@aws-amplify/graphql-schema-test-library": "^2.2.28",
     "amazon-cognito-identity-js": "^6.3.6",
     "aws-amplify": "^5.3.3",
     "aws-appsync": "^4.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,10 +583,10 @@
     graphql-transformer-common "4.30.1"
     immer "^9.0.12"
 
-"@aws-amplify/graphql-schema-test-library@^1.1.18":
-  version "1.1.27"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-schema-test-library/-/graphql-schema-test-library-1.1.27.tgz#30f5a732ce65031169907c386777f0bc0adfa0c2"
-  integrity sha512-ay27o/ZWR/wsYflQJOWrPT5j71Iklo1JkDkOU5BGzRk61QCV631i1o4R7N0TuDAIPTDewDf4Hvgy97y6n1jk3A==
+"@aws-amplify/graphql-schema-test-library@^2.2.28":
+  version "2.2.28"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-schema-test-library/-/graphql-schema-test-library-2.2.28.tgz#a60ae3fd2d9e5d4bd154899a6e0d28a48af0a855"
+  integrity sha512-1ZFFGKICIINhZkbkHC9lrPD9nMa5uLppmUyL1cJR2TKqneVKO8l0B88nnqhwjq/9yREFEP06VklORfm1XBKeUQ==
 
 "@aws-amplify/graphql-searchable-transformer@2.7.1":
   version "2.7.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

* upgrade test schema library


A major version bump in the test schema library caused the E2E tests to not update with the new schemas.

https://github.com/aws-amplify/amplify-codegen/pull/835 should have been caught by the tests, but the schema was not included in the tests.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* E2E tests

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
