### PR TITLE
fix(amplify-codegen): fix for non-model decoding in flutter v1

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -1142,12 +1142,14 @@ class Contact {
   Contact.fromJson(Map<String, dynamic> json)  
     : _contactName = json['contactName'],
       _phone = json['phone'] != null
-        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']))
+          ? json['phone']['serializedData'] != null
+              ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData']))
+              : Phone.fromJson(new Map<String, dynamic>.from(json['phone']))
         : null,
       _mailingAddresses = json['mailingAddresses'] is List
         ? (json['mailingAddresses'] as List)
           .where((e) => e != null)
-          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e)))
+          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'] ?? e)))
           .toList()
         : null;
   
@@ -1390,12 +1392,14 @@ class Person extends amplify_core.Model {
     : id = json['id'],
       _name = json['name'],
       _phone = json['phone'] != null
-        ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']))
+          ? json['phone']['serializedData'] != null
+              ? Phone.fromJson(new Map<String, dynamic>.from(json['phone']['serializedData']))
+              : Phone.fromJson(new Map<String, dynamic>.from(json['phone']))
         : null,
       _mailingAddresses = json['mailingAddresses'] is List
         ? (json['mailingAddresses'] as List)
           .where((e) => e != null)
-          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e)))
+          .map((e) => Address.fromJson(new Map<String, dynamic>.from(e['serializedData'] ?? e)))
           .toList()
         : null;
   

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -746,7 +746,9 @@ export class AppSyncModelDartVisitor<
                 `${fieldName} = json['${varName}'] is List`,
                 indent(`? (json['${varName}'] as List)`),
                 indent(`.where((e) => e != null)`, 2),
-                indent(`.map((e) => ${this.getNativeType({ ...field, isList: false })}.fromJson(new Map<String, dynamic>.from(e)))`, 2),
+                indent(`.map((e) => ${this.getNativeType({ ...field, isList: false })}.fromJson(new Map<String, dynamic>.from(${
+                  this.isNonModelType(field) ? "e['serializedData'] ?? e" : 'e'
+                })))`, 2),
                 indent(`.toList()`, 2),
                 indent(`: null`),
               ]
@@ -756,8 +758,10 @@ export class AppSyncModelDartVisitor<
             // single non-model i.e. embedded
             return [
               `${fieldName} = json['${varName}'] != null`,
-              indent(`? ${this.getNativeType(field)}.fromJson(new Map<String, dynamic>.from(json['${varName}']))`),
-              indent(`: null`),
+              indent(`? json['${varName}']['serializedData'] != null`, 2),
+              indent(`? ${this.getNativeType(field)}.fromJson(new Map<String, dynamic>.from(json['${varName}']['serializedData']))`, 4),
+              indent(`: ${this.getNativeType(field)}.fromJson(new Map<String, dynamic>.from(json['${varName}']))`, 4),
+              indent(`: null`,),
             ].join('\n');
           }
           //regular type


### PR DESCRIPTION
#### Description of changes
Added the dropped Flutter V1 `Model.fromJson()` decoding logic back to non-model embeds. Customer observed embedded non-model types not populating values after requests were made. This adds a fallback to previous logic.


#### Issue #, if available
https://github.com/aws-amplify/amplify-flutter/issues/4872



#### Description of how you validated changes
Validated decoding against this schema in both Flutter V1 and V2. 
```graphql
type MyModel @model @auth(rules: [{ allow: owner }]) {
  id: ID!
  owner: String
  token: Token
  tokens: [Token]
}

type Token {
  externalId: String!
  value: String!
}
```


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
