### PR TITLE
chore: fix windows build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "authenticate-e2e-profile": "source scripts/cloud-utils.sh && authenticateWithE2EProfile",
     "extract-dependency-licenses": "./scripts/extract-dependency-licenses.sh",
     "verify-dependency-licenses-extract": "yarn extract-dependency-licenses && ./scripts/verify-dependency-licenses.sh",
-    "deprecate": "ts-node scripts/deprecate_release.ts",
-    "postinstall": "./scripts/postinstall.sh"
+    "deprecate": "ts-node scripts/deprecate_release.ts"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-codegen/issues"

--- a/scripts/create-private-package-manifest.sh
+++ b/scripts/create-private-package-manifest.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# set exit on error to true
+set -e
+
+# create a new file to store the private packages
+# this will be imported and used in the Git Client to determine the packages to deprecate
+
 echo 'export default [' > scripts/components/private_packages.ts
 grep -l packages/*/package.json -e '"private": "\?true"\?' | xargs cat | jq .name | tr -s '\n' ',' >> scripts/components/private_packages.ts 
 echo '];' >> scripts/components/private_packages.ts

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -475,6 +475,10 @@ function _deploy {
 function _deprecate {
   loadCacheFromLinuxBuildJob
   echo "Deprecate"
+
+  echo "creating private package manifest"
+  ./scripts/create-private-package-manifest.sh
+
   echo "Authenticate with NPM"
   if [ "$USE_NPM_REGISTRY" == "true" ]; then
       PUBLISH_TOKEN=$(echo "$NPM_PUBLISH_TOKEN" | jq -r '.token')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Move the `postinstall` script to be run as part of deprecate workflow where it is needed.
This was causing issues in windows environments where the script is not being executed as part of `postinstall` action.
![image](https://github.com/aws-amplify/amplify-category-api/assets/55896475/bc322c2a-a42a-4aa6-8ac2-2b4c0fbab981)
Verified that the contents of the script or execute permissions aren't the issue.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
