### PR TITLE
chore: add checklist to verify the supported graphql types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ List any codegen parameters changed or added.
 - [ ] Breaking changes to existing customers are released behind a feature flag or major version update
 - [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
 - [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
-- [ ] Changes adhere to [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.
+- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.
 
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@ List any codegen parameters changed or added.
 - [ ] Breaking changes to existing customers are released behind a feature flag or major version update
 - [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
 - [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
+- [ ] Changes adhere to [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.
 
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
#### Description of changes
Add a checklist step to verify the supported graphql types to the PR template.

#### Codegen Paramaters Changed or Added
NA

#### Issue #, if available
NA

#### Description of how you validated changes
NA

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
