### PR TITLE
fix: set relational fields on many-to-many join table to optional

### DIFF
--- a/dependency_licenses.txt
+++ b/dependency_licenses.txt
@@ -8809,11 +8809,11 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: braces, clone-deep, normalize-path. A copy of the source code may be downloaded from https://github.com/micromatch/braces.git (braces), https://github.com/jonschlinkert/clone-deep.git (clone-deep), https://github.com/jonschlinkert/normalize-path.git (normalize-path). This software contains the following license and notice below:
+The following software may be included in this product: braces, fill-range, is-number, micromatch. A copy of the source code may be downloaded from https://github.com/micromatch/braces.git (braces), https://github.com/jonschlinkert/fill-range.git (fill-range), https://github.com/jonschlinkert/is-number.git (is-number), https://github.com/micromatch/micromatch.git (micromatch). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2018, Jon Schlinkert.
+Copyright (c) 2014-present, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9893,6 +9893,32 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: clone-deep, normalize-path. A copy of the source code may be downloaded from https://github.com/jonschlinkert/clone-deep.git (clone-deep), https://github.com/jonschlinkert/normalize-path.git (normalize-path). This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2014-2018, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 -----
 
@@ -13202,32 +13228,6 @@ LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE A
 NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: fill-range, is-number, micromatch. A copy of the source code may be downloaded from https://github.com/jonschlinkert/fill-range.git (fill-range), https://github.com/jonschlinkert/is-number.git (is-number), https://github.com/micromatch/micromatch.git (micromatch). This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2014-present, Jon Schlinkert.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 -----
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-dart-visitor.test.ts.snap
@@ -2940,35 +2940,17 @@ class PostTags extends amplify_core.Model {
     return id;
   }
   
-  Post get post {
-    try {
-      return _post!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
+  Post? get post {
+    return _post;
   }
   
-  Tag get tag {
-    try {
-      return _tag!;
-    } catch(e) {
-      throw amplify_core.AmplifyCodeGenModelException(
-          amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastExceptionMessage,
-          recoverySuggestion:
-            amplify_core.AmplifyExceptionMessages.codeGenRequiredFieldForceCastRecoverySuggestion,
-          underlyingException: e.toString()
-          );
-    }
+  Tag? get tag {
+    return _tag;
   }
   
-  const PostTags._internal({required this.id, required post, required tag}): _post = post, _tag = tag;
+  const PostTags._internal({required this.id, post, tag}): _post = post, _tag = tag;
   
-  factory PostTags({String? id, required Post post, required Tag tag}) {
+  factory PostTags({String? id, Post? post, Tag? tag}) {
     return PostTags._internal(
       id: id == null ? amplify_core.UUID.getUUID() : id,
       post: post,
@@ -3013,8 +2995,8 @@ class PostTags extends amplify_core.Model {
   
   PostTags copyWithModelFieldValues({
     ModelFieldValue<String>? id,
-    ModelFieldValue<Post>? post,
-    ModelFieldValue<Tag>? tag
+    ModelFieldValue<Post?>? post,
+    ModelFieldValue<Tag?>? tag
   }) {
     return PostTags(
       id: id == null ? this.id : id.value,
@@ -3066,14 +3048,14 @@ class PostTags extends amplify_core.Model {
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: PostTags.POST,
-      isRequired: true,
+      isRequired: false,
       targetName: 'postID',
       ofModelName: 'Post'
     ));
     
     modelSchemaDefinition.addField(amplify_core.ModelFieldDefinition.belongsTo(
       key: PostTags.TAG,
-      isRequired: true,
+      isRequired: false,
       targetName: 'tagID',
       ofModelName: 'Tag'
     ));

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-java-visitor.test.ts.snap
@@ -2320,8 +2320,8 @@ public final class PostTags implements Model {
   public static final QueryField POST = field(\\"PostTags\\", \\"postID\\");
   public static final QueryField TAG = field(\\"PostTags\\", \\"tagID\\");
   private final @ModelField(targetType=\\"ID\\", isRequired = true) String id;
-  private final @ModelField(targetType=\\"Post\\", isRequired = true) @BelongsTo(targetName = \\"postID\\", type = Post.class) Post post;
-  private final @ModelField(targetType=\\"Tag\\", isRequired = true) @BelongsTo(targetName = \\"tagID\\", type = Tag.class) Tag tag;
+  private final @ModelField(targetType=\\"Post\\") @BelongsTo(targetName = \\"postID\\", type = Post.class) Post post;
+  private final @ModelField(targetType=\\"Tag\\") @BelongsTo(targetName = \\"tagID\\", type = Tag.class) Tag tag;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime createdAt;
   private @ModelField(targetType=\\"AWSDateTime\\", isReadOnly = true) Temporal.DateTime updatedAt;
   public String getId() {
@@ -2391,7 +2391,7 @@ public final class PostTags implements Model {
       .toString();
   }
   
-  public static PostStep builder() {
+  public static BuildStep builder() {
       return new Builder();
   }
   
@@ -2416,23 +2416,15 @@ public final class PostTags implements Model {
       post,
       tag);
   }
-  public interface PostStep {
-    TagStep post(Post post);
-  }
-  
-
-  public interface TagStep {
+  public interface BuildStep {
+    PostTags build();
+    BuildStep id(String id);
+    BuildStep post(Post post);
     BuildStep tag(Tag tag);
   }
   
 
-  public interface BuildStep {
-    PostTags build();
-    BuildStep id(String id);
-  }
-  
-
-  public static class Builder implements PostStep, TagStep, BuildStep {
+  public static class Builder implements BuildStep {
     private String id;
     private Post post;
     private Tag tag;
@@ -2457,15 +2449,13 @@ public final class PostTags implements Model {
     }
     
     @Override
-     public TagStep post(Post post) {
-        Objects.requireNonNull(post);
+     public BuildStep post(Post post) {
         this.post = post;
         return this;
     }
     
     @Override
      public BuildStep tag(Tag tag) {
-        Objects.requireNonNull(tag);
         this.tag = tag;
         return this;
     }
@@ -2484,8 +2474,7 @@ public final class PostTags implements Model {
   public final class CopyOfBuilder extends Builder {
     private CopyOfBuilder(String id, Post post, Tag tag) {
       super(id, post, tag);
-      Objects.requireNonNull(post);
-      Objects.requireNonNull(tag);
+      
     }
     
     @Override

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -377,8 +377,8 @@ type EagerPostTags = {
   readonly posttitle?: string | null;
   readonly tagCustomTagId?: string | null;
   readonly taglabel?: string | null;
-  readonly post: Post;
-  readonly tag: Tag;
+  readonly post?: Post | null;
+  readonly tag?: Tag | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
@@ -393,8 +393,8 @@ type LazyPostTags = {
   readonly posttitle?: string | null;
   readonly tagCustomTagId?: string | null;
   readonly taglabel?: string | null;
-  readonly post: AsyncItem<Post>;
-  readonly tag: AsyncItem<Tag>;
+  readonly post: AsyncItem<Post | undefined>;
+  readonly tag: AsyncItem<Tag | undefined>;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-json-metadata-visitor.test.ts.snap
@@ -2382,7 +2382,7 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
                     \\"type\\": {
                         \\"model\\": \\"Post\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -2398,7 +2398,7 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
                     \\"type\\": {
                         \\"model\\": \\"Tag\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -2458,7 +2458,7 @@ exports[`Metadata visitor for custom PK support relation metadata for manyToMany
     \\"enums\\": {},
     \\"nonModels\\": {},
     \\"codegenVersion\\": \\"3.4.4\\",
-    \\"version\\": \\"7c85f0b3f2df2a63cd6e1c28593a5381\\"
+    \\"version\\": \\"112de974c2f8a3b504248fcb5c316289\\"
 };"
 `;
 
@@ -2654,7 +2654,7 @@ export const schema: Schema = {
                     \\"type\\": {
                         \\"model\\": \\"Post\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -2670,7 +2670,7 @@ export const schema: Schema = {
                     \\"type\\": {
                         \\"model\\": \\"Tag\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -2730,6 +2730,6 @@ export const schema: Schema = {
     \\"enums\\": {},
     \\"nonModels\\": {},
     \\"codegenVersion\\": \\"3.4.4\\",
-    \\"version\\": \\"7c85f0b3f2df2a63cd6e1c28593a5381\\"
+    \\"version\\": \\"112de974c2f8a3b504248fcb5c316289\\"
 };"
 `;

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -1529,7 +1529,7 @@ exports[`Custom primary key tests should generate correct model intropection fil
                     \\"type\\": {
                         \\"model\\": \\"Post\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -1545,7 +1545,7 @@ exports[`Custom primary key tests should generate correct model intropection fil
                     \\"type\\": {
                         \\"model\\": \\"Tag\\"
                     },
-                    \\"isRequired\\": true,
+                    \\"isRequired\\": false,
                     \\"attributes\\": [],
                     \\"association\\": {
                         \\"connectionType\\": \\"BELONGS_TO\\",
@@ -2673,7 +2673,7 @@ Object {
           },
           "attributes": Array [],
           "isArray": false,
-          "isRequired": true,
+          "isRequired": false,
           "name": "enthusiast",
           "type": Object {
             "model": "Enthusiast",
@@ -2705,7 +2705,7 @@ Object {
           },
           "attributes": Array [],
           "isArray": false,
-          "isRequired": true,
+          "isRequired": false,
           "name": "like",
           "type": Object {
             "model": "Like",

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -4,7 +4,142 @@ exports[`AppSyncSwiftVisitor Many To Many V2 Tests Should generate the intermedi
 "// swiftlint:disable all
 import Amplify
 import Foundation
-"
+
+public struct PostTags: Model {
+  public let id: String
+  internal var _post: LazyReference<Post>
+  public var post: Post   {
+      get async throws { 
+        try await _post.require()
+      } 
+    }
+  internal var _tag: LazyReference<Tag>
+  public var tag: Tag   {
+      get async throws { 
+        try await _tag.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      post: Post,
+      tag: Tag) {
+    self.init(id: id,
+      post: post,
+      tag: tag,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      post: Post,
+      tag: Tag,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self._post = LazyReference(post)
+      self._tag = LazyReference(tag)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post) {
+    self._post = LazyReference(post)
+  }
+  public mutating func setTag(_ tag: Tag) {
+    self._tag = LazyReference(tag)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      _post = try values.decodeIfPresent(LazyReference<Post>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      _tag = try values.decodeIfPresent(LazyReference<Tag>.self, forKey: .tag) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(_post, forKey: .post)
+      try container.encode(_tag, forKey: .tag)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Many To Many V2 Tests Should generate the intermediate model successfully 2`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post: Model {
+  public let id: String
+  public var title: String
+  public var content: String?
+  public var tags: List<PostTags>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      content: String? = nil,
+      tags: List<PostTags>? = []) {
+    self.init(id: id,
+      title: title,
+      content: content,
+      tags: tags,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      content: String? = nil,
+      tags: List<PostTags>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.content = content
+      self.tags = tags
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
+`;
+
+exports[`AppSyncSwiftVisitor Many To Many V2 Tests Should generate the intermediate model successfully 3`] = `
+"// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Tag: Model {
+  public let id: String
+  public var label: String
+  public var posts: List<PostTags>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      label: String,
+      posts: List<PostTags>? = []) {
+    self.init(id: id,
+      label: label,
+      posts: posts,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      label: String,
+      posts: List<PostTags>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.label = label
+      self.posts = posts
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}"
 `;
 
 exports[`AppSyncSwiftVisitor Primary Key Tests Should generate foreign key fields in hasMany uni relation for model with CPK 1`] = `

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-swift-visitor.test.ts.snap
@@ -8,23 +8,23 @@ import Foundation
 public struct PostTags: Model {
   public let id: String
   internal var _post: LazyReference<Post>
-  public var post: Post   {
+  public var post: Post?   {
       get async throws { 
-        try await _post.require()
+        try await _post.get()
       } 
     }
   internal var _tag: LazyReference<Tag>
-  public var tag: Tag   {
+  public var tag: Tag?   {
       get async throws { 
-        try await _tag.require()
+        try await _tag.get()
       } 
     }
   public var createdAt: Temporal.DateTime?
   public var updatedAt: Temporal.DateTime?
   
   public init(id: String = UUID().uuidString,
-      post: Post,
-      tag: Tag) {
+      post: Post? = nil,
+      tag: Tag? = nil) {
     self.init(id: id,
       post: post,
       tag: tag,
@@ -32,8 +32,8 @@ public struct PostTags: Model {
       updatedAt: nil)
   }
   internal init(id: String = UUID().uuidString,
-      post: Post,
-      tag: Tag,
+      post: Post? = nil,
+      tag: Tag? = nil,
       createdAt: Temporal.DateTime? = nil,
       updatedAt: Temporal.DateTime? = nil) {
       self.id = id
@@ -42,10 +42,10 @@ public struct PostTags: Model {
       self.createdAt = createdAt
       self.updatedAt = updatedAt
   }
-  public mutating func setPost(_ post: Post) {
+  public mutating func setPost(_ post: Post? = nil) {
     self._post = LazyReference(post)
   }
-  public mutating func setTag(_ tag: Tag) {
+  public mutating func setTag(_ tag: Tag? = nil) {
     self._tag = LazyReference(tag)
   }
   public init(from decoder: Decoder) throws {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-swift-visitor.test.ts
@@ -2839,8 +2839,10 @@ describe('AppSyncSwiftVisitor', () => {
           posts: [Post] @manyToMany(relationName: "PostTags")
         }
       `;
-      const generatedCode = getVisitorPipelinedTransformer(schema, CodeGenGenerateEnum.code).generate();
+      const generatedCode = getVisitorPipelinedTransformer(schema, 'PostTags', CodeGenGenerateEnum.code).generate();
       expect(generatedCode).toMatchSnapshot();
+      expect(getVisitorPipelinedTransformer(schema, 'Post', CodeGenGenerateEnum.code).generate()).toMatchSnapshot();
+      expect(getVisitorPipelinedTransformer(schema, 'Tag', CodeGenGenerateEnum.code).generate()).toMatchSnapshot();
     });
   });
 

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/gqlv2-regression-tests/__snapshots__/appsync-javascript-visitor.test.ts.snap
@@ -406,16 +406,16 @@ export declare const Tag: (new (init: ModelInit<Tag, TagMetaData>) => Tag) & {
 
 type EagerPostTags = {
   readonly id: string;
-  readonly post: Post;
-  readonly tag: Tag;
+  readonly post?: Post | null;
+  readonly tag?: Tag | null;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }
 
 type LazyPostTags = {
   readonly id: string;
-  readonly post: AsyncItem<Post>;
-  readonly tag: AsyncItem<Tag>;
+  readonly post: AsyncItem<Post | undefined>;
+  readonly tag: AsyncItem<Tag | undefined>;
   readonly createdAt?: string | null;
   readonly updatedAt?: string | null;
 }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -915,7 +915,7 @@ export class AppSyncModelVisitor<
         }),
         {
           type: firstModel.name,
-          isNullable: false,
+          isNullable: true,
           isList: false,
           name: camelCase(firstModel.name),
           directives: [
@@ -932,7 +932,7 @@ export class AppSyncModelVisitor<
         },
         {
           type: secondModel.name,
-          isNullable: false,
+          isNullable: true,
           isList: false,
           name: camelCase(secondModel.name),
           directives: [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

[BREAKING CHANGE]: set relational fields on many-to-many join table to optional

API change: https://github.com/aws-amplify/amplify-category-api/pull/2660

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

* Unit testing
* [E2E testing](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow%3A71b106ad-b37e-42bd-8da8-74df404190d1?region=us-east-1)
* TODO: check impact on runtime libraries

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [x] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [x] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
