### PR TITLE
chore(deps): bump fast-xml-parser from 4.3.2 to 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "glob-parent": "^6.0.2",
     "parse-url": "^8.1.0",
     "graphql": "15.8.0",
-    "xml2js": "0.5.0"
+    "xml2js": "0.5.0",
+    "fast-xml-parser": "^4.4.1"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10675,17 +10675,10 @@ fast-url-parser@^1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
-  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
-  dependencies:
-    strnum "^1.0.5"
-
-fast-xml-parser@^4.2.5:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz#761e641260706d6e13251c4ef8e3f5694d4b0d79"
-  integrity sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==
+fast-xml-parser@4.2.5, fast-xml-parser@^4.2.5, fast-xml-parser@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
+  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Security patch for fast-xml-parser. Dependabot was not able to create this automatically because some deps rely on an exact version `fast-xml-parser@4.2.5`. I created a resolution to the patched version of `fast-xml-parser`.

`fast-xml-parser@4.2.5` is pulled in through various AWS SDK packages. The AWS SDK packages are dependencies of amplify-backend (which is only used as a test package in this repo). 

```
npm list fast-xml-parser
amplify-codegen@0.1.0 /Users/dppilche/amplify/amplify-codegen
├─┬ @aws-amplify/amplify-codegen-e2e-tests@2.45.2 -> ./packages/amplify-codegen-e2e-tests
│ ├─┬ @aws-amplify/backend@1.0.0
│ │ ├─┬ @aws-amplify/backend-data@1.0.0
│ │ │ └─┬ @aws-amplify/data-construct@1.8.1
│ │ │   ├─┬ @aws-amplify/backend-output-storage@0.2.2
│ │ │   │ └─┬ @aws-amplify/platform-core@0.4.4 invalid: "^0.2.0" from node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage
│ │ │   │   └─┬ @aws-sdk/client-sts@3.445.0
│ │ │   │     └── fast-xml-parser@4.4.1
```


API Category also has a resolution so I think there shouldn't be any I'll effects from this. I've started an E2E test run to confirm.

[E2E Tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow:ec5ac998-2423-4350-83b2-95c01daad7ed?region=us-east-1)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
