### PR TITLE
test: remove sandbox deletion prompt

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
+++ b/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
@@ -103,8 +103,6 @@ export const sandboxDeploy = async (cwd: string, props: Gen2DeployProps = {}): P
     spawn(ampxCli, ['sandbox'], commandOptions)
       .wait('Watching for file changes...')
       .sendCtrlC()
-      .wait('Would you like to delete all the resources in your sandbox environment')
-      .sendLine('N')
       .runAsync();
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
The E2E tests are failing on main because the behavior of `npx ampx sandbox` has changed.

Remove sandbox deletion prompt with `ctrl+c` in E2E tests. sandbox no longer prompts this with `ctrl+c`.


#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

[E2E Tests](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow:04671c07-76e5-426a-8355-80452294ed28?region=us-east-1)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
