### PR TITLE
test: remove duplicate enum def

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/__tests__/backends/graphql-generator-gen2/resource.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/backends/graphql-generator-gen2/resource.ts
@@ -20,10 +20,6 @@ const schema = a.schema({
     'PROGRESS',
     'COMPLETED',
   ]),
-  EchoQueryStatus: a.enum([
-    'PROGRESS',
-    'COMPLETED',
-  ]),
   // Non model type
   EchoResponse: a.customType({
     content: a.string(),


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

It is not possible to use `a.ref` in a custom query/mutation currently. Previously the `enum` would need to be defined twice (once as the top-level enum type and then in the custom query/mutation).

```typescript
EchoQueryStatus: a.enum([
  'PROGRESS',
  'COMPLETED',
]),
// Custom query
echoQuery: a
  .query()
  .arguments({
    status: a.enum(['PROGRESS', 'COMPLETED']),
  })
```

A change to the data schema builder now auto-creates the top-level enum type. This resulted in duplicate enum definition for `EchoQueryStatus` in our tests.

```graphql
enum EchoQueryStatus {
  PROGRESS
  COMPLETED
}

# defined twice
enum EchoQueryStatus {
  PROGRESS
  COMPLETED
}
```


#### Description of how you validated changes


[E2E tests](https://us-east-1.console.aws.amazon.com/codebuild/home?region=us-east-1#/builds/build-batch/amplify-codegen-e2e-workflow:459bcbdf-9e47-485c-a353-f877ec583a43/view/new)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
