### PR TITLE
fix(amplify-codegen): support multiple indexes on the same field in introspection schema

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-index.test.ts
@@ -68,6 +68,78 @@ describe('processIndex', () => {
     ]);
   });
 
+  it('support multiple @index directives on a field', () => {
+    const model: CodeGenModel = {
+      directives: [
+        {
+          name: 'model',
+          arguments: {},
+        },
+      ],
+      name: 'testModel',
+      type: 'model',
+      fields: [
+        {
+          type: 'field',
+          isList: false,
+          isNullable: true,
+          name: 'connectionField',
+          directives: [
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItemAndSortField',
+                sortKeyFields: ['sortField'],
+              },
+            },
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItemAndAnotherSortField',
+                sortKeyFields: ['anotherSortField'],
+              },
+            },
+            {
+              name: 'index',
+              arguments: {
+                name: 'byItemAndSomeOtherSortField',
+                sortKeyFields: ['someOtherSortField'],
+              },
+            },
+          ],
+        },
+      ],
+    };
+    processIndex(model);
+    expect(model.directives).toEqual([
+      {
+        name: 'model',
+        arguments: {},
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItemAndSortField',
+          fields: ['connectionField', 'sortField'],
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItemAndAnotherSortField',
+          fields: ['connectionField', 'anotherSortField'],
+        },
+      },
+      {
+        name: 'key',
+        arguments: {
+          name: 'byItemAndSomeOtherSortField',
+          fields: ['connectionField', 'someOtherSortField'],
+        },
+      },
+    ]);
+  });
+
   it('adds simple @index directives as model key attributes', () => {
     const model: CodeGenModel = {
       directives: [

--- a/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/fieldUtils.ts
@@ -15,6 +15,9 @@ export function removeFieldFromModel(model: CodeGenModel, fieldName: string): vo
 export const getDirective = (fieldOrModel: CodeGenField | CodeGenModel) => (directiveName: string): CodeGenDirective | undefined =>
   fieldOrModel.directives.find(d => d.name === directiveName);
 
+export const getDirectives = (fieldOrModel: CodeGenField | CodeGenModel) => (directiveName: string): CodeGenDirective[] | undefined =>
+  fieldOrModel.directives.filter(d => d.name === directiveName);
+
 // Function matching to GraphQL transformer so that the auto-generated field
 export function toCamelCase(words: string[]): string {
   const formatted = words.map((w, i) => (i === 0 ? w.charAt(0).toLowerCase() + w.slice(1) : w.charAt(0).toUpperCase() + w.slice(1)));


### PR DESCRIPTION
#### Description of changes
Fixes a bug where multiple indexes on a field is not correctly represented on the generated model introspection schema.

#### Codegen Paramaters Changed or Added
No.
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
Fixes https://github.com/aws-amplify/amplify-category-api/issues/2815


#### Description of how you validated changes
- Unit tests
- Manual test

> [!NOTE]  
> **Manual testing:** I've tested the fix on a sample Gen2 app using NPM overrides pointing to the local packaged module.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
