### PR TITLE
fix: allow required uni-directional hasOne with @connection when datastore is disabled

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -56,7 +56,7 @@ describe('process connection', () => {
 
       it('should return HAS_MANY for Post.comments field connection info', () => {
         const commentsField = modelMap.Post.fields[0];
-        const connectionInfo = (processConnections(commentsField, modelMap.Post, modelMap) as any) as CodeGenFieldConnectionHasMany;
+        const connectionInfo = (processConnections(commentsField, modelMap.Post, modelMap, true) as any) as CodeGenFieldConnectionHasMany;
         expect(connectionInfo).toBeDefined();
 
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
@@ -66,7 +66,7 @@ describe('process connection', () => {
 
       it('should return BELONGS_TO for Comment.post field connection info', () => {
         const postField = modelMap.Comment.fields[0];
-        const connectionInfo = (processConnections(postField, modelMap.Comment, modelMap) as any) as CodeGenFieldConnectionBelongsTo;
+        const connectionInfo = (processConnections(postField, modelMap.Comment, modelMap, true) as any) as CodeGenFieldConnectionBelongsTo;
         expect(connectionInfo).toBeDefined();
 
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
@@ -120,7 +120,7 @@ describe('process connection', () => {
 
       it('should return HAS_ONE Person.license field', () => {
         const licenseField = modelMap.Person.fields[0];
-        const connectionInfo = (processConnections(licenseField, modelMap.Person, modelMap) as any) as CodeGenFieldConnectionHasOne;
+        const connectionInfo = (processConnections(licenseField, modelMap.Person, modelMap, true) as any) as CodeGenFieldConnectionHasOne;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
         expect(connectionInfo.associatedWith).toEqual(modelMap.License.fields[0]);
@@ -130,7 +130,7 @@ describe('process connection', () => {
 
       it('should return BELONGS_TO License.person field', () => {
         const personField = modelMap.License.fields[0];
-        const connectionInfo = (processConnections(personField, modelMap.License, modelMap) as any) as CodeGenFieldConnectionBelongsTo;
+        const connectionInfo = (processConnections(personField, modelMap.License, modelMap, true) as any) as CodeGenFieldConnectionBelongsTo;
         expect(connectionInfo).toBeDefined();
         expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
         expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(true);
@@ -141,8 +141,73 @@ describe('process connection', () => {
         // Make person field optional
         personField.isNullable = true;
         expect(() => {
-          processConnections(personField, modelMap.License, modelMap);
+          processConnections(personField, modelMap.License, modelMap, true);
         }).toThrowError('DataStore does not support 1 to 1 connection with both sides of connection as optional field');
+      });
+
+      it('uni-directional One:One connection with required field and datastore is not enabled', () => {
+        const schema = /* GraphQL */ `
+          type User @model {
+            id: ID!
+          }
+          type Session @model {
+            id: ID!
+            sessionUserId: ID!
+            user: User! @connection(fields: ["sessionUserId"])
+          }
+        `;
+
+        const modelMap: CodeGenModelMap = {
+          User: {
+            name: 'User',
+            type: 'model',
+            directives: [],
+            fields: [
+              {
+                type: 'ID',
+                isNullable: false,
+                isList: false,
+                name: 'id',
+                directives: [],
+              },
+            ],
+          },
+          Session: {
+            name: 'Session',
+            type: 'model',
+            directives: [],
+            fields: [
+              {
+                type: 'ID',
+                isNullable: false,
+                isList: false,
+                name: 'id',
+                directives: [],
+              },
+              {
+                type: 'ID',
+                isNullable: false,
+                isList: false,
+                name: 'sessionUserId',
+                directives: [],
+              },
+              {
+                type: 'User',
+                isNullable: false,
+                isList: false,
+                name: 'user',
+                directives: [{ name: 'connection', arguments: { fields: ['sessionUserId'] } }],
+              },
+            ],
+          },
+        };
+
+        modelMap.Session.fields[2]
+
+        const connectionInfo = (processConnections(modelMap.Session.fields[2], modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
+        expect(connectionInfo).toBeDefined();
+        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
       });
     });
   });
@@ -192,7 +257,7 @@ describe('process connection', () => {
 
     it('should return HAS_MANY for Post.comments', () => {
       const commentsField = modelMap.Post.fields[0];
-      const connectionInfo = (processConnections(commentsField, modelMap.Post, modelMap) as any) as CodeGenFieldConnectionHasMany;
+      const connectionInfo = (processConnections(commentsField, modelMap.Post, modelMap, true) as any) as CodeGenFieldConnectionHasMany;
       expect(connectionInfo).toBeDefined();
 
       expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_MANY);
@@ -208,7 +273,7 @@ describe('process connection', () => {
 
     it('should return BELONGS_TO for Comment.post', () => {
       const commentsField = modelMap.Comment.fields[0];
-      const connectionInfo = (processConnections(commentsField, modelMap.Comment, modelMap) as any) as CodeGenFieldConnectionBelongsTo;
+      const connectionInfo = (processConnections(commentsField, modelMap.Comment, modelMap, true) as any) as CodeGenFieldConnectionBelongsTo;
       expect(connectionInfo).toBeDefined();
 
       expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
@@ -280,12 +345,12 @@ describe('process connection', () => {
 
     it('should not throw error if connection directive has keyName', () => {
       const commentsField = modelMap.Post.fields[0];
-      expect(() => processConnections(commentsField, modelMap.Post, modelMap)).not.toThrowError();
+      expect(() => processConnections(commentsField, modelMap.Post, modelMap, true)).not.toThrowError();
     });
 
     it('should support connection with @key on BELONGS_TO side', () => {
       const postField = modelMap.Comment.fields[2];
-      const connectionInfo = (processConnections(postField, modelMap.Post, modelMap) as any) as CodeGenFieldConnectionBelongsTo;
+      const connectionInfo = (processConnections(postField, modelMap.Post, modelMap, true) as any) as CodeGenFieldConnectionBelongsTo;
       expect(connectionInfo).toBeDefined();
       expect(connectionInfo.kind).toEqual(CodeGenConnectionType.BELONGS_TO);
       expect(connectionInfo.targetName).toEqual(modelMap.Comment.fields[0].name);

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -145,7 +145,7 @@ describe('process connection', () => {
         }).toThrowError('DataStore does not support 1 to 1 connection with both sides of connection as optional field');
       });
 
-      it('uni-directional One:One connection with required field and datastore is not enabled', () => {
+      describe('Uni-directional connection', () => {
         const schema = /* GraphQL */ `
           type User @model {
             id: ID!
@@ -202,12 +202,36 @@ describe('process connection', () => {
           },
         };
 
-        modelMap.Session.fields[2]
+        it('uni-directional One:One connection with required field and datastore is not enabled', () => {
+          const connectionInfo = (processConnections(modelMap.Session.fields[2], modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
+          expect(connectionInfo).toBeDefined();
+          expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+          expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        });
 
-        const connectionInfo = (processConnections(modelMap.Session.fields[2], modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
-        expect(connectionInfo).toBeDefined();
-        expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
-        expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        it('uni-directional One:One connection with optional field and datastore is not enabled', () => {
+          const field = { ...modelMap.Session.fields[2] };
+          field.isNullable = true;
+          const connectionInfo = (processConnections(field, modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
+          expect(connectionInfo).toBeDefined();
+          expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+          expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        });
+
+        it('uni-directional One:One connection with required field and datastore is enabled', () => {
+          expect(() => {
+            processConnections(modelMap.Session.fields[2], modelMap.User, modelMap, true);
+          }).toThrowError('DataStore does not support 1 to 1 connection with both sides of connection as optional field');
+        });
+
+        it('uni-directional One:One connection with optional field and datastore is enabled', () => {
+          const field = { ...modelMap.Session.fields[2] };
+          field.isNullable = true;
+          const connectionInfo = (processConnections(field, modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
+          expect(connectionInfo).toBeDefined();
+          expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
+          expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);
+        });
       });
     });
   });

--- a/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/utils/process-connections.test.ts
@@ -227,7 +227,7 @@ describe('process connection', () => {
         it('uni-directional One:One connection with optional field and datastore is enabled', () => {
           const field = { ...modelMap.Session.fields[2] };
           field.isNullable = true;
-          const connectionInfo = (processConnections(field, modelMap.User, modelMap, false) as any) as CodeGenFieldConnectionBelongsTo;
+          const connectionInfo = (processConnections(field, modelMap.User, modelMap, true) as any) as CodeGenFieldConnectionBelongsTo;
           expect(connectionInfo).toBeDefined();
           expect(connectionInfo.kind).toEqual(CodeGenConnectionType.HAS_ONE);
           expect(connectionInfo.isConnectingFieldAutoCreated).toEqual(false);

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -2408,6 +2408,345 @@ exports[`Generation Route Introspection Visitor Metadata snapshot should generat
 }"
 `;
 
+exports[`Generation Route Introspection Visitor V1 Transformer uni-directional One:One connection with optional field and datastore is disabled 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"User\\": {
+            \\"name\\": \\"User\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Users\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"Session\\": {
+            \\"name\\": \\"Session\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"sessionUserId\\": {
+                    \\"name\\": \\"sessionUserId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"user\\": {
+                    \\"name\\": \\"user\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"User\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [],
+                        \\"targetNames\\": []
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Sessions\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}"
+`;
+
+exports[`Generation Route Introspection Visitor V1 Transformer uni-directional One:One connection with optional field and datastore is enabled 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"User\\": {
+            \\"name\\": \\"User\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Users\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"Session\\": {
+            \\"name\\": \\"Session\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"sessionUserId\\": {
+                    \\"name\\": \\"sessionUserId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"user\\": {
+                    \\"name\\": \\"user\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"User\\"
+                    },
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [],
+                        \\"targetNames\\": []
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Sessions\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}"
+`;
+
+exports[`Generation Route Introspection Visitor V1 Transformer uni-directional One:One connection with required field and datastore is disabled 1`] = `
+"{
+    \\"version\\": 1,
+    \\"models\\": {
+        \\"User\\": {
+            \\"name\\": \\"User\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Users\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        },
+        \\"Session\\": {
+            \\"name\\": \\"Session\\",
+            \\"fields\\": {
+                \\"id\\": {
+                    \\"name\\": \\"id\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"sessionUserId\\": {
+                    \\"name\\": \\"sessionUserId\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"ID\\",
+                    \\"isRequired\\": true,
+                    \\"attributes\\": []
+                },
+                \\"user\\": {
+                    \\"name\\": \\"user\\",
+                    \\"isArray\\": false,
+                    \\"type\\": {
+                        \\"model\\": \\"User\\"
+                    },
+                    \\"isRequired\\": true,
+                    \\"attributes\\": [],
+                    \\"association\\": {
+                        \\"connectionType\\": \\"HAS_ONE\\",
+                        \\"associatedWith\\": [],
+                        \\"targetNames\\": []
+                    }
+                },
+                \\"createdAt\\": {
+                    \\"name\\": \\"createdAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                },
+                \\"updatedAt\\": {
+                    \\"name\\": \\"updatedAt\\",
+                    \\"isArray\\": false,
+                    \\"type\\": \\"AWSDateTime\\",
+                    \\"isRequired\\": false,
+                    \\"attributes\\": [],
+                    \\"isReadOnly\\": true
+                }
+            },
+            \\"syncable\\": true,
+            \\"pluralName\\": \\"Sessions\\",
+            \\"attributes\\": [
+                {
+                    \\"type\\": \\"model\\",
+                    \\"properties\\": {}
+                }
+            ],
+            \\"primaryKeyInfo\\": {
+                \\"isCustomPrimaryKey\\": false,
+                \\"primaryKeyFieldName\\": \\"id\\",
+                \\"sortKeyFieldNames\\": []
+            }
+        }
+    },
+    \\"enums\\": {},
+    \\"nonModels\\": {}
+}"
+`;
+
 exports[`Model Introspection Visitor Metadata snapshot should generate correct model intropection file validated by JSON schema 1`] = `
 "{
     \\"version\\": 1,

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -3,8 +3,6 @@ import { METADATA_SCALAR_MAP } from '../../scalars';
 import { AppSyncDirectives, DefaultDirectives, V1Directives, DeprecatedDirective, Directive, V2Directives } from '@aws-amplify/graphql-directives';
 import { scalars } from '../../scalars/supported-scalars';
 import { AppSyncModelIntrospectionVisitor } from '../../visitors/appsync-model-introspection-visitor';
-import { deprecate } from 'util';
-import { isDataStoreEnabled } from 'graphql-transformer-core';
 
 const defaultModelIntropectionVisitorSettings = {
   isTimestampFieldsAdded: true,

--- a/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-connections.ts
@@ -128,6 +128,7 @@ export function processConnections(
   field: CodeGenField,
   model: CodeGenModel,
   modelMap: CodeGenModelMap,
+  isDataStoreEnabled: boolean,
 ): CodeGenFieldConnection | undefined {
   const connectionDirective = field.directives.find(d => d.name === 'connection');
   if (connectionDirective) {
@@ -189,7 +190,7 @@ export function processConnections(
             targetName: connectionFields[0] || makeConnectionAttributeName(model.name, field.name),
             targetNames: [] // New attribute for v2 custom pk support. Not used in v1 so use empty array.
           };
-        } else if (field.isNullable && !otherSideField.isNullable) {
+        } else if ((field.isNullable && !otherSideField.isNullable) || !isDataStoreEnabled) {
           /*
           # model
           type License { # belongsTo

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -169,7 +169,7 @@ export interface ParsedAppSyncModelConfig extends ParsedConfig {
   selectedType?: string;
   generate?: CodeGenGenerateEnum;
   target?: string;
-  isDataStoreEnabled?: string;
+  isDataStoreEnabled?: boolean;
   isTimestampFieldsAdded?: boolean;
   handleListNullabilityTransparently?: boolean;
   usePipelinedTransformer?: boolean;
@@ -818,7 +818,7 @@ export class AppSyncModelVisitor<
   protected processConnectionDirective(): void {
     Object.values(this.modelMap).forEach(model => {
       model.fields.forEach(field => {
-        const connectionInfo = processConnections(field, model, this.modelMap);
+        const connectionInfo = processConnections(field, model, this.modelMap, !!this.config.isDataStoreEnabled);
         if (connectionInfo) {
           if (connectionInfo.kind === CodeGenConnectionType.HAS_MANY || connectionInfo.kind === CodeGenConnectionType.HAS_ONE) {
             // Need to update the other side of the connection even if there is no connection directive


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

CLI v11.0.0 introduced creating the model introspection schema at the end of every amplify push. Some customers using the v1 transformer with `@connection` with DataStore disabled were unable to upgrade to later versions of the CLI and successfully push. The model generation at the end of the push failed with `DataStore does not support 1 to 1 connection with both sides of connection as optional field`. This error is not applicable to customers not using DataStore. This error would also print the case the connection was required on both sides.

This change removes this restriction from customers not using DataStore. 


Currently working (user is not required).
```graphql
type User @model {
  id: ID!
}
type Session @model {
  id: ID!
  sessionUserId: ID!
  # works when user is not required
  user: User @connection(fields: ["sessionUserId"])
}
```
Results in following connection info.

```typescript
{
  kind: 'HAS_ONE',
  associatedWith: {
    type: 'ID',
    isNullable: false,
    isList: false,
    name: 'id',
    directives: []
  },
  associatedWithFields: [],
  connectedModel: { name: 'User', type: 'model', directives: [], fields: [ [Object] ] },
  isConnectingFieldAutoCreated: false,
  targetName: 'sessionUserId',
  targetNames: []
}
```

Removing the restriction allows to set `user` as a required field.
```graphql
type User @model {
  id: ID!
}
type Session @model {
  id: ID!
  sessionUserId: ID!
  # user is required
  user: User! @connection(fields: ["sessionUserId"])
}
```

Results in the following connection info.

```typescript
{
  kind: 'HAS_ONE',
  associatedWith: {
    type: 'ID',
    isNullable: false,
    isList: false,
    name: 'id',
    directives: []
  },
  associatedWithFields: [],
  connectedModel: { name: 'User', type: 'model', directives: [], fields: [ [Object] ] },
  isConnectingFieldAutoCreated: false,
  targetName: 'sessionUserId',
  targetNames: []
}
```

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

https://github.com/aws-amplify/amplify-category-api/issues/1419

#### Description of how you validated changes

* Unit test
* e2e test https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow%3A6e0f2996-f724-4536-8b73-e5dad41d18a0?region=us-east-1
* Manual testing with customer schema

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
