### PR TITLE
fix(appsync-modelgen-plugin): add conversation.owner field

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -98,6 +98,13 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                             \\"isArray\\": false,
                             \\"isRequired\\": false,
                             \\"isReadOnly\\": true
+                        },
+                        \\"owner\\": {
+                            \\"name\\": \\"owner\\",
+                            \\"type\\": \\"String\\",
+                            \\"attributes\\": [],
+                            \\"isArray\\": false,
+                            \\"isRequired\\": false
                         }
                     },
                     \\"syncable\\": true,

--- a/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
@@ -60,6 +60,7 @@ function generateConversationModel(modelName: string, messageModelName: string):
       messages: generateMessagesField(messageModelName),
       createdAt: generateTimestampField('createdAt'),
       updatedAt: generateTimestampField('updatedAt'),
+      owner: generateField('owner', 'String'),
     },
     syncable: true,
     pluralName: plural(modelName),


### PR DESCRIPTION
#### Description of changes
- Adds missing `owner` field to `Conversation<RouteName>` model.

#### Codegen Paramaters Changed or Added
N/A

#### Issue #, if available
N/A

#### Description of how you validated changes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~Breaking changes to existing customers are released behind a feature flag or major version update~
- [ ] ~Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified~
- [ ] ~Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.~
- [ ] ~Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
