### PR TITLE
chore: update schema test library version, cookie dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "graphql": "15.8.0",
     "xml2js": "0.5.0",
     "axios": "^1.7.4",
-    "**/@aws-amplify/amplify-codegen-e2e-tests/**/fast-xml-parser": "^4.4.1"
+    "**/@aws-amplify/amplify-codegen-e2e-tests/**/fast-xml-parser": "^4.4.1",
+    "**/@aws-amplify/amplify-codegen-e2e-tests/**/cookie": "^0.7.0"
   },
   "config": {
     "commitizen": {

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-amplify/amplify-codegen-e2e-core": "1.6.5",
-    "@aws-amplify/graphql-schema-test-library": "^2.2.28",
+    "@aws-amplify/graphql-schema-test-library": "^3.0.0",
     "amazon-cognito-identity-js": "^6.3.6",
     "aws-amplify": "^5.3.3",
     "aws-appsync": "^4.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,10 +583,10 @@
     graphql-transformer-common "4.30.1"
     immer "^9.0.12"
 
-"@aws-amplify/graphql-schema-test-library@^2.2.28":
-  version "2.2.28"
-  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-schema-test-library/-/graphql-schema-test-library-2.2.28.tgz#a60ae3fd2d9e5d4bd154899a6e0d28a48af0a855"
-  integrity sha512-1ZFFGKICIINhZkbkHC9lrPD9nMa5uLppmUyL1cJR2TKqneVKO8l0B88nnqhwjq/9yREFEP06VklORfm1XBKeUQ==
+"@aws-amplify/graphql-schema-test-library@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@aws-amplify/graphql-schema-test-library/-/graphql-schema-test-library-3.0.4.tgz#05bcb53a0b6364e49eec1fb526dfca2cad79097c"
+  integrity sha512-KM7HMrAP3wPHuKD1Rd/Z00bkVqtNbRNmTMmNOTDkommwnirrjBAFtZCLCp5GL1zdhxqsheCSuFZur+RGYAQqqA==
 
 "@aws-amplify/graphql-searchable-transformer@2.7.1":
   version "2.7.1"
@@ -9580,10 +9580,10 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+cookie@^0.4.0, cookie@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 copyfiles@^2.2.0:
   version "2.4.1"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Consume the latest version of `@aws-amplify/graphql-schema-test-library` that is published from [API repo main branch](https://github.com/aws-amplify/amplify-category-api/blob/main/packages/amplify-graphql-schema-test-library/package.json).
- Upgrade the `cookie` version pulled in transitively from the E2E test package.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

CI checks - triggered E2E

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
