### PR TITLE
chore: handle Gen1 usage prompt during init

### DIFF
--- a/packages/amplify-codegen-e2e-core/src/init/initProjectHelper.ts
+++ b/packages/amplify-codegen-e2e-core/src/init/initProjectHelper.ts
@@ -1,5 +1,5 @@
 import { nspawn as spawn, getCLIPath, singleSelect, addCITags } from '..';
-import { KEY_DOWN_ARROW, AmplifyFrontend } from '../utils';
+import { KEY_DOWN_ARROW, AmplifyFrontend, ExecutionContext } from '../utils';
 import { amplifyRegions } from '../configure';
 import { v4 as uuid } from 'uuid';
 
@@ -44,6 +44,7 @@ export function initJSProjectWithProfile(cwd: string, settings: Object = {}): Pr
 
   return new Promise((resolve, reject) => {
     const chain = spawn(getCLIPath(), cliArgs, { cwd, stripColors: true, env, disableCIDetection: s.disableCIDetection })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')
@@ -91,19 +92,28 @@ export function initJSProjectWithProfile(cwd: string, settings: Object = {}): Pr
   });
 }
 
+export const confirmUsingGen1Amplify = (executionContext: ExecutionContext): ExecutionContext => {
+  return executionContext
+  .wait('Do you want to continue with Amplify Gen 1?')
+  .sendConfirmYes()
+  .wait('Why would you like to use Amplify Gen 1?')
+  .sendCarriageReturn()
+}
+
 export function initAndroidProjectWithProfile(cwd: string, settings: Object): Promise<void> {
   const s = { ...defaultSettings, ...settings };
 
   addCITags(cwd);
 
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['init'], {
+    const chain = spawn(getCLIPath(), ['init'], {
       cwd,
       stripColors: true,
       env: {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
     })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')
@@ -141,13 +151,14 @@ export function initIosProjectWithProfile(cwd: string, settings: Object): Promis
   addCITags(cwd);
 
   return new Promise((resolve, reject) => {
-    spawn(getCLIPath(), ['init'], {
+    const chain = spawn(getCLIPath(), ['init'], {
       cwd,
       stripColors: true,
       env: {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
     })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')
@@ -178,6 +189,7 @@ export function initFlutterProjectWithProfile(cwd: string, settings: Object): Pr
 
   return new Promise((resolve, reject) => {
     let chain = spawn(getCLIPath(), ['init'], { cwd, stripColors: true })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')
@@ -228,6 +240,7 @@ export function initProjectWithAccessKey(
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
     })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(s.name)
       .wait('Initialize the project with the above configuration?')

--- a/packages/amplify-codegen-e2e-core/src/utils/pinpoint.ts
+++ b/packages/amplify-codegen-e2e-core/src/utils/pinpoint.ts
@@ -1,5 +1,5 @@
 import { Pinpoint } from 'aws-sdk';
-import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions, addCITags, KEY_DOWN_ARROW } from '..';
+import { getCLIPath, nspawn as spawn, singleSelect, amplifyRegions, addCITags, KEY_DOWN_ARROW, confirmUsingGen1Amplify } from '..';
 import _ from 'lodash';
 
 const settings = {
@@ -80,6 +80,7 @@ export function initProjectForPinpoint(cwd: string): Promise<void> {
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
     })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendLine(settings.name)
       .wait('Initialize the project with the above configuration?')

--- a/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
+++ b/packages/amplify-codegen-e2e-tests/src/init-special-cases/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions, addCITags, KEY_DOWN_ARROW } from '@aws-amplify/amplify-codegen-e2e-core';
+import { nspawn as spawn, getCLIPath, singleSelect, amplifyRegions, addCITags, KEY_DOWN_ARROW, confirmUsingGen1Amplify } from '@aws-amplify/amplify-codegen-e2e-core';
 import fs from 'fs-extra';
 import os from 'os';
 
@@ -52,6 +52,7 @@ async function initWorkflow(cwd: string, settings: { accessKeyId: string; secret
         CLI_DEV_INTERNAL_DISABLE_AMPLIFY_APP_CREATION: '1',
       },
     })
+      confirmUsingGen1Amplify(chain)
       .wait('Enter a name for the project')
       .sendCarriageReturn()
       .wait('Initialize the project with the above configuration?')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds the missing prompts during `amplify init` that were recently added by CLI team.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

Full E2E

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
