### PR TITLE
fix(conversation): prefix supporting types with AmplifyAI

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -182,7 +182,7 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                         \\"role\\": {
                             \\"name\\": \\"role\\",
                             \\"type\\": {
-                                \\"enum\\": \\"ConversationParticipantRole\\"
+                                \\"enum\\": \\"AmplifyAIConversationParticipantRole\\"
                             },
                             \\"attributes\\": [],
                             \\"isArray\\": false,
@@ -191,7 +191,7 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                         \\"content\\": {
                             \\"name\\": \\"content\\",
                             \\"type\\": {
-                                \\"nonModel\\": \\"ContentBlock\\"
+                                \\"nonModel\\": \\"AmplifyAIContentBlock\\"
                             },
                             \\"attributes\\": [],
                             \\"isArray\\": true,
@@ -207,7 +207,7 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                         \\"toolConfiguration\\": {
                             \\"name\\": \\"toolConfiguration\\",
                             \\"type\\": {
-                                \\"nonModel\\": \\"ToolConfiguration\\"
+                                \\"nonModel\\": \\"AmplifyAIToolConfiguration\\"
                             },
                             \\"attributes\\": [],
                             \\"isArray\\": true,
@@ -270,7 +270,7 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
             \\"nonModels\\": {},
             \\"enums\\": {
                 \\"ConversationParticipantRole\\": {
-                    \\"name\\": \\"ConversationParticipantRole\\",
+                    \\"name\\": \\"AmplifyAIConversationParticipantRole\\",
                     \\"values\\": [
                         \\"user\\",
                         \\"assistant\\"
@@ -326,7 +326,7 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                     \\"isRequired\\": false,
                     \\"name\\": \\"onCreateAssistantResponsePirateChat\\",
                     \\"type\\": {
-                        \\"nonModel\\": \\"ConversationMessageStreamPart\\"
+                        \\"nonModel\\": \\"AmplifyAIConversationMessageStreamPart\\"
                     },
                     \\"arguments\\": {
                         \\"conversationId\\": {

--- a/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
@@ -26,7 +26,7 @@ export function processConversationRoute(
     nonModels: {},
     enums: {
       ConversationParticipantRole: {
-        name: 'ConversationParticipantRole',
+        name: 'AmplifyAIConversationParticipantRole',
         values: ['user', 'assistant'],
       }
     },
@@ -91,10 +91,10 @@ function generateConversationMessageModel(conversationModelName: string, modelNa
       id: generateField('id', 'ID', { isRequired: true }),
       conversationId: generateField('conversationId', 'ID', { isRequired: true }),
       conversation: generateConversationField(conversationModelName),
-      role: generateField('role', { enum: 'ConversationParticipantRole' }),
-      content: generateField('content', { nonModel: 'ContentBlock' }, { isArray: true }),
+      role: generateField('role', { enum: 'AmplifyAIConversationParticipantRole' }),
+      content: generateField('content', { nonModel: 'AmplifyAIContentBlock' }, { isArray: true }),
       aiContext: generateField('aiContext', 'AWSJSON'),
-      toolConfiguration: generateField('toolConfiguration', { nonModel: 'ToolConfiguration' }, { isArray: true, isArrayNullable: true }),
+      toolConfiguration: generateField('toolConfiguration', { nonModel: 'AmplifyAIToolConfiguration' }, { isArray: true, isArrayNullable: true }),
       createdAt: generateTimestampField('createdAt'),
       updatedAt: generateTimestampField('updatedAt'),
     },
@@ -185,7 +185,7 @@ function generateSubscriptionMetadata(routeName: string, modelName: string): Sch
     isArray: false,
     isRequired: false,
     name: `onCreateAssistantResponse${routeName}`,
-    type: { nonModel: 'ConversationMessageStreamPart' },
+    type: { nonModel: 'AmplifyAIConversationMessageStreamPart' },
     arguments: {
       'conversationId': {
         name: 'conversationId',


### PR DESCRIPTION
## Related PRs
- https://github.com/aws-amplify/amplify-category-api/pull/3023
- https://github.com/aws-amplify/amplify-api-next/pull/395

## Problem
Conversation routes add several GraphQL types (type, input, enum, interface) to the GraphQL schema. These types are only added if a conversation route is defined via the `@conversation` directive and are conversation route agnostic (only added once per GraphQL schema regardless of the amount of conversation routes).

These types have generic enough names that they can conflict with customer defined types. 

<details>
<summary>GraphQL Types</summary>

```graphql
enum ConversationParticipantRole {
  user
  assistant
}

interface ConversationMessage {
  id: ID!
  conversationId: ID!
  associatedUserMessageId: ID
  role: ConversationParticipantRole
  content: [ContentBlock]
  aiContext: AWSJSON
  toolConfiguration: ToolConfiguration
  createdAt: AWSDateTime
  updatedAt: AWSDateTime
  owner: String
}

input DocumentBlockSourceInput {
  bytes: String
}

input DocumentBlockInput {
  format: String!
  name: String!
  source: DocumentBlockSourceInput!
}

input ImageBlockSourceInput {
  bytes: String
}

input ImageBlockInput {
  format: String!
  source: ImageBlockSourceInput!
}

input ToolUseBlockInput {
  toolUseId: String!
  name: String!
  input: AWSJSON!
}

input ToolResultContentBlockInput {
  document: DocumentBlockInput
  image: ImageBlockInput
  json: AWSJSON
  text: String
}

input ToolResultBlockInput {
  content: [ToolResultContentBlockInput!]!
  toolUseId: String!
  status: String
}

type DocumentBlockSource {
  bytes: String
}

type DocumentBlock {
  format: String!
  name: String!
  source: DocumentBlockSource!
}

type ImageBlock {
  format: String!
  source: ImageBlockSource!
}

type ImageBlockSource {
  bytes: String
}

type ToolUseBlock {
  toolUseId: String!
  name: String!
  input: AWSJSON!
}

type ToolResultContentBlock {
  document: DocumentBlock
  image: ImageBlock
  json: AWSJSON
  text: String
}

type ToolResultBlock {
  content: [ToolResultContentBlock!]!
  toolUseId: String!
  status: String
}

type ContentBlockText {
  text: String
}

type ContentBlockImage {
  image: ImageBlock
}

type ContentBlockDocument {
  document: DocumentBlock
}

type ContentBlockToolUse {
  toolUse: ToolUseBlock
}

type ContentBlockToolResult {
  toolResult: ToolResultBlock
}

input ContentBlockInput {
  text: String
  document: DocumentBlockInput
  image: ImageBlockInput
  toolResult: ToolResultBlockInput
  toolUse: ToolUseBlockInput
}

type ContentBlock {
  text: String
  document: DocumentBlock
  image: ImageBlock
  toolResult: ToolResultBlock
  toolUse: ToolUseBlock
}

input ToolConfigurationInput {
  tools: [ToolInput]
}

input ToolInput {
  toolSpec: ToolSpecificationInput
}

input ToolSpecificationInput {
  name: String!
  description: String
  inputSchema: ToolInputSchemaInput!
}
```
</details>

## Description of changes
Prefixes all supporting types with `"AmplifyAI"`.

The supporting types themselves are defined in `data-schema` (see related PR https://github.com/aws-amplify/amplify-api-next/pull/395). 

This PR updates appsync-modelgen-plugin as a consumer of these types. This is necessary to ensure the MIS is correct because the `@model`s generated by the conversation transformer have fields using the supporting types.

#### Codegen Paramaters Changed or Added
N/A

## Issue #, if available
See https://github.com/aws-amplify/amplify-ui/issues/5773#issuecomment-2365309568
> 3b. I was already using Tool is my data model. It seems like any reserved words should be prefixed with a Namespace to prevent conflict.

## Description of how you validated changes
Mix of manual and automated testing through tagged releases:
- @aws-amplify/appsync-modelgen-plugin@2.15.1-ai-next.0
- @aws-amplify/data-schema@0.0.0-ai-next-20241113232635
- @aws-amplify/graphql-api-construct@1.17.2-ai-next.1

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] ~Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)~
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~Breaking changes to existing customers are released behind a feature flag or major version update~
- [x] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] ~Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.~
- [x] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
