### PR TITLE
chore: added emit metric function with buildspec for canaries

### DIFF
--- a/.codebuild/canary_workflow.yml
+++ b/.codebuild/canary_workflow.yml
@@ -22,7 +22,7 @@ batch:
       depend-on:
         - build_linux
     - identifier: build_app_swift_us_east_1
-      buildspec: .codebuild/run_ios_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -31,7 +31,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_us_east_1
-      buildspec: .codebuild/run_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -40,7 +40,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_us_east_1
-      buildspec: .codebuild/run_e2e_tests.yml
+      buildspec: .codebuild/run_canary_e2e_tests.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:

--- a/.codebuild/run_canary_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_canary_android_modelgen_e2e_test.yml
@@ -1,0 +1,35 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+
+phases:
+  install:
+    commands:
+      - sudo apt update
+      - yes | sudo apt install android-sdk
+      - export ANDROID_HOME=/usr/lib/android-sdk
+      - yes | sudo apt install sdkmanager
+      # Review SDK licenses
+      - yes | sudo sdkmanager --licenses
+
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
+      - source ./shared-scripts.sh && _unassumeTestAccountCredentials
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitCodegenCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/.codebuild/run_canary_e2e_tests.yml
+++ b/.codebuild/run_canary_e2e_tests.yml
@@ -1,0 +1,26 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+
+phases:
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
+      - source ./shared-scripts.sh && _unassumeTestAccountCredentials
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitCodegenCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/.codebuild/run_canary_ios_modelgen_e2e_test.yml
+++ b/.codebuild/run_canary_ios_modelgen_e2e_test.yml
@@ -1,0 +1,32 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+phases:
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+      - unset AWS_ACCESS_KEY_ID
+      - unset AWS_SECRET_ACCESS_KEY
+      - unset AWS_SESSION_TOKEN
+      - export PATH_TO_MODELS=$CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/test-apps/swift/amplify/generated
+      - cd $PATH_TO_MODELS && zip -r models.zip models
+      - aws s3 cp $PATH_TO_MODELS/models.zip s3://$ARTIFACT_BUCKET_NAME/models.zip
+      - export MODELS_S3_URL=$(aws s3 presign s3://$ARTIFACT_BUCKET_NAME/models.zip --expires-in 3600)
+      - cd $CODEBUILD_SRC_DIR && ./.codebuild/scripts/run-ios-modelgen-e2e-test.sh
+  post_build:
+    commands:
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitCodegenCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -492,3 +492,14 @@ function _deprecate {
   yarn deprecate
   unsetNpmRegistryUrl
 }
+
+function _emitCodegenCanaryMetric {
+  aws cloudwatch \
+    put-metric-data \
+    --metric-name CodegenCanarySuccessRate \
+    --namespace amplify-codegen-canary-e2e-tests \
+    --unit Count \
+    --value $CODEBUILD_BUILD_SUCCEEDING \
+    --dimensions branch=release \
+    --region us-west-2
+}


### PR DESCRIPTION
#### Description of changes
- Added specific build specifications for iOS, Android, and JS apps in the canary pipeline.
- Introduced the `_emitCodegenCanaryMetric` function in `shared-scripts.sh` to send metric data to CloudWatch.
- Updated the canary workflow to include the appropriate buildspec values for all tests.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
