### PR TITLE
chore: disable eslint for build-app test canary

### DIFF
--- a/.codebuild/canary_workflow.yml
+++ b/.codebuild/canary_workflow.yml
@@ -46,6 +46,7 @@ batch:
         variables:
           TEST_SUITE: src/__tests__/build-app-ts.test.ts
           CLI_REGION: us-east-1
+          DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
     - identifier: cleanup_e2e_resources


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Updated `build-app-test.ts` to include `DISABLE_ESLINT_PLUGIN: true`.  
- Resolves the `react` version conflict between `eslintrc.js` and `base-config.js`.
- Verified locally by forking release branch and verifying the workflow succeeds.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
