### PR TITLE
fix: updated github workflow runs-on property to x-large runners

### DIFF
--- a/.github/workflows/build-swift-modelgen.yml
+++ b/.github/workflows/build-swift-modelgen.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   Build-Swift-Modelgen:
     name: Build
-    runs-on: macos-13-xl
+    runs-on: macos-13-xlarge
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
- Updated the `build-swift-modelgen.yml` workflow `runs-on` property.
-  It was previously set to an invalid value, `macos-13-xl`.
- Updated it to the correct value, `macos-13-xlarge`.


#### Description of how you validated changes
- [https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/running-jobs-on-larger-runners?platform=mac#availabl[…]r-runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/running-jobs-on-larger-runners?platform=mac#available-macos-larger-runners)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
