### PR TITLE
chore: update emit metric function to differentiate tests

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -500,6 +500,6 @@ function _emitCodegenCanaryMetric {
     --namespace amplify-codegen-canary-e2e-tests \
     --unit Count \
     --value $CODEBUILD_BUILD_SUCCEEDING \
-    --dimensions branch=release \
+    --dimensions branch=release,test=$(basename "$TEST_SUITE" .test.ts | sed "s/build-app-//") \
     --region us-west-2
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->

### Background
- The Codegen Canary workflow comprises three distinct test suites:
  1. `build-app-ts`
  2. `build-app-android`
  3. `build-app-swift`
- To improve error detection speed and efficiency, updates to the Canary frequency and alarms were necessary.
- Separating metrics for each test suite facilitates easier troubleshooting during `ALARM` states and helps have fewer data points to consider during each Evaluation period for the workflow.

### Changes Implemented
1. Enhanced `_emitCodegenCanaryMetric` function:
   - Added a new `test` dimension to differentiate between test suites.
   - The `test` dimension now includes the following values:
     - `ts` for TypeScript tests
     - `swift` for Swift tests
     - `android` for Android tests
   - These values correspond directly to their respective `TEST_SUITE` in the `canary_workflow.yml`.

### Testing
1. Deployed local changes to a personal CodeBuild Testing account.
2. Executed the Codegen canary workflow to validate:
   - Correct metric naming conventions
   - Proper functionality of the new dimension
  
![Metrics Visualization](https://drive-render.corp.amazon.com/view/tkhanolk@/d9.png)

[Amazon Drive Link If image not visible](https://drive.corp.amazon.com/documents/tkhanolk@/d9.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] Relevant documentation is changed or added (and PR referenced)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
