### PR TITLE
ci: renew corretto pgp key

### DIFF
--- a/.codebuild/run_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_android_modelgen_e2e_test.yml
@@ -12,7 +12,7 @@ phases:
   install:
     commands:
       # Corretto PGP Key has expired. Fetch the renewed key. https://github.com/corretto/corretto-21/issues/83
-      - sudo rm /usr/share/keyrings/corretto-keyring.gpg && wget -O - https://apt.corretto.aws/corretto.key | sudo gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg
+      - sudo apt-key del A122542AB04F24E3 && sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A122542AB04F24E3
       - sudo apt update
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk

--- a/.codebuild/run_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_android_modelgen_e2e_test.yml
@@ -11,6 +11,8 @@ env:
 phases:
   install:
     commands:
+      # Corretto PGP Key has expired. Fetch the renewed key. https://github.com/corretto/corretto-21/issues/83
+      - sudo rm /usr/share/keyrings/corretto-keyring.gpg && wget -O - https://apt.corretto.aws/corretto.key | sudo gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg
       - sudo apt update
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

The build Android app E2E test is failing because the Corretto pgp key has expired and is not able finish installing with APT. Remove and refetch the key as recommended in https://github.com/corretto/corretto-21/issues/83.

We could also create a new ECR image, but I figured this would be sufficient and less effort.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

N/A

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->

N/A

#### Description of how you validated changes

E2E test: https://594813022831-5xzrh3qa.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow%3A54f8919b-dbb0-4d9b-adca-d5dd3e6621d0?region=us-east-1

This PR only fixes `build_app_android`. The `l_graphql_generator_gen2` and `w_graphql_generator_gen2` will still fail due to a different issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
