### PR TITLE
Revert "ci: renew corretto pgp key (#925)"

### DIFF
--- a/.codebuild/run_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_android_modelgen_e2e_test.yml
@@ -11,8 +11,6 @@ env:
 phases:
   install:
     commands:
-      # Corretto PGP Key has expired. Fetch the renewed key. https://github.com/corretto/corretto-21/issues/83
-      - sudo apt-key del A122542AB04F24E3 && sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys A122542AB04F24E3
       - sudo apt update
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk


### PR DESCRIPTION
This reverts commit 37cbcb09de3702a9e8f4c539b2a60db5b2012d4e.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Revert the change to update the pgp key. The canary is using a new CodeBuild image that already has the updated key. I will follow up this PR with a change to use the canary image for the E2E tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
