### PR TITLE
fix: stop pascal casing enums for MIS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -257,7 +257,7 @@ module.exports = {
     '__mocks__',
     '__e2e__',
     'coverage',
-    
+
     // Ignore project/file templates
     'function-template-dir',
 
@@ -271,6 +271,8 @@ module.exports = {
     'test-apps',
 
     // Ignore lint for standalone JSON validation function
-    '/packages/appsync-modelgen-plugin/src/validate-cjs.js'
+    '/packages/appsync-modelgen-plugin/src/validate-cjs.js',
+
+    '.eslintrc.js'
   ]
 };

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -2972,8 +2972,8 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                 \\"enumVal2\\"
             ]
         },
-        \\"camel\\": {
-            \\"name\\": \\"camel\\",
+        \\"camelCase\\": {
+            \\"name\\": \\"camelCase\\",
             \\"values\\": [
                 \\"bactrian\\",
                 \\"dromedary\\"

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -2971,6 +2971,13 @@ exports[`Model Introspection Visitor Metadata snapshot should generate correct m
                 \\"enumVal1\\",
                 \\"enumVal2\\"
             ]
+        },
+        \\"camel\\": {
+            \\"name\\": \\"camel\\",
+            \\"values\\": [
+                \\"bactrian\\",
+                \\"dromedary\\"
+            ]
         }
     },
     \\"nonModels\\": {

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-dart-visitor.test.ts
@@ -276,7 +276,7 @@ describe('AppSync Dart Visitor', () => {
       `;
       const outputModels: string[] = ['Todo', 'Task'];
       outputModels.forEach(model => {
-        const generatedCode = getVisitor({schema, selectedType: model, directives: [...AppSyncDirectives, ...V1Directives, DeprecatedDirective] }).generate();
+        const generatedCode = getVisitor({ schema, selectedType: model, directives: [...AppSyncDirectives, ...V1Directives, DeprecatedDirective] }).generate();
         expect(generatedCode).toMatchSnapshot();
       });
     });
@@ -330,6 +330,26 @@ describe('AppSync Dart Visitor', () => {
         expect(generatedCode).toMatchSnapshot();
       });
     });
+
+    it('should pascal case enum', () => {
+      const schema = /* GraphQL */ `
+        enum status {
+            yes
+            no
+            maybe
+        }`;
+
+      const generatedCode = getVisitor({ schema, selectedType: 'status' }).generate();
+      const statusEnum = generatedCode.split('\n').slice(-5).join('\n')
+      expect(statusEnum).toMatchInlineSnapshot(`
+        "enum Status {
+          yes,
+          no,
+          maybe
+        }"
+      `);
+
+    })
   });
 
   describe('Field tests', () => {
@@ -405,7 +425,7 @@ describe('AppSync Dart Visitor', () => {
           name: String
         }
       `;
-      const visitor = getVisitor({schema, generate: CodeGenGenerateEnum.loader });
+      const visitor = getVisitor({ schema, generate: CodeGenGenerateEnum.loader });
       const generatedCode = visitor.generate();
       expect(generatedCode).toMatchSnapshot();
     });
@@ -565,7 +585,7 @@ describe('AppSync Dart Visitor', () => {
 
     models.forEach(type => {
       it(`should generate correct dart class for ${!type ? 'ModelProvider' : type} with nullsafety`, () => {
-        const generatedCode = getVisitor({schema, selectedType: type, generate: !type ? CodeGenGenerateEnum.loader : CodeGenGenerateEnum.code }).generate();
+        const generatedCode = getVisitor({ schema, selectedType: type, generate: !type ? CodeGenGenerateEnum.loader : CodeGenGenerateEnum.code }).generate();
 
         expect(generatedCode).toMatchSnapshot();
       })
@@ -594,7 +614,7 @@ describe('AppSync Dart Visitor', () => {
           name: String
         }
       `;
-      const visitor = getVisitor({ schema, isTimestampFieldsAdded: true  });
+      const visitor = getVisitor({ schema, isTimestampFieldsAdded: true });
 
 
       const generatedCode = visitor.generate();
@@ -871,7 +891,7 @@ describe('AppSync Dart Visitor', () => {
           content: String
           related: [SqlRelated!] @hasMany(references: ["primaryId"])
         }
-  
+
         type SqlRelated @refersTo(name: "sql_related") @model {
           id: Int! @primaryKey
           content: String
@@ -899,7 +919,7 @@ describe('AppSync Dart Visitor', () => {
           content: String
           related: SqlRelated @hasOne(references: ["primaryId"])
         }
-  
+
         type SqlRelated @refersTo(name: "sql_related") @model {
           id: Int! @primaryKey
           content: String
@@ -927,13 +947,13 @@ describe('AppSync Dart Visitor', () => {
           relatedMany: [RelatedMany] @hasMany(references: ["primaryId"])
           relatedOne: RelatedOne @hasOne(references: ["primaryId"])
         }
-        
+
         type RelatedMany @model {
           id: ID! @primaryKey
           primaryId: ID!
           primary: Primary @belongsTo(references: ["primaryId"])
         }
-        
+
         type RelatedOne @model {
           id: ID! @primaryKey
           primaryId: ID!
@@ -959,7 +979,7 @@ describe('AppSync Dart Visitor', () => {
           bar1: Bar @hasOne(references: ["bar1Id"])
           bar2: Bar @hasOne(references: ["bar2Id"])
         }
-        
+
         type Bar @model {
           id: ID!
           bar1Id: ID
@@ -990,7 +1010,7 @@ describe('AppSync Dart Visitor', () => {
           content: String
           related: [Related!] @hasMany(references: ["primaryTenantId", "primaryInstanceId", "primaryRecordId"])
         }
-        
+
         type Related @model {
           content: String
           primaryTenantId: ID!
@@ -1021,7 +1041,7 @@ describe('AppSync Dart Visitor', () => {
           content: String
           related: Related @hasOne(references: ["primaryTenantId", "primaryInstanceId", "primaryRecordId"])
         }
-        
+
         type Related @model {
           content: String
           primaryTenantId: ID!

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-javascript-visitor.test.ts
@@ -87,6 +87,25 @@ describe('Javascript visitor', () => {
       `);
     });
 
+    it('should pascal case enum', () => {
+      const schema = /* GraphQL */ `
+      enum status {
+        pending
+        done
+      }`;
+
+      const visitor = getVisitor(schema)
+      const enumObj = (visitor as any).enumMap['status'];
+      const statusEnum = (visitor as any).generateEnumObject(enumObj, true);
+      validateTs(statusEnum);
+      expect(statusEnum).toMatchInlineSnapshot(`
+        "export const Status = {
+          \\"PENDING\\": \\"pending\\",
+          \\"DONE\\": \\"done\\"
+        };"
+      `);
+    });
+
     it('should generate import statements', () => {
       const imports = (visitor as any).generateImportsJavaScriptImplementation();
       validateTs(imports);

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -115,6 +115,10 @@ describe('Model Introspection Visitor', () => {
     interface SimpleInterface {
       firstName: String!
     }
+    enum camel {
+      bactrian
+      dromedary
+    }
     union SimpleUnion = SimpleModel | SimpleEnum | SimpleNonModelType | SimpleInput | SimpleInterface
   `;
   const visitor: AppSyncModelIntrospectionVisitor = getVisitor(schema);
@@ -142,6 +146,10 @@ describe('Model Introspection Visitor', () => {
     it('should return interface type for Interface', () => {
       expect((visitor as any).getType('SimpleInterface')).toEqual({ interface: 'SimpleInterface' });
     });
+
+    it('should not pascal case enum', () => {
+      expect((visitor as any).getType('camel')).toEqual({ enum: 'camel' })
+    })
 
     it('should throw error for unknown type', () => {
       expect(() => (visitor as any).getType('unknown')).toThrowError('Unknown type');

--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/appsync-model-introspection-visitor.test.ts
@@ -115,7 +115,7 @@ describe('Model Introspection Visitor', () => {
     interface SimpleInterface {
       firstName: String!
     }
-    enum camel {
+    enum camelCase {
       bactrian
       dromedary
     }
@@ -148,7 +148,7 @@ describe('Model Introspection Visitor', () => {
     });
 
     it('should not pascal case enum', () => {
-      expect((visitor as any).getType('camel')).toEqual({ enum: 'camel' })
+      expect((visitor as any).getType('camelCase')).toEqual({ enum: 'camelCase' })
     })
 
     it('should throw error for unknown type', () => {

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -26,6 +26,7 @@ import {
 import { generateLicense } from '../utils/generateLicense';
 import { GraphQLSchema } from 'graphql';
 import { DART_SCALAR_MAP } from '../scalars';
+import { pascalCase } from 'change-case';
 
 export interface RawAppSyncModelDartConfig extends RawAppSyncModelConfig {}
 
@@ -166,7 +167,7 @@ export class AppSyncModelDartVisitor<
     //Enum
     Object.entries(this.getSelectedEnums()).forEach(([name, enumVal]) => {
       const body = Object.values(enumVal.values).join(',\n');
-      result.push([`enum ${name} {`, indentMultiline(body), '}'].join('\n'));
+      result.push([`enum ${pascalCase(name)} {`, indentMultiline(body), '}'].join('\n'));
     });
     return result.join('\n\n');
   }

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-java-visitor.ts
@@ -158,7 +158,7 @@ export class AppSyncModelJavaVisitor<
       const enumDeclaration = new JavaDeclarationBlock()
         .asKind('enum')
         .access('public')
-        .withName(this.getEnumName(enumValue))
+        .withName(pascalCase(this.getEnumName(enumValue)))
         .annotate(['SuppressWarnings("all")'])
         .withComment('Auto generated enum from GraphQL schema.');
       const body = Object.values(enumValue.values);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-javascript-visitor.ts
@@ -2,6 +2,7 @@ import { DEFAULT_SCALARS, NormalizedScalarsMap } from '@graphql-codegen/visitor-
 import { GraphQLSchema } from 'graphql';
 import { AppSyncModelTypeScriptVisitor } from './appsync-typescript-visitor';
 import { CodeGenEnum, CodeGenModel, ParsedAppSyncModelConfig, RawAppSyncModelConfig } from './appsync-visitor';
+import { pascalCase } from 'change-case';
 
 export interface RawAppSyncModelJavaScriptConfig extends RawAppSyncModelConfig {
   /**
@@ -112,7 +113,7 @@ export class AppSyncModelJavascriptVisitor<
    * @param exportEnum: boolean export the enum object
    */
   protected generateEnumObject(enumObj: CodeGenEnum, exportEnum: boolean = false): string {
-    const enumName = this.getEnumName(enumObj);
+    const enumName = pascalCase(this.getEnumName(enumObj));
     const header = [exportEnum ? 'export' : null, 'const', enumName].filter(h => h).join(' ');
 
     return `${header} = ${JSON.stringify(enumObj.values, null, 2)};`;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-swift-visitor.ts
@@ -1,5 +1,5 @@
 import { indent, indentMultiline, NormalizedScalarsMap } from '@graphql-codegen/visitor-plugin-common';
-import { camelCase } from 'change-case';
+import { camelCase, pascalCase } from 'change-case';
 import { GraphQLSchema } from 'graphql';
 import { lowerCaseFirst } from 'lower-case-first';
 import { plurality } from 'graphql-transformer-common';
@@ -305,7 +305,7 @@ export class AppSyncSwiftVisitor<
         .asKind('enum')
         .access('public')
         .withProtocols(['String', 'EnumPersistable'])
-        .withName(this.getEnumName(enumValue));
+        .withName(pascalCase(this.getEnumName(enumValue)));
 
       Object.entries(enumValue.values).forEach(([name, value]) => {
         enumDeclaration.addEnumValue(name, value);

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -9,6 +9,7 @@ import {
   ParsedAppSyncModelConfig,
   RawAppSyncModelConfig,
 } from './appsync-visitor';
+import { pascalCase } from 'change-case';
 
 export interface RawAppSyncModelTypeScriptConfig extends RawAppSyncModelConfig {}
 export interface ParsedAppSyncModelTypeScriptConfig extends ParsedAppSyncModelConfig {
@@ -77,7 +78,7 @@ export class AppSyncModelTypeScriptVisitor<
   protected generateEnumDeclarations(enumObj: CodeGenEnum, exportEnum: boolean = false): string {
     const enumDeclarations = new TypeScriptDeclarationBlock()
       .asKind('enum')
-      .withName(this.getEnumName(enumObj))
+      .withName(pascalCase(this.getEnumName(enumObj)))
       .withEnumValues(enumObj.values)
       .export(exportEnum);
 

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -6,7 +6,7 @@ import {
   ParsedConfig,
   RawConfig,
 } from '@graphql-codegen/visitor-plugin-common';
-import { camelCase, constantCase, pascalCase } from 'change-case';
+import { camelCase, constantCase } from 'change-case';
 import { plural } from 'pluralize';
 import crypto from 'crypto';
 import {
@@ -608,9 +608,9 @@ export class AppSyncModelVisitor<
 
   protected getEnumName(enumField: CodeGenEnum | string): string {
     if (typeof enumField === 'string') {
-      return pascalCase(enumField);
+      return enumField;
     }
-    return pascalCase(enumField.name);
+    return enumField.name;
   }
 
   protected getModelName(model: CodeGenModel) {


### PR DESCRIPTION
#### Description of changes

Codegen currently pascal cases enums defined in the GraphQL schema.

Gen 2 doesn't pascal case top-level enums:
```ts
const schema = a.schema({
  foo: a.enum(["a1", "b1"]),
});
```
generates:
```gql
enum foo {
  a1
  b1
}
```

This naming discrepancy hasn't caused problems yet because:
1. Type names for return types aren’t included in GraphQL operations.
2. The only way an enum can be used as an input today is through a generated model query. For example:
```ts
const schema = a.schema({
  foo: a.enum(["a1", "b1"]),
  Todo: a.model({
    status: a.boolean(),
    test: a.ref('foo')
  }),
});
```
But we create a wrapper input type for all model generated queries. So the actual GraphQL mutation here uses CreateTodoInput + Variables and never mentions the `foo` type.
```js
{
  "query": "mutation ($input: CreateTodoInput!) {
    createTodo(input: $input) {
      id
      status
      test
      createdAt
      updatedAt
    }
  }",
  "variables": {
    "input": {
        "status": true,
        "test": "b1"
    }
  }
}
```

This changes with the custom type / enum input for custom operation work in progress.
```ts
const schema = a.schema({
  foo: a.enum(["a1", "b1"]),
  fcnCall: a
    .query()
    .arguments({
      e3: a.ref("foo"),
    }),
});
```
will generate a GraphQL query like:
```js
{
  "query": "query ($e3: Foo) {
    fcnCall(e3: $e3)
  }",
  "variables": {
    "e3": "a1"
  }
}
```
because there isn’t a wrapper input type.

> [!NOTE]
> This change only applies to the model introspection schema.
> Codegenerated enums are still pascal cased because changing that will cause a breaking change if the schema defined enum casing doesn't match. Non-MIS consuming clients (e.g. native codegen) doesn't support custom operations, so the feature motivating this change doesn't apply.


#### Codegen Paramaters Changed or Added

#### Issue #, if available
N/A

#### Description of how you validated changes
- [E2E test run](https://us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow:1b6f242b-973e-4946-9a1f-f65b607965f6?region=us-east-1)

> [!NOTE]
> Two Gen 2 related E2Es are failing in this run, but they have been failing for a long time and the failures are unrelated. I'm unsure of when the change causing these failures was introduced. The only way I've been able to repro the failure locally is by running `yarn e2e ...` instead of `npm e2e ...`, which results in both yarn.lock and package-lock.json files being generated in the project root. This in turn causes an error when deploying and mimics the observed failures in CloudBuild runs.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] ~Relevant documentation is changed or added (and PR referenced)~
- [ ] ~Breaking changes to existing customers are released behind a feature flag or major version update~
- [ ] ~Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified~
- [ ] ~Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.~
- [x] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
