### PR TITLE
feat: add regionalized build spec for three canaries

### DIFF
--- a/.codebuild/android_canary_workflow.yml
+++ b/.codebuild/android_canary_workflow.yml
@@ -1,0 +1,189 @@
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_LARGE
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: build_linux
+      buildspec: .codebuild/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: test
+      buildspec: .codebuild/test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+      depend-on:
+        - build_linux
+    - identifier: publish_to_local_registry
+      buildspec: .codebuild/publish_to_local_registry.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: build_app_android_ap_northeast_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-northeast-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_ap_northeast_2
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-northeast-2
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_ap_south_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-south-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_ap_southeast_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-southeast-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_ap_southeast_2
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-southeast-2
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_ca_central_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ca-central-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_eu_central_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-central-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_eu_north_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-north-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_eu_west_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-west-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_eu_west_2
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-west-2
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_eu_west_3
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-west-3
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_sa_east_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: sa-east-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_us_east_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: us-east-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_us_east_2
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: us-east-2
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_us_west_1
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: us-west-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_android_us_west_2
+      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: us-west-2
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: cleanup_e2e_resources
+      buildspec: .codebuild/cleanup_e2e_resources.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_app_ts_us_east_1

--- a/.codebuild/android_canary_workflow.yml
+++ b/.codebuild/android_canary_workflow.yml
@@ -1,3 +1,4 @@
+# auto generated file. DO NOT EDIT manually
 version: 0.2
 env:
   shell: bash
@@ -21,8 +22,18 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
+    - identifier: build_app_android_ap_east_1
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-east-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_android_ap_northeast_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -32,7 +43,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_ap_northeast_2
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -41,8 +52,18 @@ batch:
           CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_android_ap_northeast_3
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: ap-northeast-3
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_android_ap_south_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -52,7 +73,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_ap_southeast_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -62,7 +83,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_ap_southeast_2
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -72,7 +93,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_ca_central_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -82,7 +103,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_eu_central_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -92,7 +113,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_eu_north_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -101,8 +122,18 @@ batch:
           CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_android_eu_south_1
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: eu-south-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_android_eu_west_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -112,7 +143,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_eu_west_2
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -122,7 +153,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_eu_west_3
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -131,8 +162,18 @@ batch:
           CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_android_me_south_1
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-android.test.ts
+          CLI_REGION: me-south-1
+          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_android_sa_east_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -142,7 +183,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_us_east_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -152,7 +193,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_us_east_2
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -162,7 +203,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_us_west_1
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -172,7 +213,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_android_us_west_2
-      buildspec: .codebuild/run_canary_android_modelgen_e2e_test.yml
+      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -186,4 +227,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_ts_us_east_1
+        - build_app_android_ap_east_1

--- a/.codebuild/canary_workflow_base.yml
+++ b/.codebuild/canary_workflow_base.yml
@@ -1,0 +1,23 @@
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_LARGE
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: build_linux
+      buildspec: .codebuild/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: test
+      buildspec: .codebuild/test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+      depend-on:
+        - build_linux
+    - identifier: publish_to_local_registry
+      buildspec: .codebuild/publish_to_local_registry.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux

--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -107,7 +107,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/add-codegen-ios.test.ts|src/__tests__/configure-codegen-android.test.ts|src/__tests__/configure-codegen-js.test.ts|src/__tests__/graphql-codegen-android.test.ts
-          CLI_REGION: us-east-1
+          CLI_REGION: ap-east-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -118,7 +118,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-codegen-js.test.ts|src/__tests__/remove-codegen-android.test.ts|src/__tests__/remove-codegen-ios.test.ts|src/__tests__/add-codegen-android.test.ts
-          CLI_REGION: us-east-2
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -129,7 +129,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/configure-codegen-ios.test.ts|src/__tests__/datastore-modelgen-android.test.ts|src/__tests__/datastore-modelgen-js.test.ts|src/__tests__/feature-flags.test.ts
-          CLI_REGION: us-west-2
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -140,7 +140,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-codegen-ios.test.ts|src/__tests__/add-codegen-js.test.ts|src/__tests__/datastore-modelgen-ios.test.ts|src/__tests__/remove-codegen-js.test.ts
-          CLI_REGION: eu-west-2
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -151,7 +151,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/datastore-modelgen-flutter.test.ts|src/__tests__/env-codegen.test.ts|src/__tests__/model-introspection-codegen.test.ts|src/__tests__/pull-codegen.test.ts
-          CLI_REGION: eu-central-1
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -162,7 +162,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/push-codegen-ios.test.ts|src/__tests__/push-codegen-android.test.ts|src/__tests__/graphql-documents-generator.test.ts|src/__tests__/push-codegen-js.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -173,7 +173,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/build-app-ts.test.ts|src/__tests__/graphql-generator-app.test.ts|src/__tests__/push-codegen-admin-modelgen.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
@@ -185,7 +185,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ca-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-

--- a/.codebuild/ios_canary_workflow.yml
+++ b/.codebuild/ios_canary_workflow.yml
@@ -1,0 +1,189 @@
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_LARGE
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: build_linux
+      buildspec: .codebuild/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: test
+      buildspec: .codebuild/test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+      depend-on:
+        - build_linux
+    - identifier: publish_to_local_registry
+      buildspec: .codebuild/publish_to_local_registry.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: build_app_swift_ap_northeast_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ap-northeast-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_ap_northeast_2
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ap-northeast-2
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_ap_south_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ap-south-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_ap_southeast_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ap-southeast-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_ap_southeast_2
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ap-southeast-2
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_ca_central_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: ca-central-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_eu_central_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: eu-central-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_eu_north_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: eu-north-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_eu_west_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: eu-west-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_eu_west_2
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: eu-west-2
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_eu_west_3
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: eu-west-3
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_sa_east_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: sa-east-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_us_east_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: us-east-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_us_east_2
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: us-east-2
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_us_west_1
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: us-west-1
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_swift_us_west_2
+      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          CLI_REGION: us-west-2
+          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: cleanup_e2e_resources
+      buildspec: .codebuild/cleanup_e2e_resources.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_app_ts_us_east_1

--- a/.codebuild/ios_canary_workflow.yml
+++ b/.codebuild/ios_canary_workflow.yml
@@ -1,3 +1,4 @@
+# auto generated file. DO NOT EDIT manually
 version: 0.2
 env:
   shell: bash
@@ -21,164 +22,204 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: build_app_swift_ap_northeast_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ap_east_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
+          CLI_REGION: ap-east-1
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ios_ap_northeast_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ap-northeast-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_ap_northeast_2
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ap_northeast_2
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ap-northeast-2
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_ap_south_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ap_northeast_3
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
+          CLI_REGION: ap-northeast-3
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ios_ap_south_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ap-south-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_ap_southeast_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ap_southeast_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ap-southeast-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_ap_southeast_2
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ap_southeast_2
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ap-southeast-2
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_ca_central_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_ca_central_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: ca-central-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_eu_central_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_eu_central_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: eu-central-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_eu_north_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_eu_north_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: eu-north-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_eu_west_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_eu_south_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
+          CLI_REGION: eu-south-1
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ios_eu_west_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: eu-west-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_eu_west_2
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_eu_west_2
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: eu-west-2
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_eu_west_3
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_eu_west_3
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: eu-west-3
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_sa_east_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_me_south_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
+          CLI_REGION: me-south-1
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ios_sa_east_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: sa-east-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_us_east_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_us_east_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: us-east-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_us_east_2
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_us_east_2
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: us-east-2
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_us_west_1
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_us_west_1
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: us-west-1
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
-    - identifier: build_app_swift_us_west_2
-      buildspec: .codebuild/run_canary_ios_modelgen_e2e_test.yml
+    - identifier: build_app_ios_us_west_2
+      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
+          TEST_SUITE: src/__tests__/build-app-ios.test.ts
           CLI_REGION: us-west-2
-          CANARY_METRIC_NAME: SwiftAppBuildCodegenSuccessRate
+          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
       depend-on:
         - publish_to_local_registry
     - identifier: cleanup_e2e_resources
@@ -186,4 +227,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_ts_us_east_1
+        - build_app_ios_ap_east_1

--- a/.codebuild/run_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_android_modelgen_e2e_test.yml
@@ -17,8 +17,9 @@ phases:
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk
       - yes | sudo apt install sdkmanager
-      # Review SDK licenses
-      - yes | sudo sdkmanager --licenses
+      # Licenses acceptance is needed for Android project build.
+      # "sdkmanager --licenses" is handled in test beforeAll setup,
+      # and this ensures the project accepts all licenses needed.
 
   build:
     commands:

--- a/.codebuild/run_canary_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_canary_android_modelgen_e2e_test.yml
@@ -15,8 +15,9 @@ phases:
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk
       - yes | sudo apt install sdkmanager
-      # Review SDK licenses
-      - yes | sudo sdkmanager --licenses
+      # Licenses acceptance is needed for Android project build.
+      # "sdkmanager --licenses" is handled in test beforeAll setup,
+      # and this ensures the project accepts all licenses needed.
 
   build:
     commands:

--- a/.codebuild/run_regionalized_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_regionalized_android_modelgen_e2e_test.yml
@@ -1,0 +1,35 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+
+phases:
+  install:
+    commands:
+      - sudo apt update
+      - yes | sudo apt install android-sdk
+      - export ANDROID_HOME=/usr/lib/android-sdk
+      - yes | sudo apt install sdkmanager
+      # Review SDK licenses
+      - yes | sudo sdkmanager --licenses
+
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
+      - source ./shared-scripts.sh && _unassumeTestAccountCredentials
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitRegionalizedCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/.codebuild/run_regionalized_android_modelgen_e2e_test.yml
+++ b/.codebuild/run_regionalized_android_modelgen_e2e_test.yml
@@ -15,8 +15,10 @@ phases:
       - yes | sudo apt install android-sdk
       - export ANDROID_HOME=/usr/lib/android-sdk
       - yes | sudo apt install sdkmanager
-      # Review SDK licenses
-      - yes | sudo sdkmanager --licenses
+      - yes | sudo apt install sdkmanager
+      # Licenses acceptance is needed for Android project build.
+      # "sdkmanager --licenses" is handled in test beforeAll setup,
+      # and this ensures the project accepts all licenses needed.
 
   build:
     commands:

--- a/.codebuild/run_regionalized_ios_modelgen_e2e_test.yml
+++ b/.codebuild/run_regionalized_ios_modelgen_e2e_test.yml
@@ -1,0 +1,32 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+phases:
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+      - unset AWS_ACCESS_KEY_ID
+      - unset AWS_SECRET_ACCESS_KEY
+      - unset AWS_SESSION_TOKEN
+      - export PATH_TO_MODELS=$CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/test-apps/swift/amplify/generated
+      - cd $PATH_TO_MODELS && zip -r models.zip models
+      - aws s3 cp $PATH_TO_MODELS/models.zip s3://$ARTIFACT_BUCKET_NAME/models.zip
+      - export MODELS_S3_URL=$(aws s3 presign s3://$ARTIFACT_BUCKET_NAME/models.zip --expires-in 3600)
+      - cd $CODEBUILD_SRC_DIR && ./.codebuild/scripts/run-ios-modelgen-e2e-test.sh
+  post_build:
+    commands:
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitRegionalizedCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/.codebuild/run_regionalized_ts_modelgen_e2e_test.yml
+++ b/.codebuild/run_regionalized_ts_modelgen_e2e_test.yml
@@ -1,0 +1,26 @@
+version: 0.2
+env:
+  shell: bash
+  variables:
+    AMPLIFY_DIR: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin
+    AMPLIFY_PATH: /root/.npm-global/lib/node_modules/@aws-amplify/cli-internal/bin/amplify
+    CI: true
+    CODEBUILD: true
+    NODE_OPTIONS: --max-old-space-size=8096
+
+phases:
+  build:
+    commands:
+      - source ./shared-scripts.sh && _setupE2ETestsLinux
+      - codebuild-breakpoint
+      - source ./shared-scripts.sh && _runE2ETestsLinux
+  post_build:
+    commands:
+      - source ./shared-scripts.sh && _unassumeTestAccountCredentials
+      - aws sts get-caller-identity
+      - source ./shared-scripts.sh && _scanArtifacts && _emitRegionalizedCanaryMetric
+
+artifacts:
+  files:
+    - '**/*'
+  base-directory: $CODEBUILD_SRC_DIR/packages/amplify-codegen-e2e-tests/amplify-e2e-reports

--- a/.codebuild/ts_canary_workflow.yml
+++ b/.codebuild/ts_canary_workflow.yml
@@ -1,3 +1,4 @@
+# auto generated file. DO NOT EDIT manually
 version: 0.2
 env:
   shell: bash
@@ -21,8 +22,19 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
+    - identifier: build_app_ts_ap_east_1
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-east-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_ts_ap_northeast_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -33,7 +45,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_ap_northeast_2
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -43,8 +55,19 @@ batch:
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_ts_ap_northeast_3
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-northeast-3
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_ts_ap_south_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -55,7 +78,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_ap_southeast_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -66,7 +89,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_ap_southeast_2
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -77,7 +100,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_ca_central_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -88,7 +111,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_eu_central_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -99,7 +122,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_eu_north_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -109,8 +132,19 @@ batch:
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_ts_eu_south_1
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-south-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_ts_eu_west_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -121,7 +155,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_eu_west_2
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -132,7 +166,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_eu_west_3
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -142,8 +176,19 @@ batch:
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
+    - identifier: build_app_ts_me_south_1
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: me-south-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
     - identifier: build_app_ts_sa_east_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -154,7 +199,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_us_east_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -165,7 +210,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_us_east_2
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -176,7 +221,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_us_west_1
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -187,7 +232,7 @@ batch:
       depend-on:
         - publish_to_local_registry
     - identifier: build_app_ts_us_west_2
-      buildspec: .codebuild/run_canary_e2e_tests.yml
+      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -202,4 +247,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_ts_us_east_1
+        - build_app_ts_ap_east_1

--- a/.codebuild/ts_canary_workflow.yml
+++ b/.codebuild/ts_canary_workflow.yml
@@ -1,0 +1,205 @@
+version: 0.2
+env:
+  shell: bash
+  compute-type: BUILD_GENERAL1_LARGE
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: build_linux
+      buildspec: .codebuild/build_linux.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: test
+      buildspec: .codebuild/test.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+      depend-on:
+        - build_linux
+    - identifier: publish_to_local_registry
+      buildspec: .codebuild/publish_to_local_registry.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_linux
+    - identifier: build_app_ts_ap_northeast_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-northeast-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_ap_northeast_2
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-northeast-2
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_ap_south_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-south-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_ap_southeast_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-southeast-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_ap_southeast_2
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ap-southeast-2
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_ca_central_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: ca-central-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_eu_central_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-central-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_eu_north_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-north-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_eu_west_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-west-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_eu_west_2
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-west-2
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_eu_west_3
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: eu-west-3
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_sa_east_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: sa-east-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_us_east_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: us-east-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_us_east_2
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: us-east-2
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_us_west_1
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: us-west-1
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: build_app_ts_us_west_2
+      buildspec: .codebuild/run_canary_e2e_tests.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          TEST_SUITE: src/__tests__/build-app-ts.test.ts
+          CLI_REGION: us-west-2
+          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
+          DISABLE_ESLINT_PLUGIN: true
+      depend-on:
+        - publish_to_local_registry
+    - identifier: cleanup_e2e_resources
+      buildspec: .codebuild/cleanup_e2e_resources.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+      depend-on:
+        - build_app_ts_us_east_1

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-push": "npm run lint && npm run test-changed",
-      "pre-commit": "yarn split-e2e-tests && yarn extract-dependency-licenses"
+      "pre-commit": "yarn split-e2e-tests && yarn split-canary-tests && yarn extract-dependency-licenses"
     }
   },
   "author": "Amazon Web Services",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cloud-e2e": "source scripts/cloud-utils.sh && cloudE2E",
     "cloud-e2e-beta": "source scripts/cloud-utils.sh && cloudE2EBeta",
     "split-e2e-tests": "yarn ts-node ./scripts/split-e2e-tests.ts && git add .codebuild/e2e_workflow.yml",
+    "split-canary-tests": "yarn ts-node ./scripts/split-canary-tests.ts && git add .codebuild/ts_canary_workflow.yml && git add .codebuild/ios_canary_workflow.yml && git add .codebuild/android_canary_workflow.yml",
     "view-test-artifacts": "yarn authenticate-e2e-profile && yarn ts-node ./scripts/view-test-artifacts.ts",
     "cloud-e2e-debug": "source scripts/cloud-utils.sh && cloudE2EDebug",
     "authenticate-e2e-profile": "source scripts/cloud-utils.sh && authenticateWithE2EProfile",

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-android.test.ts
@@ -38,6 +38,8 @@ describe('build app - Android', () => {
     await addCodegen(projectRoot, {
       frontendType: AmplifyFrontend.android,
     });
+
+    // Required to accept all licenses needed per this test project build
     await acceptLicenses(projectRoot);
   });
 

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -10,14 +10,26 @@ import { deleteS3Bucket, sleep } from '@aws-amplify/amplify-codegen-e2e-core';
 
 // Ensure to update scripts/split-e2e-tests.ts is also updated this gets updated
 const AWS_REGIONS_TO_RUN_TESTS = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-2',
-  'eu-central-1',
+  'ap-east-1',
   'ap-northeast-1',
+  'ap-northeast-2',
+  'ap-northeast-3',
+  'ap-south-1',
   'ap-southeast-1',
   'ap-southeast-2',
+  'ca-central-1',
+  'eu-central-1',
+  'eu-north-1',
+  'eu-south-1',
+  'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'me-south-1',
+  'sa-east-1',
+  'us-east-1',
+  'us-east-2',
+  'us-west-1',
+  'us-west-2',
 ];
 
 const reportPathDir = path.normalize(path.join(__dirname, '..', 'amplify-e2e-reports'));

--- a/scripts/split-canary-tests.ts
+++ b/scripts/split-canary-tests.ts
@@ -1,0 +1,155 @@
+import { sync } from 'globby';
+import * as fs from 'fs-extra';
+import { join } from 'path';
+import * as yaml from 'js-yaml';
+
+const REPO_ROOT: string = join(__dirname, '..');
+const CODEBUILD_CONFIG_PATH: string = join(REPO_ROOT, '.codebuild');
+const CODEBUILD_CONFIG_BASE_PATH: string = join(CODEBUILD_CONFIG_PATH, 'canary_workflow_base.yml');
+
+/**
+ * Supported regions:
+ * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
+ *
+ * NOTE: The list of supported regions must be kept in sync amongst all of:
+ * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/split-e2e-tests.ts
+ * - amplify-codegen/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+ */
+const SUPPORTED_REGIONS_PATH: string = join(REPO_ROOT, 'scripts', 'support-test-regions.json');
+const AWS_REGIONS_TO_RUN_TESTS: string[] = JSON.parse(fs.readFileSync(SUPPORTED_REGIONS_PATH, 'utf-8'));
+
+enum ComputeType {
+  MEDIUM = 'BUILD_GENERAL1_MEDIUM',
+  LARGE = 'BUILD_GENERAL1_LARGE',
+}
+type PlatformConfig = {
+  platform: string;
+  metric: string;
+  outputPath: string;
+}
+type JobConfig = {
+  platformConfig: PlatformConfig;
+  region: string;
+  tsBuild: boolean;
+};
+type Job = {
+  identifier: string;
+  buildspec: string;
+  env: {
+    'compute-type': ComputeType;
+    variables?: {
+      TEST_SUITE: string;
+      CLI_REGION: string;
+      CANARY_METRIC_NAME: string;
+      DISABLE_ESLINT_PLUGIN?: boolean;
+    };
+  };
+  'depend-on': string[];
+}
+
+const saveConfig = (config: any, outputPath: string) => {
+  const output = ['# auto generated file. DO NOT EDIT manually', yaml.dump(config, { noRefs: true })];
+  // console.log(output.join('\n'));
+  fs.writeFileSync(outputPath, output.join('\n'));
+}
+
+const getConfigBase = (): any => {
+  return yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8'));
+}
+
+const getOutputPath = (output: string) => {
+  return join(CODEBUILD_CONFIG_PATH, output);
+}
+
+const getPlatformsConfig = (): PlatformConfig[] => {
+  return [
+    {
+      platform: 'ts',
+      metric: 'TsAppBuildCodegenSuccessRate',
+      outputPath: getOutputPath('ts_canary_workflow.yml')
+    },
+    {
+      platform: 'ios',
+      metric: 'IosAppBuildCodegenSuccessRate',
+      outputPath: getOutputPath('ios_canary_workflow.yml')
+    },
+    {
+      platform: 'android',
+      metric: 'AndroidAppBuildCodegenSuccessRate',
+      outputPath: getOutputPath('android_canary_workflow.yml')
+    },
+  ];
+}
+
+const getJobsForPlatformConfig = (platformConfig: PlatformConfig): Job[] => {
+  return AWS_REGIONS_TO_RUN_TESTS.map(region =>
+    getJob({
+      platformConfig,
+      region,
+      tsBuild: platformConfig.platform === 'ts',
+    }),
+  );
+}
+
+const getJob = (jobConfig: JobConfig): Job => {
+  return {
+    identifier: getIdentifier(jobConfig),
+    buildspec: getBuildspec(jobConfig),
+    env: {
+      'compute-type': ComputeType.LARGE,
+      variables: {
+        TEST_SUITE: getTestSuite(jobConfig),
+        CLI_REGION: jobConfig.region,
+        CANARY_METRIC_NAME: jobConfig.platformConfig.metric,
+        ...(jobConfig.tsBuild && { DISABLE_ESLINT_PLUGIN: true }),
+      }
+    },
+    'depend-on': ['publish_to_local_registry'],
+  };
+}
+
+const getCleanupJob = (jobs: Job[]): Job => {
+  return {
+    identifier: 'cleanup_e2e_resources',
+    buildspec: '.codebuild/cleanup_e2e_resources.yml',
+    env: {
+      'compute-type': ComputeType.MEDIUM,
+    },
+    'depend-on': [jobs[0].identifier],
+  };
+}
+
+const getIdentifier = (jobConfig: JobConfig): string => {
+  return `build_app_${jobConfig.platformConfig.platform}_${jobConfig.region.replace(/-/g, '_')}`
+}
+
+const getBuildspec = (jobConfig: JobConfig): string => {
+  return `.codebuild/run_regionalized_${jobConfig.platformConfig.platform}_modelgen_e2e_test.yml`;
+};
+
+const getTestSuite = (jobConfig: JobConfig): string => {
+  return `src/__tests__/build-app-${jobConfig.platformConfig.platform}.test.ts`;
+};
+
+const main = (): void => {
+  const configBase: any = getConfigBase();
+  const platformsConfig: PlatformConfig[] = getPlatformsConfig();
+
+  const baseBuildJobs = configBase.batch['build-graph'];
+
+  platformsConfig.forEach(platformsConfig => {
+    const jobs = getJobsForPlatformConfig(platformsConfig);
+    const cleanupJob = getCleanupJob(jobs);
+    const currentBatch = [...baseBuildJobs, ...jobs, cleanupJob];
+
+    configBase.batch['build-graph'] = currentBatch;
+    saveConfig(configBase, platformsConfig.outputPath);
+
+    console.log(`Successfully generated the buildspec at ${platformsConfig.outputPath}`);
+    console.log(`Total number of splitted jobs: ${currentBatch.length}`);
+    console.log(`Total number of regions: ${AWS_REGIONS_TO_RUN_TESTS.length}\n`);
+  });
+}
+
+main();

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -3,18 +3,6 @@ import * as fs from 'fs-extra';
 import { join } from 'path';
 import * as yaml from 'js-yaml';
 
-// Ensure to update packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts is also updated this gets updated
-const AWS_REGIONS_TO_RUN_TESTS = [
-  'us-east-1',
-  'us-east-2',
-  'us-west-2',
-  'eu-west-2',
-  'eu-central-1',
-  'ap-northeast-1',
-  'ap-southeast-1',
-  'ap-southeast-2',
-];
-
 // some tests require additional time, the parent account can handle longer tests (up to 90 minutes)
 const USE_PARENT_ACCOUNT = [];
 const REPO_ROOT = join(__dirname, '..');
@@ -30,6 +18,18 @@ const EXCLUDE_TESTS = [
   'src/__tests__/graphql-generator-gen2.test.ts'
 ];
 const DEBUG_FLAG = '--debug';
+
+/**
+ * Supported regions:
+ * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
+ *
+ * NOTE: The list of supported regions must be kept in sync amongst all of:
+ * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/split-e2e-tests.ts
+ * - amplify-codegen/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+ */
+const SUPPORTED_REGIONS_PATH: string = join(REPO_ROOT, 'scripts', 'support-test-regions.json');
+const AWS_REGIONS_TO_RUN_TESTS: string[] = JSON.parse(fs.readFileSync(SUPPORTED_REGIONS_PATH, 'utf-8'));
 
 export function loadConfigBase() {
   return yaml.load(fs.readFileSync(CODEBUILD_CONFIG_BASE_PATH, 'utf8'));

--- a/scripts/support-test-regions.json
+++ b/scripts/support-test-regions.json
@@ -1,0 +1,22 @@
+[
+  "ap-east-1",
+  "ap-northeast-1",
+  "ap-northeast-2",
+  "ap-northeast-3",
+  "ap-south-1",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ca-central-1",
+  "eu-central-1",
+  "eu-north-1",
+  "eu-south-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-west-3",
+  "me-south-1",
+  "sa-east-1",
+  "us-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2"
+]

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -503,3 +503,14 @@ function _emitCodegenCanaryMetric {
     --dimensions branch=release,test=$(basename "$TEST_SUITE" .test.ts | sed "s/build-app-//") \
     --region us-west-2
 }
+
+function _emitRegionalizedCanaryMetric {
+  aws cloudwatch \
+    put-metric-data \
+    --metric-name $CANARY_METRIC_NAME \
+    --namespace amplify-codegen-canary-e2e-tests \
+    --unit Count \
+    --value $CODEBUILD_BUILD_SUCCEEDING \
+    --dimensions branch=release,region=$CLI_REGION \
+    --region us-west-2
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added regionalized `.yml` CodeBuild spec files for three app builds (`ts`, `swift`, `android`) canaries.

These build spec files are auto generated by running `yarn split-canary-tests`, with regions sourced from [Amplify supported regions](https://docs.aws.amazon.com/general/latest/gr/amplify.html).

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
