### PR TITLE
fix: add script to use node 18.20

### DIFF
--- a/.codebuild/build_windows.yml
+++ b/.codebuild/build_windows.yml
@@ -2,6 +2,12 @@ version: 0.2
 env:
   shell: powershell.exe
 phases:
+  pre_build:
+    commands:
+      - choco install -fy nodejs-lts --version=18.20.4
+      - |
+        $nodeVersion = node -v
+        Write-Host "Node version: $nodeVersion"
   build:
     commands:
       # commands need to be run in stand-alone bash scripts so that bash can be used on windows

--- a/.codebuild/build_windows.yml
+++ b/.codebuild/build_windows.yml
@@ -2,12 +2,6 @@ version: 0.2
 env:
   shell: powershell.exe
 phases:
-  pre_build:
-    commands:
-      - choco install -fy nodejs-lts --version=18.20.4
-      - |
-        $nodeVersion = node -v
-        Write-Host "Node version: $nodeVersion"
   build:
     commands:
       # commands need to be run in stand-alone bash scripts so that bash can be used on windows

--- a/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
+++ b/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
@@ -7,57 +7,18 @@ import { spawnSync } from 'child_process';
  * Retrieve the path to the `npx` executable for interacting with the amplify gen2 cli.
  * @returns the local `npx` executable path.
  */
-const getNpxPath = (): string => {
-  console.log(`DEBUG: process.platform is: ${process.platform}`);
-  if (process.platform === 'win32') {
-    const scriptRunnerPath = getScriptRunnerPath();
-    console.log(`DEBUG: getScriptRunnerPath() returned: ${scriptRunnerPath}`);
-    const npxPath = scriptRunnerPath.replace('node.exe', 'npx.cmd');
-    console.log(`DEBUG: Resolved npxPath for Windows: ${npxPath}`);
-    return npxPath;
-  } else {
-    console.log(`DEBUG: Non-Windows platform; using 'npx'`);
-    return 'npx';
-  }
-};
+const getNpxPath = (): string => (process.platform === 'win32' ? getScriptRunnerPath().replace('node.exe', 'npx.cmd') : 'npx');
 
 /**
  * Retrieve the path to the `ampx` executable for interacting with the amplify gen2 cli.
  * @param cwd current working directory
  * @returns the local `ampx` executable path
+ *
+ * Note:
+ * Use shell: true to properly execute the .cmd file on Windows
  */
-const getAmpxPath = (cwd: string): string => {
-  // Retrieve the path to npx
-  const npxPath = getNpxPath();
-  console.log(`DEBUG: Resolved npx path: ${npxPath}`);
-
-  // Execute the command to find 'ampx'
-  // Use shell: true to properly execute the .cmd file on Windows
-  const spawnResult = spawnSync(npxPath, ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe', shell: true });
-
-  // Log the entire result of spawnSync for inspection
-  console.log('DEBUG: spawnSync result:', spawnResult);
-
-  if (spawnResult.error) {
-    console.error('DEBUG: spawnSync encountered an error:', spawnResult.error);
-  }
-
-  // Log stderr if available
-  if (spawnResult.stderr) {
-    console.error('DEBUG: spawnSync stderr:', spawnResult.stderr.toString());
-  }
-
-  // Ensure stdout exists before converting to string
-  const stdout = spawnResult.stdout;
-  if (!stdout) {
-    console.error('DEBUG: No stdout received from spawnSync.');
-    return '';
-  }
-
-  const result = stdout.toString().trim();
-  console.log(`DEBUG: Parsed output: "${result}"`);
-  return result;
-};
+const getAmpxPath = (cwd: string): string =>
+  spawnSync(getNpxPath(), ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe', shell: true }).stdout.toString().trim();
 
 const codegenPackagesInGen2 = [
   '@aws-amplify/graphql-generator',

--- a/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
+++ b/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
@@ -7,14 +7,56 @@ import { spawnSync } from 'child_process';
  * Retrieve the path to the `npx` executable for interacting with the amplify gen2 cli.
  * @returns the local `npx` executable path.
  */
-const getNpxPath = (): string => (process.platform === 'win32' ? getScriptRunnerPath().replace('node.exe', 'npx.cmd') : 'npx');
+const getNpxPath = (): string => {
+  console.log(`DEBUG: process.platform is: ${process.platform}`);
+  if (process.platform === 'win32') {
+    const scriptRunnerPath = getScriptRunnerPath();
+    console.log(`DEBUG: getScriptRunnerPath() returned: ${scriptRunnerPath}`);
+    const npxPath = scriptRunnerPath.replace('node.exe', 'npx.cmd');
+    console.log(`DEBUG: Resolved npxPath for Windows: ${npxPath}`);
+    return npxPath;
+  } else {
+    console.log(`DEBUG: Non-Windows platform; using 'npx'`);
+    return 'npx';
+  }
+};
+
 /**
  * Retrieve the path to the `ampx` executable for interacting with the amplify gen2 cli.
  * @param cwd current working directory
  * @returns the local `ampx` executable path
  */
-const getAmpxPath = (cwd: string): string =>
-  spawnSync(getNpxPath(), ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe' }).stdout.toString().trim();
+const getAmpxPath = (cwd: string): string => {
+  // Retrieve the path to npx
+  const npxPath = getNpxPath();
+  console.log(`DEBUG: Resolved npx path: ${npxPath}`);
+
+  // Execute the command to find 'ampx'
+  const spawnResult = spawnSync(npxPath, ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe' });
+
+  // Log the entire result of spawnSync for inspection
+  console.log('DEBUG: spawnSync result:', spawnResult);
+
+  if (spawnResult.error) {
+    console.error('DEBUG: spawnSync encountered an error:', spawnResult.error);
+  }
+
+  // Log stderr if available
+  if (spawnResult.stderr) {
+    console.error('DEBUG: spawnSync stderr:', spawnResult.stderr.toString());
+  }
+
+  // Ensure stdout exists before converting to string
+  const stdout = spawnResult.stdout;
+  if (!stdout) {
+    console.error('DEBUG: No stdout received from spawnSync.');
+    return '';
+  }
+
+  const result = stdout.toString().trim();
+  console.log(`DEBUG: Parsed output: "${result}"`);
+  return result;
+};
 
 const codegenPackagesInGen2 = [
   '@aws-amplify/graphql-generator',

--- a/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
+++ b/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
@@ -10,15 +10,28 @@ import { spawnSync } from 'child_process';
 const getNpxPath = (): string => (process.platform === 'win32' ? getScriptRunnerPath().replace('node.exe', 'npx.cmd') : 'npx');
 
 /**
- * Retrieve the path to the `ampx` executable for interacting with the amplify gen2 cli.
+ * Retrieve the path to the `ampx` executable for interacting with the Amplify Gen2 CLI.
  * @param cwd current working directory
  * @returns the local `ampx` executable path
  *
  * Note:
- * Use shell: true to properly execute the .cmd file on Windows
+ * On Windows, batch files (like npx.cmd) must be executed through a shell.
+ * Therefore, this function uses `shell: process.platform === 'win32'` to ensure that the command
+ * is run via the shell on Windows. This change was required after upgrading to Node 18,
+ * where a security update now causes an EINVAL error if a .cmd file is executed without the shell option.
+ *
+ * See: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high
+ *
+ * Warning:
+ * Command arguments **must** be sanitized to avoid injection risks.
  */
 const getAmpxPath = (cwd: string): string =>
-  spawnSync(getNpxPath(), ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe', shell: true }).stdout.toString().trim();
+  spawnSync(getNpxPath(), ['which', 'ampx'], {
+    cwd,
+    env: process.env,
+    stdio: 'pipe',
+    shell: process.platform === 'win32',
+  }).stdout.toString().trim();
 
 const codegenPackagesInGen2 = [
   '@aws-amplify/graphql-generator',

--- a/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
+++ b/packages/amplify-codegen-e2e-tests/src/gen2-codegen-tests-base/commands.ts
@@ -32,7 +32,8 @@ const getAmpxPath = (cwd: string): string => {
   console.log(`DEBUG: Resolved npx path: ${npxPath}`);
 
   // Execute the command to find 'ampx'
-  const spawnResult = spawnSync(npxPath, ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe' });
+  // Use shell: true to properly execute the .cmd file on Windows
+  const spawnResult = spawnSync(npxPath, ['which', 'ampx'], { cwd, env: process.env, stdio: 'pipe', shell: true });
 
   // Log the entire result of spawnSync for inspection
   console.log('DEBUG: spawnSync result:', spawnResult);

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -549,8 +549,8 @@ function _setupNodeVersionWindows {
   # Install Node.js using Chocolatey
   choco install -fy nodejs-lts --version=$version
   
-  # Refresh environment variables
-  refreshenv
+  # Refresh environment variables (in PowerShell)
+  $env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Process)
   
   # Verify the Node.js version in use
   nodeVersion=$(node -v)

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -288,7 +288,6 @@ function _setupGen2E2ETestsWindows {
     _setShell
 }
 
-
 function _runE2ETestsLinux {
     echo "RUN E2E Tests Linux"
     retry runE2eTest

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -549,6 +549,9 @@ function _setupNodeVersionWindows {
   # Install Node.js using Chocolatey
   choco install -fy nodejs-lts --version=$version
   
+  # Refresh environment variables
+  refreshenv
+  
   # Verify the Node.js version in use
   nodeVersion=$(node -v)
   echo "Node version: $nodeVersion"

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -134,7 +134,7 @@ function _setShell {
 function _buildLinux {
   _setShell
   echo "Setup Node Version $AMPLIFY_NODE_VERSION for Linux"
-  setupNodeVersionLinux $AMPLIFY_NODE_VERSION
+  _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -143,7 +143,7 @@ function _buildLinux {
 function _buildWindows {
   echo "Linux Build"
   echo "Setup Node Version $AMPLIFY_NODE_VERSION for Windows"
-  setupNodeVersionWindows $AMPLIFY_NODE_VERSION
+  _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
   yarn run production-build
   storeCacheForWindowsBuildJob
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -550,11 +550,12 @@ function _setupNodeVersionWindows {
   echo "Installing Node.js version $version on Windows"
   
   # Install Node.js using Chocolatey
+  echo "Installing Node.js version $version using Chocolatey"
   choco install -fy nodejs-lts --version=$version
-  cmd //c refreshenv
-  
-  # Refresh environment variables
-  export PATH=$PATH
+
+  # Manually update PATH
+  echo "Updating PATH to include Node.js"
+  export PATH="/c/Program Files/nodejs:$PATH"
   
   # Verify the Node.js version in use
   nodeVersion=$(node -v)

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -535,6 +535,9 @@ function _setupNodeVersionLinux {
   # Install and use the specified Node.js version
   nvm install "$version"
   nvm use "$version"
+
+  # Refresh environment variables
+  source ~/.bashrc  # Or source the appropriate shell profile file like ~/.bash_profile or ~/.zshrc
   
   # Verify the Node.js version in use
   echo "Node.js version in use:"

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -276,7 +276,7 @@ function _setupE2ETestsWindows {
 
 function _setupGen2E2ETestsLinux {
     echo "Setup Node Version"
-    _setupNodeVersion $AMPLIFY_NODE_VERSION
+    _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
     echo "Setup Gen2 E2E Tests Linux"
     loadCacheFromLinuxBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
@@ -285,6 +285,8 @@ function _setupGen2E2ETestsLinux {
 }
 
 function _setupGen2E2ETestsWindows {
+    echo "Setup Node Version"
+    _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
     echo "Setup Gen2 E2E Tests Windows"
     loadCacheFromWindowsBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache windows
@@ -518,7 +520,7 @@ function _emitRegionalizedCanaryMetric {
     --region us-west-2
 }
 
-function _setupNodeVersion {
+function _setupNodeVersionLinux {
   local version=$1  # Version number passed as an argument
   
   echo "Installing NVM and setting Node.js version to $version"
@@ -537,4 +539,17 @@ function _setupNodeVersion {
   # Verify the Node.js version in use
   echo "Node.js version in use:"
   node -v
+}
+
+function _setupNodeVersionWindows {
+  local version=$1  # Version number passed as an argument
+  
+  echo "Installing Node.js version $version on Windows"
+  
+  # Install Node.js using Chocolatey
+  choco install -fy nodejs-lts --version=$version
+  
+  # Verify the Node.js version in use
+  nodeVersion=$(node -v)
+  echo "Node version: $nodeVersion"
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+AMPLIFY_NODE_VERSION=18.20.4
+
 # set exit on error to true
 set -e
 
@@ -131,6 +133,7 @@ function _setShell {
 
 function _buildLinux {
   _setShell
+  _setupNodeVersion $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -512,4 +515,25 @@ function _emitRegionalizedCanaryMetric {
     --value $CODEBUILD_BUILD_SUCCEEDING \
     --dimensions branch=release,region=$CLI_REGION \
     --region us-west-2
+}
+
+function _setupNodeVersion {
+  local version=$1  # Version number passed as an argument
+  
+  echo "Installing NVM and setting Node.js version to $version"
+  
+  # Install NVM
+  curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+  
+  # Load NVM
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  
+  # Install and use the specified Node.js version
+  nvm install "$version"
+  nvm use "$version"
+  
+  # Verify the Node.js version in use
+  echo "Node.js version in use:"
+  node -v
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -556,10 +556,6 @@ function _setupNodeVersionWindows {
   # Refresh environment variables
   echo "Refreshing environment variables"
   export PATH=$PATH
-
-  # # Manually update PATH
-  # echo "Updating PATH to include Node.js"
-  # export PATH="/c/Program Files/nodejs:$PATH"
   
   # Verify the Node.js version in use
   nodeVersion=$(node -v)

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -552,8 +552,8 @@ function _setupNodeVersionWindows {
   # Install Node.js using Chocolatey
   choco install -fy nodejs-lts --version=$version
   
-  # Refresh environment variables (in PowerShell)
-  $env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Process)
+  # Refresh environment variables
+  export PATH=$PATH
   
   # Verify the Node.js version in use
   nodeVersion=$(node -v)

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -133,6 +133,8 @@ function _setShell {
 
 function _buildLinux {
   _setShell
+  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Linux"
+  setupNodeVersionLinux $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -140,6 +142,8 @@ function _buildLinux {
 
 function _buildWindows {
   echo "Linux Build"
+  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Windows"
+  _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
   yarn run production-build
   storeCacheForWindowsBuildJob
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -133,8 +133,6 @@ function _setShell {
 
 function _buildLinux {
   _setShell
-  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Linux"
-  _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -142,8 +140,6 @@ function _buildLinux {
 
 function _buildWindows {
   echo "Linux Build"
-  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Windows"
-  _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
   yarn run production-build
   storeCacheForWindowsBuildJob
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -134,7 +134,7 @@ function _setShell {
 function _buildLinux {
   _setShell
   echo "Setup Node Version $AMPLIFY_NODE_VERSION for Linux"
-  setupNodeVersionLinux $AMPLIFY_NODE_VERSION
+  _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -551,6 +551,7 @@ function _setupNodeVersionWindows {
   
   # Install Node.js using Chocolatey
   choco install -fy nodejs-lts --version=$version
+  cmd //c refreshenv
   
   # Refresh environment variables
   export PATH=$PATH

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -553,9 +553,13 @@ function _setupNodeVersionWindows {
   echo "Installing Node.js version $version using Chocolatey"
   choco install -fy nodejs-lts --version=$version
 
-  # Manually update PATH
-  echo "Updating PATH to include Node.js"
-  export PATH="/c/Program Files/nodejs:$PATH"
+  # Refresh environment variables
+  echo "Refreshing environment variables"
+  export PATH=$PATH
+
+  # # Manually update PATH
+  # echo "Updating PATH to include Node.js"
+  # export PATH="/c/Program Files/nodejs:$PATH"
   
   # Verify the Node.js version in use
   nodeVersion=$(node -v)

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -133,6 +133,8 @@ function _setShell {
 
 function _buildLinux {
   _setShell
+  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Linux"
+  setupNodeVersionLinux $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -140,6 +142,8 @@ function _buildLinux {
 
 function _buildWindows {
   echo "Linux Build"
+  echo "Setup Node Version $AMPLIFY_NODE_VERSION for Windows"
+  setupNodeVersionWindows $AMPLIFY_NODE_VERSION
   yarn run production-build
   storeCacheForWindowsBuildJob
 }

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -133,7 +133,6 @@ function _setShell {
 
 function _buildLinux {
   _setShell
-  _setupNodeVersion $AMPLIFY_NODE_VERSION
   echo "Linux Build"
   yarn run production-build
   storeCacheForLinuxBuildJob
@@ -276,6 +275,8 @@ function _setupE2ETestsWindows {
 }
 
 function _setupGen2E2ETestsLinux {
+    echo "Setup Node Version"
+    _setupNodeVersion $AMPLIFY_NODE_VERSION
     echo "Setup Gen2 E2E Tests Linux"
     loadCacheFromLinuxBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache

--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -275,8 +275,6 @@ function _setupE2ETestsWindows {
 }
 
 function _setupGen2E2ETestsLinux {
-    echo "Setup Node Version"
-    _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
     echo "Setup Gen2 E2E Tests Linux"
     loadCacheFromLinuxBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache
@@ -285,8 +283,6 @@ function _setupGen2E2ETestsLinux {
 }
 
 function _setupGen2E2ETestsWindows {
-    echo "Setup Node Version"
-    _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
     echo "Setup Gen2 E2E Tests Windows"
     loadCacheFromWindowsBuildJob
     loadCache verdaccio-cache $CODEBUILD_SRC_DIR/../verdaccio-cache windows
@@ -306,11 +302,15 @@ function _runE2ETestsWindows {
 
 function _runGen2E2ETestsLinux {
     echo "RUN Gen2 E2E Tests Linux"
+    echo "Setup Node Version"
+    _setupNodeVersionLinux $AMPLIFY_NODE_VERSION
     retry runGen2E2eTest
 }
 
 function _runGen2E2ETestsWindows {
     echo "RUN Gen2 E2E Tests Windows"
+    echo "Setup Node Version"
+    _setupNodeVersionWindows $AMPLIFY_NODE_VERSION
     retry runGen2E2eTest
 }
 


### PR DESCRIPTION
#### Description of changes

`l_graphql_generator_gen2` and `w_graphql_generator_gen2` were failing because CodeBuild was using an older Node version. This PR adds logic to install Node 18.20 for both Windows and Linux environments.

After upgrading to Node 18.20, on Windows, the execution of `npx.cmd` was failing with an `EINVAL` error when calling `spawnSync` in the test. This error is due to a recent [Node.js security update (April 10, 2024)](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high). The update enforces that batch files (like `.cmd`) must be run with `shell: true` to prevent potential command injection vulnerabilities. Without this option, Node now errors with `EINVAL` when trying to execute these files directly. By adding `shell: true` to the spawn options, we ensure that the batch file is executed through the shell, which resolves the error and allows the tests to locate and run `ampx` as expected.

#### Description of how you validated changes

[e2e](https://tiny.amazon.com/g6reutmn/IsenLink)
- Note that 2 other e2e are failing as @Siqi-Shan's fix is not merged yet. 

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
