### PR TITLE
fix: use correct region in amplify configure

### DIFF
--- a/.codebuild/android_canary_workflow.yml
+++ b/.codebuild/android_canary_workflow.yml
@@ -22,16 +22,6 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: build_app_android_ap_east_1
-      buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          TEST_SUITE: src/__tests__/build-app-android.test.ts
-          CLI_REGION: ap-east-1
-          CANARY_METRIC_NAME: AndroidAppBuildCodegenSuccessRate
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_app_android_ap_northeast_1
       buildspec: .codebuild/run_regionalized_android_modelgen_e2e_test.yml
       env:
@@ -227,4 +217,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_android_ap_east_1
+        - build_app_android_ap_northeast_1

--- a/.codebuild/e2e_workflow.yml
+++ b/.codebuild/e2e_workflow.yml
@@ -107,7 +107,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/add-codegen-ios.test.ts|src/__tests__/configure-codegen-android.test.ts|src/__tests__/configure-codegen-js.test.ts|src/__tests__/graphql-codegen-android.test.ts
-          CLI_REGION: ap-east-1
+          CLI_REGION: ap-northeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -118,7 +118,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-codegen-js.test.ts|src/__tests__/remove-codegen-android.test.ts|src/__tests__/remove-codegen-ios.test.ts|src/__tests__/add-codegen-android.test.ts
-          CLI_REGION: ap-northeast-1
+          CLI_REGION: ap-northeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -129,7 +129,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/configure-codegen-ios.test.ts|src/__tests__/datastore-modelgen-android.test.ts|src/__tests__/datastore-modelgen-js.test.ts|src/__tests__/feature-flags.test.ts
-          CLI_REGION: ap-northeast-2
+          CLI_REGION: ap-northeast-3
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -140,7 +140,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/graphql-codegen-ios.test.ts|src/__tests__/add-codegen-js.test.ts|src/__tests__/datastore-modelgen-ios.test.ts|src/__tests__/remove-codegen-js.test.ts
-          CLI_REGION: ap-northeast-3
+          CLI_REGION: ap-south-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -151,7 +151,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/datastore-modelgen-flutter.test.ts|src/__tests__/env-codegen.test.ts|src/__tests__/model-introspection-codegen.test.ts|src/__tests__/pull-codegen.test.ts
-          CLI_REGION: ap-south-1
+          CLI_REGION: ap-southeast-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -162,7 +162,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/push-codegen-ios.test.ts|src/__tests__/push-codegen-android.test.ts|src/__tests__/graphql-documents-generator.test.ts|src/__tests__/push-codegen-js.test.ts
-          CLI_REGION: ap-southeast-1
+          CLI_REGION: ap-southeast-2
       depend-on:
         - publish_to_local_registry
     - identifier: >-
@@ -173,7 +173,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/build-app-ts.test.ts|src/__tests__/graphql-generator-app.test.ts|src/__tests__/push-codegen-admin-modelgen.test.ts|src/__tests__/uninitialized-project-codegen-js.test.ts
-          CLI_REGION: ap-southeast-2
+          CLI_REGION: ca-central-1
           DISABLE_ESLINT_PLUGIN: true
       depend-on:
         - publish_to_local_registry
@@ -185,7 +185,7 @@ batch:
         variables:
           TEST_SUITE: >-
             src/__tests__/uninitialized-project-modelgen-android.test.ts|src/__tests__/uninitialized-project-modelgen-flutter.test.ts|src/__tests__/uninitialized-project-modelgen-ios.test.ts|src/__tests__/uninitialized-project-modelgen-js.test.ts
-          CLI_REGION: ca-central-1
+          CLI_REGION: eu-central-1
       depend-on:
         - publish_to_local_registry
     - identifier: >-

--- a/.codebuild/ios_canary_workflow.yml
+++ b/.codebuild/ios_canary_workflow.yml
@@ -22,16 +22,6 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: build_app_ios_ap_east_1
-      buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          TEST_SUITE: src/__tests__/build-app-swift.test.ts
-          CLI_REGION: ap-east-1
-          CANARY_METRIC_NAME: IosAppBuildCodegenSuccessRate
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_app_ios_ap_northeast_1
       buildspec: .codebuild/run_regionalized_ios_modelgen_e2e_test.yml
       env:
@@ -227,4 +217,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_ios_ap_east_1
+        - build_app_ios_ap_northeast_1

--- a/.codebuild/ts_canary_workflow.yml
+++ b/.codebuild/ts_canary_workflow.yml
@@ -22,17 +22,6 @@ batch:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
         - build_linux
-    - identifier: build_app_ts_ap_east_1
-      buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          TEST_SUITE: src/__tests__/build-app-ts.test.ts
-          CLI_REGION: ap-east-1
-          CANARY_METRIC_NAME: TsAppBuildCodegenSuccessRate
-          DISABLE_ESLINT_PLUGIN: true
-      depend-on:
-        - publish_to_local_registry
     - identifier: build_app_ts_ap_northeast_1
       buildspec: .codebuild/run_regionalized_ts_modelgen_e2e_test.yml
       env:
@@ -247,4 +236,4 @@ batch:
       env:
         compute-type: BUILD_GENERAL1_MEDIUM
       depend-on:
-        - build_app_ts_ap_east_1
+        - build_app_ts_ap_northeast_1

--- a/packages/amplify-codegen-e2e-core/src/configure/index.ts
+++ b/packages/amplify-codegen-e2e-core/src/configure/index.ts
@@ -31,6 +31,7 @@ const defaultProjectSettings = {
  *
  * NOTE:
  * - The list is used to configure correct region in Amplify profile as env var $CLI_REGION
+ * - The list much be in the same order as 'amplify configure' regions selection dropdown
  * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
  *
  * The list of supported regions must be kept in sync amongst all of:

--- a/packages/amplify-codegen-e2e-core/src/configure/index.ts
+++ b/packages/amplify-codegen-e2e-core/src/configure/index.ts
@@ -28,7 +28,7 @@ const defaultProjectSettings = {
 /**
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
- * 
+ *
  * NOTE:
  * - The list is used to configure correct region in Amplify profile as env var $CLI_REGION
  * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions

--- a/packages/amplify-codegen-e2e-core/src/configure/index.ts
+++ b/packages/amplify-codegen-e2e-core/src/configure/index.ts
@@ -25,6 +25,21 @@ const defaultProjectSettings = {
   startCmd: '\r',
 };
 
+/**
+ * Supported regions:
+ * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
+ * 
+ * NOTE:
+ * - The list is used to configure correct region in Amplify profile as env var $CLI_REGION
+ * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
+ *
+ * The list of supported regions must be kept in sync amongst all of:
+ * - Amplify CLI 'amplify configure' command regions dropdown
+ * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/e2e-test-regions.json
+ * - amplify-codegen/scripts/split-canary-tests.ts
+ * - amplify-codegen/scripts/split-e2e-tests.ts
+ */
 export const amplifyRegions = [
   'us-east-1',
   'us-east-2',
@@ -38,6 +53,7 @@ export const amplifyRegions = [
   'eu-central-1',
   'ap-northeast-1',
   'ap-northeast-2',
+  'ap-northeast-3',
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-south-1',

--- a/scripts/e2e-test-regions.json
+++ b/scripts/e2e-test-regions.json
@@ -1,5 +1,4 @@
 [
-  { "name": "ap-east-1", "optIn": true },
   { "name": "ap-northeast-1", "optIn": false },
   { "name": "ap-northeast-2", "optIn": false },
   { "name": "ap-northeast-3", "optIn": false },

--- a/scripts/split-canary-tests.ts
+++ b/scripts/split-canary-tests.ts
@@ -10,11 +10,17 @@ const CODEBUILD_CONFIG_BASE_PATH: string = join(CODEBUILD_CONFIG_PATH, 'canary_w
 /**
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
+ * 
+ * NOTE:
+ * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
+ * - Since 'ap-east-1' is not available via 'amplify configure', test $CLI_REGION with 'ap-east-1' will run in 'us-east-1'
+ * and fail Amplify profile assertion in test setup phase
  *
- * NOTE: The list of supported regions must be kept in sync amongst all of:
+ * The list of supported regions must be kept in sync amongst all of:
+ * - Amplify CLI 'amplify configure' command regions dropdown
  * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/e2e-test-regions.json
  * - amplify-codegen/scripts/split-e2e-tests.ts
- * - amplify-codegen/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
  */
 const SUPPORTED_REGIONS_PATH: string = join(REPO_ROOT, 'scripts', 'e2e-test-regions.json');
 const AWS_REGIONS_TO_RUN_TESTS: string[] = JSON.parse(fs.readFileSync(SUPPORTED_REGIONS_PATH, 'utf-8')).map(region => region.name);

--- a/scripts/split-canary-tests.ts
+++ b/scripts/split-canary-tests.ts
@@ -10,7 +10,7 @@ const CODEBUILD_CONFIG_BASE_PATH: string = join(CODEBUILD_CONFIG_PATH, 'canary_w
 /**
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
- * 
+ *
  * NOTE:
  * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
  * - Since 'ap-east-1' is not available via 'amplify configure', test $CLI_REGION with 'ap-east-1' will run in 'us-east-1'

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -22,7 +22,7 @@ const DEBUG_FLAG = '--debug';
 /**
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
- * 
+ *
  * NOTE:
  * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
  * - Since 'ap-east-1' is not available via 'amplify configure', test $CLI_REGION with 'ap-east-1' will run in 'us-east-1'

--- a/scripts/split-e2e-tests.ts
+++ b/scripts/split-e2e-tests.ts
@@ -22,11 +22,17 @@ const DEBUG_FLAG = '--debug';
 /**
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
+ * 
+ * NOTE:
+ * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
+ * - Since 'ap-east-1' is not available via 'amplify configure', test $CLI_REGION with 'ap-east-1' will run in 'us-east-1'
+ * and fail Amplify profile assertion in test setup phase
  *
- * NOTE: The list of supported regions must be kept in sync amongst all of:
+ * The list of supported regions must be kept in sync amongst all of:
+ * - Amplify CLI 'amplify configure' command regions dropdown
  * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/e2e-test-regions.json
  * - amplify-codegen/scripts/split-canary-tests.ts
- * - amplify-codegen/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
  */
 const SUPPORTED_REGIONS_PATH: string = join(REPO_ROOT, 'scripts', 'e2e-test-regions.json');
 const AWS_REGIONS_TO_RUN_TESTS: string[] = JSON.parse(fs.readFileSync(SUPPORTED_REGIONS_PATH, 'utf-8')).map(region => region.name);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Fixed possible region discrepancy in `amplify configure` due to mismatch between Amplify CLI command dropdown and test script region list.

Plus, removed `ap-east-1` from E2E regions as there is a known difference between Amplify CLI regions and Amplify supported regions. Customer will still be able to deploy app to `ap-east-1`, but this region is not currently supported via `amplify configure`. Having test running in this region will redirect test back to `us-east-1` and failed the Amplify profile assertion in test setup phase.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

CI E2Es



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
