### PR TITLE
fix: cleanup detection of regional availability

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -99,7 +99,7 @@ type AWSAccountInfo = {
 };
 
 const BUCKET_TEST_REGEX = /test/;
-const IAM_TEST_REGEX = /!RotateE2eAwsToken-e2eTestContextRole|-integtest$|^amplify-|^eu-|^us-|^ap-/;
+const IAM_TEST_REGEX = /-RotateE2eAwsToken-e2eTestContextRole|-integtest|^amplify-/;
 const STALE_DURATION_MS = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
 const isCI = (): boolean => process.env.CI && process.env.CODEBUILD ? true : false;

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -118,7 +118,7 @@ const handleExpiredTokenException = (): void => {
  * @returns true if region is enabled in that account, false otherwise
  */
 const isRegionEnabled = async (accountInfo: AWSAccountInfo, region: string): Promise<boolean> => {
-  const account = new Account(getAWSConfig(accountInfo, region));
+  const account = new Account({ ...accountInfo, region: 'us-east-1' });
   const optStatus = await account.getRegionOptStatus({ RegionName: region }).promise();
 
   return optStatus.RegionOptStatus === 'ENABLED' || optStatus.RegionOptStatus === 'ENABLED_BY_DEFAULT';

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -12,8 +12,15 @@ import { deleteS3Bucket, sleep } from '@aws-amplify/amplify-codegen-e2e-core';
  * Supported regions:
  * - All Amplify regions, as reported https://docs.aws.amazon.com/general/latest/gr/amplify.html
  *
- * NOTE: The list of supported regions must be kept in sync amongst all of:
+ * NOTE:
+ * - 'ap-east-1' is not included in the list due to known discrepancy in Amplify CLI 'configure' command dropdown and supported regions
+ * - Since 'ap-east-1' is not available via 'amplify configure', test $CLI_REGION with 'ap-east-1' will run in 'us-east-1'
+ * and fail Amplify profile assertion in test setup phase
+ *
+ * The list of supported regions must be kept in sync amongst all of:
+ * - Amplify CLI 'amplify configure' command regions dropdown
  * - the internal pipeline that publishes new lambda layer versions
+ * - amplify-codegen/scripts/e2e-test-regions.json
  * - amplify-codegen/scripts/split-canary-tests.ts
  * - amplify-codegen/scripts/split-e2e-tests.ts
  */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Added additional handling to invalid token scenarios in cleanup scripts, since some child test accounts do not have opt-in region enabled, and will encounter invalid token/client error.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
