### PR TITLE
fix: handle pagination when fetching region list in cleanup

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -176,12 +176,13 @@ const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleIn
 const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]> => {
   // Specify service region to avoid possible endpoint unavailable error
   const account = new Account({ ...accountInfo, region: 'us-east-1' });
-  const response = await account.listRegions({ RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'] }).promise();
+  const response = await account.listRegions({
+    RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'],
+    MaxResults: AWS_REGIONS_TO_RUN_TESTS.length,
+  }).promise();
   console.log(response);
   console.log(response.Regions);
-  const enabledRegions = response.Regions.map(r =>
-    r.RegionOptStatus === 'ENABLED' || r.RegionOptStatus === 'ENABLED_BY_DEFAULT' ? r.RegionName : null,
-  ).filter(Boolean);
+  const enabledRegions = response.Regions.map(r => r.RegionName).filter(Boolean);
 
   return enabledRegions;
 };

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -177,6 +177,7 @@ const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]>
   // Specify service region to avoid possible endpoint unavailable error
   const account = new Account({ ...accountInfo, region: 'us-east-1' });
   const response = await account.listRegions().promise();
+  console.log(response);
   const enabledRegions = response.Regions.map(r =>
     r.RegionOptStatus === 'ENABLED' || r.RegionOptStatus === 'ENABLED_BY_DEFAULT' ? r.RegionName : null,
   ).filter(Boolean);

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -176,8 +176,9 @@ const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleIn
 const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]> => {
   // Specify service region to avoid possible endpoint unavailable error
   const account = new Account({ ...accountInfo, region: 'us-east-1' });
-  const response = await account.listRegions().promise();
+  const response = await account.listRegions({ RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'] }).promise();
   console.log(response);
+  console.log(response.Regions);
   const enabledRegions = response.Regions.map(r =>
     r.RegionOptStatus === 'ENABLED' || r.RegionOptStatus === 'ENABLED_BY_DEFAULT' ? r.RegionName : null,
   ).filter(Boolean);

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -180,8 +180,6 @@ const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]>
     RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'],
     MaxResults: AWS_REGIONS_TO_RUN_TESTS.length,
   }).promise();
-  console.log(response);
-  console.log(response.Regions);
   const enabledRegions = response.Regions.map(r => r.RegionName).filter(Boolean);
 
   return enabledRegions;

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -167,7 +167,7 @@ const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleIn
   ...(region ? { region } : {}),
   maxRetries: 10,
  });
- 
+
  /**
  * Returns a list of regions enabled given the AWS account information
  * @param accountInfo aws account to check region
@@ -192,6 +192,7 @@ const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]>
     enabledRegions.push(...response.Regions.map(r => r.RegionName).filter(Boolean));
   } while (nextToken);
 
+  console.log('All enabled regions fetched: ', enabledRegions);
   return enabledRegions;
 };
 
@@ -205,7 +206,6 @@ const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]>
 const getAmplifyApps = async (account: AWSAccountInfo, region: string, regionsEnabled: string[]): Promise<AmplifyAppInfo[]> => {
   const amplifyClient = new aws.Amplify(getAWSConfig(account, region));
 
-  console.log(regionsEnabled);
   if (!regionsEnabled.includes(region)) {
     console.error(`Listing apps for account ${account.accountId}-${region} failed since ${region} is not enabled. Skipping.`);
     return [];

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -167,7 +167,7 @@ const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleIn
   ...(region ? { region } : {}),
   maxRetries: 10,
  });
-
+ 
  /**
  * Returns a list of regions enabled given the AWS account information
  * @param accountInfo aws account to check region
@@ -176,11 +176,21 @@ const getOrphanTestIamRoles = async (account: AWSAccountInfo): Promise<IamRoleIn
 const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]> => {
   // Specify service region to avoid possible endpoint unavailable error
   const account = new Account({ ...accountInfo, region: 'us-east-1' });
-  const response = await account.listRegions({
-    RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'],
-    MaxResults: AWS_REGIONS_TO_RUN_TESTS.length,
-  }).promise();
-  const enabledRegions = response.Regions.map(r => r.RegionName).filter(Boolean);
+
+  const enabledRegions: string[] = [];
+  let nextToken: string | undefined = undefined;
+
+  do {
+    const input: Account.Types.ListRegionsRequest = {
+      RegionOptStatusContains: ['ENABLED', 'ENABLED_BY_DEFAULT'],
+      NextToken: nextToken,
+    };
+
+    const response = await account.listRegions(input).promise();
+    nextToken = response.NextToken;
+
+    enabledRegions.push(...response.Regions.map(r => r.RegionName).filter(Boolean));
+  } while (nextToken);
 
   return enabledRegions;
 };

--- a/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
+++ b/packages/amplify-codegen-e2e-tests/src/cleanup-e2e-resources.ts
@@ -194,6 +194,7 @@ const getRegionsEnabled = async (accountInfo: AWSAccountInfo): Promise<string[]>
 const getAmplifyApps = async (account: AWSAccountInfo, region: string, regionsEnabled: string[]): Promise<AmplifyAppInfo[]> => {
   const amplifyClient = new aws.Amplify(getAWSConfig(account, region));
 
+  console.log(regionsEnabled);
   if (!regionsEnabled.includes(region)) {
     console.error(`Listing apps for account ${account.accountId}-${region} failed since ${region} is not enabled. Skipping.`);
     return [];


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Disabled pagination when fetching all regions from SDK `Account.listRegions`, so all regions will be retrieved from request for cleanup.

#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] E2E test run linked


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
