### PR TITLE
chore: add deleteProject function to canary files

### DIFF
--- a/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-android.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-android.test.ts
@@ -10,6 +10,7 @@ import {
   addCodegen,
   AmplifyFrontend,
   apiGqlCompile,
+  deleteProject
 } from '@aws-amplify/amplify-codegen-e2e-core';
 const { schemas } = require('@aws-amplify/graphql-schema-test-library');
 import { existsSync, writeFileSync, readdirSync, rmSync, readFileSync } from 'fs';
@@ -44,6 +45,7 @@ describe('build app - Android', () => {
   });
 
   afterAll(async () => {
+    await deleteProject(projectRoot);
     rmSync(path.join(projectRoot, 'amplify'), { recursive: true, force: true });
     rmSync(path.join(projectRoot, '.graphqlconfig.yml'), { recursive: true, force: true });
   });

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-swift.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-swift.test.ts
@@ -9,6 +9,7 @@ import {
   addCodegen,
   AmplifyFrontend,
   apiGqlCompile,
+  deleteProject
 } from '@aws-amplify/amplify-codegen-e2e-core';
 const { schemas } = require('@aws-amplify/graphql-schema-test-library');
 import { writeFileSync, readdirSync, readFileSync, rmSync, mkdirSync } from 'fs';
@@ -46,6 +47,7 @@ describe('build app - Swift', () => {
   });
 
   afterAll(async () => {
+    await deleteProject(projectRoot);
     await rmSync(path.join(projectRoot, 'amplify'), { recursive: true, force: true });
     rmSync(path.join(projectRoot, '.graphqlconfig.yml'), { recursive: true, force: true });
 

--- a/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-ts.test.ts
+++ b/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-ts.test.ts
@@ -10,6 +10,7 @@ import {
   addCodegen,
   AmplifyFrontend,
   apiGqlCompile,
+  deleteProject
 } from '@aws-amplify/amplify-codegen-e2e-core';
 const { schemas } = require('@aws-amplify/graphql-schema-test-library');
 import { existsSync, writeFileSync, readdirSync, rmSync } from 'fs';
@@ -37,6 +38,7 @@ describe('build app - JS', () => {
   });
 
   afterAll(async () => {
+    await deleteProject(projectRoot);
     await rmSync(path.join(projectRoot, 'amplify'), { recursive: true, force: true });
     rmSync(path.join(projectRoot, '.graphqlconfig.yml'), { recursive: true, force: true });
   });


### PR DESCRIPTION
#### Description of changes
- [Build #5510](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-category-api-default-ddb-cdk-construct-canary-workflow/batch/amplify-category-api-default-ddb-cdk-construct-canary-workflow%3Ae6a53dc5-b44e-4b10-9444-aaa9952f586d/?region=us-east-1) failed due to AppSync API resource Limit.
- Resource limit reached due to stale CFN resources not being delete
- [`deleteProject`](https://github.com/aws-amplify/amplify-codegen/blob/main/packages/amplify-codegen-e2e-core/src/init/deleteProject.ts) function call missing in [`android`, `swift`, `ts`](https://github.com/aws-amplify/amplify-codegen/blob/08c92ba2db15c8dfd64feeb3a86c6358737af723/packages/amplify-codegen-e2e-tests/src/__tests__/build-app-android.test.ts#L47) canary workflow.
- Added `deleteProject` function calls to all the above codegen canary test files


#### Description of how you validated changes
- [E2E test run to validate changes](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-e2e-workflow/batch/amplify-codegen-e2e-workflow%3A00e3b896-60eb-483e-97a7-736c4ab6c08d?region=us-east-1)

#### Checklist

- [ ] PR description included
- [ ] E2E test run linked


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.