### PR TITLE
chore: add timeout before installing cli from local registry

### DIFF
--- a/shared-scripts.sh
+++ b/shared-scripts.sh
@@ -239,6 +239,12 @@ function _installCLIFromLocalRegistry {
     fi
     setNpmRegistryUrlToLocal
     changeNpmGlobalPath
+    # set longer timeout to avoid socket timeout error
+    npm config set fetch-retries 5
+    npm config set fetch-timeout 600000
+    npm config set fetch-retry-mintimeout 30000
+    npm config set fetch-retry-maxtimeout 180000
+    npm config set maxsockets 1
     npm install -g @aws-amplify/cli-internal
     echo "using Amplify CLI version: "$(amplify --version)
     npm list -g --depth=1 | grep -e '@aws-amplify/amplify-category-api' -e 'amplify-codegen'


### PR DESCRIPTION
#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
- Codegen Canary regionalized workflows fail with `npm EIDLETIMEOUT error`
- Adding longer timeouts and retries to avoid timeout error


#### Description of how you validated changes
- Ran a Codebuild job with above changes to verify canary tests pass, runs linked below
- [Android](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-android-app-build-canary-workflow/batch/amplify-codegen-android-app-build-canary-workflow%3A3bfe1ff9-a5b2-402d-b2be-2c3f085fb69b?region=us-east-1)
- [Ios](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-ios-app-build-canary-workflow/batch/amplify-codegen-ios-app-build-canary-workflow%3A20746ad4-a109-47ea-bb47-5364f3e96559?region=us-east-1)
- [Ts](https://594813022831-qxxvc3uq.us-east-1.console.aws.amazon.com/codesuite/codebuild/594813022831/projects/amplify-codegen-ts-app-build-canary-workflow/batch/amplify-codegen-ts-app-build-canary-workflow%3A083351b9-37a1-45b3-afdd-6206ab4dd2c7?region=us-east-1)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] E2E test run linked


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
