### PR TITLE
test: increase ios codegen canary timeout

### DIFF
--- a/.codebuild/scripts/run-ios-modelgen-e2e-test.sh
+++ b/.codebuild/scripts/run-ios-modelgen-e2e-test.sh
@@ -52,7 +52,7 @@ main() {
     latest_run_id=$(get_latest_run_id)
     echo "Latest run ID: $latest_run_id"
     run_status=$(get_run_status "$latest_run_id")
-    timeout=$((SECONDS + 1200))  # 1200 seconds = 20 minutes
+    timeout=$((SECONDS + 1500))  # 1500 seconds = 25 minutes
 
     # Continuously check for status until completion
     while [[ "$run_status" != "completed"  && "$SECONDS" -lt "$timeout" ]]; do


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Increase iOS codegen canary timeout. The canaries are reaching the timeout more frequently starting this afternoon. It is not clear what the issue is yet, but this will stop the bleeding.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
