### PR TITLE
chore: upgrade aws-cdk and amplify-core versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@aws-amplify/amplify-cli-core": "^4.4.0",
+    "@aws-amplify/amplify-cli-core": "^4.4.1",
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
     "@commitlint/config-lerna-scopes": "^17.0.2",
@@ -138,7 +138,7 @@
     "node-fetch": "^2.6.7",
     "parse-url": "^8.1.0",
     "xml2js": "0.5.0",
-    "aws-cdk-lib": "^2.187.0"
+    "aws-cdk-lib": "^2.189.1"
   },
   "config": {
     "commitizen": {

--- a/packages/amplify-codegen-e2e-core/package.json
+++ b/packages/amplify-codegen-e2e-core/package.json
@@ -43,7 +43,7 @@
     "@types/ini": "^1.3.31"
   },
   "peerDependencies": {
-    "@aws-amplify/amplify-cli-core": "^4.4.0",
+    "@aws-amplify/amplify-cli-core": "^4.4.1",
     "amplify-headless-interface": "^1.13.1",
     "graphql-transformer-core": "^8.0.0"
   }

--- a/packages/amplify-codegen-e2e-tests/package.json
+++ b/packages/amplify-codegen-e2e-tests/package.json
@@ -47,7 +47,7 @@
     "ts-node": "^8.10.1"
   },
   "peerDependencies": {
-    "@aws-amplify/amplify-cli-core": "^4.4.0",
+    "@aws-amplify/amplify-cli-core": "^4.4.1",
     "graphql-transformer-core": "^8.0.0"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,19 +47,19 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@aws-amplify/amplify-cli-core@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/@aws-amplify/amplify-cli-core/-/amplify-cli-core-4.4.0.tgz#08c50d4323ed40671878b8cdab6a4ad4e2356fad"
-  integrity sha512-WMdd1hZm1d9nfmRfGLqsDmgGqPZGWjjU1FFH0vuAGXLCezimCONa08J6ZnrIatS/5NGEfZZ4/ap7R6nOLjV3Sg==
+"@aws-amplify/amplify-cli-core@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/amplify-cli-core/-/amplify-cli-core-4.4.1.tgz#281e8cc72830de2fd152694db80c9348d72bd558"
+  integrity sha512-//d1HVnZljMnWkqEkIVbiW1MQ1GoGcQsoPyq246qsojbAtn6/0tiYNLrNr9Uzv3upYSHERFg/US5g4A205D/7g==
   dependencies:
     "@aws-amplify/amplify-cli-logger" "1.3.8"
     "@aws-amplify/amplify-function-plugin-interface" "1.12.1"
     "@aws-amplify/amplify-prompts" "2.8.6"
-    "@aws-amplify/graphql-transformer-interfaces" "^3.10.2"
+    "@aws-amplify/graphql-transformer-interfaces" "^3.12.0"
     "@aws-sdk/util-arn-parser" "^3.310.0"
     "@yarnpkg/lockfile" "^1.1.0"
     ajv "^6.12.6"
-    aws-cdk-lib "~2.177.0"
+    aws-cdk-lib "~2.187.0"
     chalk "^4.1.1"
     ci-info "^3.8.0"
     cli-table3 "^0.6.0"
@@ -669,10 +669,10 @@
   dependencies:
     graphql "^15.5.0"
 
-"@aws-amplify/graphql-transformer-interfaces@^3.10.2":
-  version "3.10.2"
-  resolved "https://registry.npmjs.org/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.10.2.tgz#6020deb141aac0054c0ce45a2d672eaf26bcc1b5"
-  integrity sha512-OfS0T1M47ShTd6mnWKbIReDiCTmFSWmBvdcXJQF/J09tOEaSSy5QS9H/B0QEW97QAlaasKqxVwKGAp4S5AWRJA==
+"@aws-amplify/graphql-transformer-interfaces@^3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/graphql-transformer-interfaces/-/graphql-transformer-interfaces-3.12.0.tgz#377c55fac147f9f37ae0f8643fee102f0f6cba80"
+  integrity sha512-uWR6L48kLWla4jKY8QTtOq+QNzRS/+73llKG6kVw/R7bfnpDZo60Ga1GrbWKwS4c7ud3BMcqLaJM8QKk2OZMww==
   dependencies:
     graphql "^15.5.0"
 
@@ -8635,10 +8635,10 @@ aws-appsync@^4.1.9:
     url "^0.11.0"
     uuid "3.x"
 
-aws-cdk-lib@^2.187.0, aws-cdk-lib@~2.177.0:
-  version "2.187.0"
-  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.187.0.tgz#7b76246abb77cd305cdf2cd00c4f32f9eb38cf67"
-  integrity sha512-OrAWin+LD5sZhRF5cWuEYEkmC/sxxlgcAasCpfzeRsj6yDImwmeQsaKhM7xqzZQBInog6ZbN6oFZYiWEGJMSIA==
+aws-cdk-lib@^2.189.1, aws-cdk-lib@~2.187.0:
+  version "2.193.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.193.0.tgz#2c97ac6794c955fbf62981de7d02c369fc9af967"
+  integrity sha512-Bsf11FM85+s9jSAT8JfDNlrSz6LF3Xa2eSNOyMLcXNopI7eVXP1U6opRHK0waaZGLmQfOwsbSp/9XRMKikkazg==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "^2.2.229"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"


### PR DESCRIPTION
#### Description of changes

Fixes: https://github.com/aws-amplify/amplify-codegen/security/dependabot/85



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] E2E test run linked
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
