### PR TITLE
fix: Pascal case enum names in exports block

### DIFF
--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-typescript-visitor.ts
@@ -250,8 +250,9 @@ export class AppSyncModelTypeScriptVisitor<
           const modelClassName = this.generateModelImportAlias(model);
           const exportClassName = this.getModelName(model);
           return modelClassName !== exportClassName ? `${modelClassName} as ${exportClassName}` : modelClassName;
+        } else if (model.type === 'enum') {
+          return pascalCase(model.name);
         }
-        return model.name;
       })
       .join(',\n');
     return ['export {', indentMultiline(exportStr), '};'].join('\n');


### PR DESCRIPTION
#### Description of changes
A [PR](https://github.com/aws-amplify/amplify-codegen/issues/931) was added removing pascal casing for some enum definitions.
One of the places where pascal casing was actually ADDED is JS models' `index.js` file that defines enums, then exports them.
However, in the `export` block, the pascal casing transformation wasn't applied, leading to a potential mismatch between names.

E.g: `(enum) MyCTA => MyCta` transformation generated a `MyCta` enum but was trying to export `MyCTA`
#### Codegen Paramaters Changed or Added
None

#### Issue #, if available
None

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [X] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [X] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [X] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
