### PR TITLE
Update test-swift-modelgen.sh

### DIFF
--- a/scripts/test-swift-modelgen.sh
+++ b/scripts/test-swift-modelgen.sh
@@ -45,7 +45,7 @@ function createSwiftPackage() {
     rm -rf Package.swift
     echo '// swift-tools-version: 5.7
     import PackageDescription
-    let package = Package(name: "swiftapp", platforms: [.macOS(.v10_15)], dependencies: [.package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.12.0")   ], targets: [ .executableTarget( name: "swiftapp",  dependencies: [ .product(name: "Amplify", package: "amplify-swift") ], path: "Sources")]
+    let package = Package(name: "swiftapp", platforms: [.macOS(.v12_0)], dependencies: [.package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.12.0")   ], targets: [ .executableTarget( name: "swiftapp",  dependencies: [ .product(name: "Amplify", package: "amplify-swift") ], path: "Sources")]
     )' >> Package.swift
     cat Package.swift
 }


### PR DESCRIPTION
Attempt to fix

```
Working copy of https://github.com/apple/swift-log.git resolved at 1.6.4
warning: 'sqlite.swift': /private/var/folders/95/hzm5wrys2lq3s0fd9v0ql4xc0000gn/T/tmp.4TVF7ph0/swiftapp/.build/checkouts/SQLite.swift/Package.swift:7:15: warning: 'v11' is deprecated: iOS 12.0 is the oldest supported version
        .iOS(.v11),
              ^
/private/var/folders/95/hzm5wrys2lq3s0fd9v0ql4xc0000gn/T/tmp.4TVF7ph0/swiftapp/.build/checkouts/SQLite.swift/Package.swift:10:16: warning: 'v11' is deprecated: tvOS 12.0 is the oldest supported version
        .tvOS(.v11),
               ^
error: the executable 'swiftapp' requires macos 10.15, but depends on the product 'Amplify' which requires macos 12.0; consider changing the executable 'swiftapp' to require macos 12.0 or later, or the product 'Amplify' to require macos 10.15 or earlier.
Error: Process completed with exit code 1.
```

in https://github.com/aws-amplify/amplify-codegen/actions/workflows/build-swift-modelgen.yml