### PR TITLE
Update test-swift-modelgen.sh

### DIFF
--- a/scripts/test-swift-modelgen.sh
+++ b/scripts/test-swift-modelgen.sh
@@ -45,7 +45,7 @@ function createSwiftPackage() {
     rm -rf Package.swift
     echo '// swift-tools-version: 5.7
     import PackageDescription
-    let package = Package(name: "swiftapp", platforms: [.macOS(.v12_0)], dependencies: [.package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.12.0")   ], targets: [ .executableTarget( name: "swiftapp",  dependencies: [ .product(name: "Amplify", package: "amplify-swift") ], path: "Sources")]
+    let package = Package(name: "swiftapp", platforms: [.macOS(.v12)], dependencies: [.package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.12.0")   ], targets: [ .executableTarget( name: "swiftapp",  dependencies: [ .product(name: "Amplify", package: "amplify-swift") ], path: "Sources")]
     )' >> Package.swift
     cat Package.swift
 }


### PR DESCRIPTION
Follow up from https://github.com/aws-amplify/amplify-codegen/pull/969 .

Validated locally that `...[.macOS(.v12)]...` is valid enum value.