### PR TITLE
chore: use newer macos runner

### DIFF
--- a/.github/workflows/build-swift-modelgen.yml
+++ b/.github/workflows/build-swift-modelgen.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   Build-Swift-Modelgen:
     name: Build
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     permissions:
       actions: read
       contents: read
@@ -22,6 +22,9 @@ jobs:
       fail-fast: true
 
     steps:
+      - name: Set Xcode version
+        run: sudo xcode-select --switch "/Applications/Xcode_16.1.0.app"
+        
       - name: Mask S3 URL
         run: echo "::add-mask::$MODELS_S3_URL"
 


### PR DESCRIPTION
Attempt to fix https://github.com/aws-amplify/amplify-codegen/blob/main/.github/workflows/build-swift-modelgen.yml, switch macos runner and Xcode version to minimum required Xcode version for Amplify Swift.