### PR TITLE
feat(appsync-modelgen-plugin): add metrics and usage fields to conversation message model

### DIFF
--- a/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
+++ b/packages/appsync-modelgen-plugin/src/__tests__/visitors/__snapshots__/appsync-model-introspection-visitor.test.ts.snap
@@ -214,6 +214,24 @@ exports[`Conversation Route Introspection Visitor Metadata snapshot should gener
                             \\"isRequired\\": false,
                             \\"isArrayNullable\\": true
                         },
+                        \\"metrics\\": {
+                            \\"name\\": \\"metrics\\",
+                            \\"type\\": {
+                                \\"nonModel\\": \\"AmplifyAIMetrics\\"
+                            },
+                            \\"attributes\\": [],
+                            \\"isArray\\": false,
+                            \\"isRequired\\": false
+                        },
+                        \\"usage\\": {
+                            \\"name\\": \\"usage\\",
+                            \\"type\\": {
+                                \\"nonModel\\": \\"AmplifyAIUsage\\"
+                            },
+                            \\"attributes\\": [],
+                            \\"isArray\\": false,
+                            \\"isRequired\\": false
+                        },
                         \\"createdAt\\": {
                             \\"name\\": \\"createdAt\\",
                             \\"type\\": \\"AWSDateTime\\",

--- a/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
+++ b/packages/appsync-modelgen-plugin/src/utils/process-conversation.ts
@@ -95,6 +95,8 @@ function generateConversationMessageModel(conversationModelName: string, modelNa
       content: generateField('content', { nonModel: 'AmplifyAIContentBlock' }, { isArray: true }),
       aiContext: generateField('aiContext', 'AWSJSON'),
       toolConfiguration: generateField('toolConfiguration', { nonModel: 'AmplifyAIToolConfiguration' }, { isArray: true, isArrayNullable: true }),
+      metrics: generateField('metrics', { nonModel: 'AmplifyAIMetrics' }),
+      usage: generateField('usage', { nonModel: 'AmplifyAIUsage' }),
       createdAt: generateTimestampField('createdAt'),
       updatedAt: generateTimestampField('updatedAt'),
     },


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#pull-requests
-->


#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->
Adds `metrics` and `usage` fields to the generated conversation message model in `processConversationRoute`.                                                                                                   
                                                                                                                                                                                                               
This enables clients to receive token usage metadata (input/output/total tokens) and metrics from Bedrock AI conversation responses, supporting the ability to track and limit token usage per user.           
                                                                                                                                                                                                               
The fields are typed as:                                                                                                                                                                                       
- `metrics`: `AmplifyAIMetrics` (nonModel)                                                                                                                                                                     
- `usage`: `AmplifyAIUsage` (nonModel)  
#### Codegen Paramaters Changed or Added
<!--
List any codegen parameters changed or added.
-->

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->
aws-amplify/amplify-backend#2355 

#### Related PRs (all required for aws-amplify/amplify-backend#2355)
                                                                                                                                                                                                               
This feature spans 4 repositories. PRs should be merged in this order:                                                                                                                                         
                                                                                                                                                                                                               
1. **amplify-category-api** — [aws-amplify/amplify-category-api#3448](https://github.com/aws-amplify/amplify-category-api/pull/3448) — Defines `AmplifyAIMetrics`/`AmplifyAIUsage` GraphQL types and updates resolvers                                                                                                                                                                                                        
2. **amplify-data** — [aws-amplify/amplify-data#697](https://github.com/aws-amplify/amplify-data/pull/697) — Adds TypeScript types and client-side deserializers                                               
3. **amplify-backend** — [aws-amplify/amplify-backend#3148](https://github.com/aws-amplify/amplify-backend/pull/3148) — Captures metrics/usage from Bedrock streaming response                                 
4. **amplify-codegen** — [aws-amplify/amplify-codegen#1008](https://github.com/aws-amplify/amplify-codegen/pull/1008) — Adds fields to generated introspection metadata    


#### Description of how you validated changes
- Ran `yarn build` and `yarn test` in `packages/appsync-modelgen-plugin` — all tests pass                                                                                                                      
- Updated snapshot for `appsync-model-introspection-visitor` to include the new fields                                                                                                                         
- `graphql-generator` test failures are pre-existing on `main` and unrelated to this change 


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [ ] E2E test run linked
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-codegen/blob/main/CONTRIBUTING.md#tests)
- [ ] Relevant documentation is changed or added (and PR referenced)
- [ ] Breaking changes to existing customers are released behind a feature flag or major version update
- [ ] Changes are tested using sample applications for all relevant platforms (iOS/android/flutter/Javascript) that use the feature added/modified
- [ ] Changes are tested on windows. Some Node functions (such as `path`) behave differently on windows.
- [ ] Changes adhere to the [GraphQL Spec](https://spec.graphql.org/June2018/) and supports the GraphQL types `type`, `input`, `enum`, `interface`, `union` and scalar types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
