### PR TITLE
fix(appsync-modelgen-plugin): replace relay 12 dependency chain

### DIFF
--- a/packages/appsync-modelgen-plugin/package.json
+++ b/packages/appsync-modelgen-plugin/package.json
@@ -27,9 +27,9 @@
     "extract-api": "ts-node ../../scripts/extract-api.ts"
   },
   "dependencies": {
-    "@graphql-codegen/plugin-helpers": "^3.1.1",
-    "@graphql-codegen/visitor-plugin-common": "^1.22.0",
-    "@graphql-tools/utils": "^6.0.18",
+    "@graphql-codegen/plugin-helpers": "^6.1.1",
+    "@graphql-codegen/visitor-plugin-common": "^6.2.4",
+    "@graphql-tools/utils": "^11.0.0",
     "chalk": "^3.0.0",
     "change-case": "^4.1.1",
     "graphql-transformer-common": "^4.25.1",

--- a/packages/appsync-modelgen-plugin/src/scalars/index.ts
+++ b/packages/appsync-modelgen-plugin/src/scalars/index.ts
@@ -1,7 +1,18 @@
 import { NormalizedScalarsMap } from '@graphql-codegen/visitor-plugin-common';
 import { AMPLIFY_CORE_PREFIX } from '../configs/dart-config';
 
-export const JAVA_SCALAR_MAP: NormalizedScalarsMap = {
+const createScalarMap = (scalarTypes: Record<string, string>): NormalizedScalarsMap => {
+  const normalizedScalars: NormalizedScalarsMap = {};
+  Object.entries(scalarTypes).forEach(([scalarName, scalarType]) => {
+    normalizedScalars[scalarName] = {
+      input: scalarType,
+      output: scalarType,
+    };
+  });
+  return normalizedScalars;
+};
+
+export const JAVA_SCALAR_MAP: NormalizedScalarsMap = createScalarMap({
   ID: 'String',
   String: 'String',
   Int: 'Integer',
@@ -16,7 +27,7 @@ export const JAVA_SCALAR_MAP: NormalizedScalarsMap = {
   AWSURL: 'String',
   AWSPhone: 'String',
   AWSIPAddress: 'String',
-};
+});
 
 // Package that needs to be imported when using the types
 export const JAVA_TYPE_IMPORT_MAP: Record<string, string> = {
@@ -26,7 +37,7 @@ export const JAVA_TYPE_IMPORT_MAP: Record<string, string> = {
   'Temporal.Timestamp': 'com.amplifyframework.core.model.temporal.Temporal',
 };
 
-export const SWIFT_SCALAR_MAP: NormalizedScalarsMap = {
+export const SWIFT_SCALAR_MAP: NormalizedScalarsMap = createScalarMap({
   ID: 'String',
   String: 'String',
   Int: 'Int',
@@ -41,9 +52,9 @@ export const SWIFT_SCALAR_MAP: NormalizedScalarsMap = {
   AWSURL: 'String',
   AWSPhone: 'String',
   AWSIPAddress: 'String',
-};
+});
 
-export const TYPESCRIPT_SCALAR_MAP: NormalizedScalarsMap = {
+export const TYPESCRIPT_SCALAR_MAP: NormalizedScalarsMap = createScalarMap({
   ID: 'string',
   String: 'string',
   Int: 'number',
@@ -58,9 +69,9 @@ export const TYPESCRIPT_SCALAR_MAP: NormalizedScalarsMap = {
   AWSURL: 'string',
   AWSPhone: 'string',
   AWSIPAddress: 'string',
-};
+});
 
-export const METADATA_SCALAR_MAP: NormalizedScalarsMap = {
+export const METADATA_SCALAR_MAP: NormalizedScalarsMap = createScalarMap({
   ID: 'ID',
   Boolean: 'Boolean',
   String: 'String',
@@ -75,9 +86,9 @@ export const METADATA_SCALAR_MAP: NormalizedScalarsMap = {
   Int: 'Int',
   Float: 'Float',
   AWSTimestamp: 'AWSTimestamp',
-};
+});
 
-export const DART_SCALAR_MAP: NormalizedScalarsMap = {
+export const DART_SCALAR_MAP: NormalizedScalarsMap = createScalarMap({
   ID: 'String',
   String: 'String',
   Int: 'int',
@@ -92,4 +103,4 @@ export const DART_SCALAR_MAP: NormalizedScalarsMap = {
   AWSURL: 'String',
   AWSPhone: 'String',
   AWSIPAddress: 'String',
-};
+});

--- a/packages/appsync-modelgen-plugin/src/types/disposable-compat.d.ts
+++ b/packages/appsync-modelgen-plugin/src/types/disposable-compat.d.ts
@@ -1,0 +1,7 @@
+// TypeScript 4.7 does not ship the standard Disposable globals that newer
+// graphql-tools type declarations reference. This package does not use those
+// contracts directly, so lightweight ambient declarations keep the package
+// buildable until the repo's TypeScript floor moves forward.
+interface Disposable {}
+
+interface AsyncDisposable {}

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-dart-visitor.ts
@@ -613,9 +613,9 @@ export class AppSyncModelDartVisitor<
               case 'String':
                 toStringVal = `"$${fieldName}"`;
                 break;
-              case this.scalars['AWSDate']:
-              case this.scalars['AWSTime']:
-              case this.scalars['AWSDateTime']:
+              case this.getScalarType('AWSDate'):
+              case this.getScalarType('AWSTime'):
+              case this.getScalarType('AWSDateTime'):
                 toStringVal = `(${fieldName} != null ? ${fieldName}!.format() : "null")`;
                 break;
               default:
@@ -768,25 +768,25 @@ export class AppSyncModelDartVisitor<
           //regular type
           const fieldNativeType = this.getNativeType({ ...field, isList: false });
           switch (fieldNativeType) {
-            case this.scalars['AWSDate']:
-            case this.scalars['AWSTime']:
-            case this.scalars['AWSDateTime']:
+            case this.getScalarType('AWSDate'):
+            case this.getScalarType('AWSTime'):
+            case this.getScalarType('AWSDateTime'):
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr(
                     'List',
                   )})?.map((e) => ${fieldNativeType}.fromString(e)).toList()`
                 : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromString(json['${varName}']) : null`;
-            case this.scalars['AWSTimestamp']:
+            case this.getScalarType('AWSTimestamp'):
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr(
                     'List',
                   )})?.map((e) => ${fieldNativeType}.fromSeconds(e)).toList()`
                 : `${fieldName} = json['${varName}'] != null ? ${fieldNativeType}.fromSeconds(json['${varName}']) : null`;
-            case this.scalars['Int']:
+            case this.getScalarType('Int'):
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr('List')})?.map((e) => (e as num).toInt()).toList()`
                 : `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr('num')})?.toInt()`;
-            case this.scalars['Float']:
+            case this.getScalarType('Float'):
               return field.isList
                 ? `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr('List')})?.map((e) => (e as num).toDouble()).toList()`
                 : `${fieldName} = (json['${varName}'] as ${this.getNullableTypeStr('num')})?.toDouble()`;
@@ -825,11 +825,11 @@ export class AppSyncModelDartVisitor<
         }
         const fieldNativeType = this.getNativeType({ ...field, isList: false });
         switch (fieldNativeType) {
-          case this.scalars['AWSDate']:
-          case this.scalars['AWSTime']:
-          case this.scalars['AWSDateTime']:
+          case this.getScalarType('AWSDate'):
+          case this.getScalarType('AWSTime'):
+          case this.getScalarType('AWSDateTime'):
             return field.isList ? `'${varName}': ${fieldName}?.map((e) => e.format()).toList()` : `'${varName}': ${fieldName}?.format()`;
-          case this.scalars['AWSTimestamp']:
+          case this.getScalarType('AWSTimestamp'):
             return field.isList
               ? `'${varName}': ${fieldName}?.map((e) => e.toSeconds()).toList()`
               : `'${varName}': ${fieldName}?.toSeconds()`;

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-json-metadata-visitor.ts
@@ -265,7 +265,7 @@ export class AppSyncJSONVisitor<
   private getType(gqlType: string): JSONModelFieldType {
     // Todo: Handle unlisted scalars
     if (gqlType in METADATA_SCALAR_MAP) {
-      return METADATA_SCALAR_MAP[gqlType as keyof typeof METADATA_SCALAR_MAP];
+      return METADATA_SCALAR_MAP[gqlType as keyof typeof METADATA_SCALAR_MAP].output as JSONModelFieldType;
     }
     if (gqlType in this.enumMap) {
       return { enum: this.enumMap[gqlType].name };

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-model-introspection-visitor.ts
@@ -273,7 +273,7 @@ export class AppSyncModelIntrospectionVisitor<
   protected getType(gqlType: string): FieldType | InputFieldType | UnionFieldType | InterfaceFieldType {
     // Todo: Handle unlisted scalars
     if (gqlType in METADATA_SCALAR_MAP) {
-      return METADATA_SCALAR_MAP[gqlType] as FieldType;
+      return METADATA_SCALAR_MAP[gqlType].output as FieldType;
     }
     if (gqlType in this.enumMap) {
       return { enum: this.enumMap[gqlType].name };

--- a/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
+++ b/packages/appsync-modelgen-plugin/src/visitors/appsync-visitor.ts
@@ -161,7 +161,7 @@ export interface RawAppSyncModelConfig extends RawConfig {
    * @type string
    * @description semantic version of amplify-codegen package
    */
-  codegenVersion: string;
+  codegenVersion?: string;
 }
 
 // Todo: need to figure out how to share config
@@ -584,7 +584,7 @@ export class AppSyncModelVisitor<
     const typeName = field.type;
     let typeNameStr: string = '';
     if (typeName in this.scalars) {
-      typeNameStr = this.scalars[typeName];
+      typeNameStr = this.getScalarType(typeName);
     } else if (this.isModelType(field)) {
       typeNameStr = this.getModelName(this.modelMap[typeName]);
     } else if (this.isEnumType(field)) {
@@ -596,6 +596,14 @@ export class AppSyncModelVisitor<
     }
 
     return field.isList ? this.getListType(typeNameStr, field) : typeNameStr;
+  }
+
+  protected getScalarType(typeName: string, kind: 'input' | 'output' = 'output'): string {
+    const scalar = this.scalars[typeName];
+    if (!scalar) {
+      throw new Error(`Unknown scalar ${typeName}`);
+    }
+    return scalar[kind];
   }
 
   protected getListType(typeStr: string, field: CodeGenField): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,15 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
+"@ardatan/relay-compiler@^13.0.1":
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/@ardatan/relay-compiler/-/relay-compiler-13.0.1.tgz#b00a4c1f986156fa2472db8036e9087877d37be3"
+  integrity sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    immutable "^5.1.5"
+    invariant "^2.2.4"
+
 "@ardatan/sync-fetch@^0.0.1":
   version "0.0.1"
   resolved "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz#3385d3feedceb60a896518a1db857ec1e945348f"
@@ -6101,6 +6110,11 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.29.2":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.22.15", "@babel/template@^7.3.3":
   version "7.22.15"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -6461,9 +6475,20 @@
     lodash "~4.17.0"
     tslib "~2.4.0"
 
+"@graphql-codegen/plugin-helpers@^6.1.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.2.1.tgz#8e00b06c35e36bed93f78278024ed6ff01da1c68"
+  integrity sha512-shRr26TfVZ6KFBjzRYUj02gLNh6yaECz9gTGgI6riANw5sSH9PONwTsBRYkEgU+6IXiL7VQeCumahvxSGFbRlQ==
+  dependencies:
+    "@graphql-tools/utils" "^11.0.0"
+    change-case-all "1.0.15"
+    common-tags "1.8.2"
+    import-from "4.0.0"
+    tslib "~2.6.0"
+
 "@graphql-codegen/schema-ast@^2.6.1":
   version "2.6.1"
-  resolved "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz#8ba1b38827c034b51ecd3ce88622c2ae6cd3fe1a"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.6.1.tgz#8ba1b38827c034b51ecd3ce88622c2ae6cd3fe1a"
   integrity sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.1.2"
@@ -6472,7 +6497,7 @@
 
 "@graphql-codegen/testing@^1.17.7":
   version "1.18.3"
-  resolved "https://registry.npmjs.org/@graphql-codegen/testing/-/testing-1.18.3.tgz#35ffe200c13c29aa93f41cb62b043552b860c72a"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/testing/-/testing-1.18.3.tgz#35ffe200c13c29aa93f41cb62b043552b860c72a"
   integrity sha512-ULw2TiADFokbM4ccecLtAf/tBoYOUKfoNPHelE7IE3Ci8gH9GGLLJzkiylz6u06WxHFl6h5njvo8c4gT1XcgTQ==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.1.1"
@@ -6484,7 +6509,7 @@
 
 "@graphql-codegen/typescript@^2.8.3":
   version "2.8.8"
-  resolved "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-2.8.8.tgz#8c3b9153e334db43c65f8f31ced69b4c60d14861"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.8.8.tgz#8c3b9153e334db43c65f8f31ced69b4c60d14861"
   integrity sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.1.2"
@@ -6495,7 +6520,7 @@
 
 "@graphql-codegen/visitor-plugin-common@2.13.8":
   version "2.13.8"
-  resolved "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz#09bc6317b227e5a278f394f4cef0d6c2d1910597"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz#09bc6317b227e5a278f394f4cef0d6c2d1910597"
   integrity sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==
   dependencies:
     "@graphql-codegen/plugin-helpers" "^3.1.2"
@@ -6525,6 +6550,22 @@
     parse-filepath "^1.0.2"
     tslib "~2.3.0"
 
+"@graphql-codegen/visitor-plugin-common@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.2.4.tgz#73906f34e8baaaadf5bfe5fefece4d86f835aebc"
+  integrity sha512-iwiVCc7Mv8/XAa3K35AdFQ9chJSDv/gYEnBeQFF/Sq/W8EyJoHypOGOTTLk7OSrWO4xea65ggv0e7fGt7rPJjQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^6.1.1"
+    "@graphql-tools/optimize" "^2.0.0"
+    "@graphql-tools/relay-operation-optimizer" "^7.1.1"
+    "@graphql-tools/utils" "^11.0.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.15"
+    dependency-graph "^1.0.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.6.0"
+
 "@graphql-tools/apollo-engine-loader@^8.0.0":
   version "8.0.0"
   resolved "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz#ac1f351cbe41508411784f25757f5557b0f27489"
@@ -6550,6 +6591,13 @@
   dependencies:
     tslib "^2.4.0"
 
+"@graphql-tools/optimize@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-2.0.0.tgz#7a9779d180824511248a50c5a241eff6e7a2d906"
+  integrity sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@graphql-tools/relay-operation-optimizer@^6.3.0", "@graphql-tools/relay-operation-optimizer@^6.5.0":
   version "6.5.18"
   resolved "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz#a1b74a8e0a5d0c795b8a4d19629b654cf66aa5ab"
@@ -6557,6 +6605,15 @@
   dependencies:
     "@ardatan/relay-compiler" "12.0.0"
     "@graphql-tools/utils" "^9.2.1"
+    tslib "^2.4.0"
+
+"@graphql-tools/relay-operation-optimizer@^7.1.1":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.2.tgz#5116f0d13b73a2231fd3a5adff9dc5db442e03ee"
+  integrity sha512-n/yNuj9aQVdk1bxHvnbqQdvZ5P3Ru8L7BoDlBGK9OXr2Q44XBhFIonqaxREqAWyMme5WnE+DjUswa5H70PQbRg==
+  dependencies:
+    "@ardatan/relay-compiler" "^13.0.1"
+    "@graphql-tools/utils" "^11.0.0"
     tslib "^2.4.0"
 
 "@graphql-tools/schema@^9.0.0":
@@ -6577,6 +6634,16 @@
     "@graphql-typed-document-node/core" "^3.1.1"
     cross-inspect "1.0.0"
     dset "^3.1.2"
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-11.0.0.tgz#f54a09372e96c32416fcbd0eb8e9e0f1338900bd"
+  integrity sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@whatwg-node/promise-helpers" "^1.0.0"
+    cross-inspect "1.0.1"
     tslib "^2.4.0"
 
 "@graphql-tools/utils@^6.0.18":
@@ -10028,6 +10095,13 @@
     fast-url-parser "^1.1.3"
     tslib "^2.3.1"
 
+"@whatwg-node/promise-helpers@^1.0.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz#3b54987ad6517ef6db5920c66a6f0dada606587d"
+  integrity sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==
+  dependencies:
+    tslib "^2.6.3"
+
 "@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
@@ -11690,6 +11764,13 @@ cross-inspect@1.0.0:
   dependencies:
     tslib "^2.4.0"
 
+cross-inspect@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cross-inspect/-/cross-inspect-1.0.1.tgz#15f6f65e4ca963cf4cc1a2b5fef18f6ca328712b"
+  integrity sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==
+  dependencies:
+    tslib "^2.4.0"
+
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -11881,6 +11962,11 @@ dependency-graph@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
+dependency-graph@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-1.0.0.tgz#bb5e85aec1310bc13b22dbd76e3196c4ee4c10d2"
+  integrity sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -13648,7 +13734,7 @@ immutable-tuple@^0.4.9:
   resolved "https://registry.npmjs.org/immutable-tuple/-/immutable-tuple-0.4.10.tgz#e0b1625384f514084a7a84b749a3bb26e9179929"
   integrity sha512-45jheDbc3Kr5Cw8EtDD+4woGRUV0utIrJBZT8XH0TPZRfm8tzT0/sLGGzyyCCFqFMG5Pv5Igf3WY/arn6+8V9Q==
 
-immutable@^4.3.8, immutable@~3.7.6:
+immutable@^4.3.8, immutable@^5.1.5, immutable@~3.7.6:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
   integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
@@ -15597,7 +15683,7 @@ no-case@^3.0.4:
 
 nock@13.3.0:
   version "13.3.0"
-  resolved "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
   integrity sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==
   dependencies:
     debug "^4.1.0"
@@ -17918,6 +18004,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
+tslib@^2.6.3:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@~2.0.1:
   version "2.0.3"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
@@ -17937,6 +18028,11 @@ tslib@~2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@~2.6.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Summary
Replaces the `relay-compiler@12` dependency chain in `@aws-amplify/appsync-modelgen-plugin`.

This addresses the `appsync-modelgen-plugin` subset of aws-amplify/amplify-backend#3062 and overlaps the broader fresh-install issue in aws-amplify/amplify-backend#3135.

## Changes
- Upgraded the package to the newer `@graphql-codegen/visitor-plugin-common` / `@graphql-codegen/plugin-helpers` / `@graphql-tools/utils` line that resolves `@graphql-tools/relay-operation-optimizer@7.1.2 -> @ardatan/relay-compiler@13.0.1`
- Adapted the package-owned scalar maps to the newer normalized scalar contract used by GraphQL Code Generator
- Updated visitor code to resolve scalar output types explicitly so generated Java, Dart, metadata, and model introspection output remain stable
- Made `codegenVersion` optional in `RawAppSyncModelConfig` to match existing package usage in tests and callers
- Added a minimal `Disposable` / `AsyncDisposable` ambient declaration for this package so it remains buildable under the repo's current TypeScript 4.7 floor while using newer `graphql-tools` type declarations

## Strategy
This chain is owned by `@aws-amplify/appsync-modelgen-plugin`, so a downstream-only fix in `amplify-backend` would not remove it.

The main migration work here was not the dependency bump itself. The newer GraphQL Code Generator packages normalize scalar mappings as `{ input, output }` objects instead of plain strings, so the package code had to be updated to use those mappings explicitly. Without that adaptation, generated output regressed and language-specific tests failed.

The `Disposable` compatibility declaration is a temporary build-floor bridge, not a runtime change. The repo still pins TypeScript `4.7.4`, while newer `graphql-tools` type declarations reference the standard `Disposable` globals introduced in later TypeScript lib definitions. This package does not use those contracts directly, so the ambient declaration keeps the package buildable until the repo's TypeScript floor moves forward.

## Verification
- `npx -y yarn@1.22.22 workspace @aws-amplify/appsync-modelgen-plugin build`
- `npx -y yarn@1.22.22 workspace @aws-amplify/appsync-modelgen-plugin test --runInBand`
- Fresh temp install with published `@aws-amplify/appsync-modelgen-plugin@2.15.2` showed:
  - `@graphql-codegen/visitor-plugin-common@1.22.0 -> @graphql-tools/relay-operation-optimizer@6.5.18 -> @ardatan/relay-compiler@12.0.0 -> glob@7.2.3 -> inflight@1.0.6`
  - deprecated `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-object-rest-spread`
- Fresh temp install with the local packed tarball showed:
  - `@graphql-tools/relay-operation-optimizer@7.1.2 -> @ardatan/relay-compiler@13.0.1`
  - no `glob@7`
  - no `inflight`
  - no deprecated Babel proposal plugin warnings during install
  - `0 vulnerabilities`

## Maintainer Context
This PR is the second narrow package-owned slice of the deprecated dependency chain tracked in aws-amplify/amplify-backend#3062.

The companion PR aws-amplify/amplify-codegen#1012 addresses the separate `@aws-amplify/graphql-types-generator` Babel 6 / `core-js@2` / `rimraf@3` path. Together, those two PRs cover the main `amplify-codegen`-owned subtrees from the current repro.

Downstream work is still required after release so `amplify-backend` can consume the published packages, and aws-amplify/amplify-backend#3135 remains broader than the codegen-owned surface.

## Maintainer Ask
If this approach looks acceptable, please review this as an independent `appsync-modelgen-plugin` fix. Once merged and released, downstream repos can consume the published package and re-measure the broader fresh-install impact.
