### PR TITLE
fix: remove interactive mwinit from cloud-pr.sh

### DIFF
--- a/scripts/cloud-pr.sh
+++ b/scripts/cloud-pr.sh
@@ -6,12 +6,6 @@ source $scriptDir/.env set
 printf 'What is your PR number ? '
 read PR_NUMBER
 
-if [[ -n $USE_FIDO_KEY ]] ; then
-  mwinit -s -f
-else
-  mwinit
-fi
-
 ada cred update --profile=AmplifyAPIE2EProd --account=$E2E_ACCOUNT_PROD --role=CodebuildDeveloper --provider=isengard --once
 RESULT=$(aws codebuild start-build-batch \
 --profile=AmplifyAPIE2EProd \


### PR DESCRIPTION
## Problem

`scripts/cloud-pr.sh` calls `mwinit` (or `mwinit -s -f` with FIDO key) which requires interactive OTP input. This blocks automation and CI workflows that rely on existing midway cookies.

## Solution

Remove the 6-line `if/else/fi` block that invokes `mwinit`. The script now goes straight to `ada cred update`, relying on an existing valid midway cookie — the same approach used by `cloud-e2e.sh` and `cloud-utils.sh`.

## Changes

- Removed the interactive mwinit block from `scripts/cloud-pr.sh`
- No other files modified

## Testing

- `bash -n scripts/cloud-pr.sh` passes (syntax validated)