### PR TITLE
chore: add e2e convenience tooling (cloud-e2e, e2e-monitor)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# Agent Guidelines for amplify-codegen
+
+## E2E Testing
+
+### Overview
+
+E2E tests run via AWS CodeBuild. The project uses a batch build that fans out into
+multiple test suites. All tests must pass (100%) before a PR can be merged.
+
+### Prerequisites
+
+1. Copy `scripts/sample.env` to `scripts/.env` and fill in the account IDs (get these from your team lead):
+   ```bash
+   cp scripts/sample.env scripts/.env
+   # Edit scripts/.env with your account values
+   ```
+
+2. Ensure you have valid credentials (`mwinit` or equivalent).
+
+### Triggering E2E Tests
+
+**For a PR:**
+```bash
+yarn cloud-pr
+# Interactive: prompts for PR number
+```
+
+**For the current branch:**
+```bash
+yarn cloud-e2e
+# Or directly:
+./scripts/cloud-e2e.sh
+```
+
+**For a specific PR (non-interactive):**
+```bash
+./scripts/cloud-e2e.sh pr/1035
+```
+
+### Monitoring E2E Tests
+
+After triggering, you'll get a batch ID like `amplify-codegen-e2e-workflow:abc123-...`.
+
+**Check status:**
+```bash
+yarn e2e-status <batchId>
+```
+
+**Monitor with auto-retry (polls every 5 min, retries transient failures):**
+```bash
+yarn e2e-monitor <batchId>
+# With custom max retries:
+yarn e2e-monitor <batchId> 5
+```
+
+**List recent batches:**
+```bash
+yarn e2e-list
+```
+
+**View failed builds:**
+```bash
+yarn e2e-failed <batchId>
+```
+
+**View build logs:**
+```bash
+yarn e2e-logs <buildId>
+```
+
+**Retry failed builds manually:**
+```bash
+yarn e2e-retry <batchId>
+```
+
+### Process
+
+1. **Trigger**: Run `yarn cloud-e2e` or `./scripts/cloud-e2e.sh pr/<number>`
+2. **Monitor**: Run `yarn e2e-monitor <batchId>` — this polls every 5 minutes and auto-retries transient failures
+3. **Verify**: 100% pass rate required. If failures persist after retries, investigate the logs with `yarn e2e-failed` and `yarn e2e-logs`
+4. **Retry**: For persistent transient failures, use `yarn e2e-retry <batchId>`
+
+### Important Notes
+
+- Account IDs and credentials go in `scripts/.env` (gitignored), **never** in committed code
+- The e2e profile is `AmplifyAPIE2EProd` with role `CodebuildDeveloper`
+- Tests run in `us-east-1`
+- Batch builds typically take 30-90 minutes depending on test count
+- The monitor command exits with code 0 on success, 1 on failure
+
+### Available CodeBuild Projects
+
+- `amplify-codegen-e2e-workflow` — Full e2e test suite (used by `cloud-e2e`)
+- `amplify-codegen-pr-workflow` — PR validation (used by `cloud-pr`)
+- `amplify-codegen-cleanup-workflow` — Stale resource cleanup
+
+### Debugging Failures
+
+1. Get failed builds: `yarn e2e-failed <batchId>`
+2. View logs: `yarn e2e-logs <buildId>`
+3. Re-run with debug session: `yarn cloud-e2e-debug <batchId>`
+4. Authenticate for manual AWS CLI use: `yarn authenticate-e2e-profile`

--- a/package.json
+++ b/package.json
@@ -49,7 +49,13 @@
     "authenticate-e2e-profile": "source scripts/cloud-utils.sh && authenticateWithE2EProfile",
     "extract-dependency-licenses": "./scripts/extract-dependency-licenses.sh",
     "verify-dependency-licenses-extract": "yarn extract-dependency-licenses && ./scripts/verify-dependency-licenses.sh",
-    "deprecate": "ts-node scripts/deprecate_release.ts"
+    "deprecate": "ts-node scripts/deprecate_release.ts",
+    "e2e-status": "yarn ts-node scripts/e2e-test-manager.ts status",
+    "e2e-monitor": "yarn ts-node scripts/e2e-test-manager.ts monitor",
+    "e2e-retry": "yarn ts-node scripts/e2e-test-manager.ts retry",
+    "e2e-list": "yarn ts-node scripts/e2e-test-manager.ts list",
+    "e2e-failed": "yarn ts-node scripts/e2e-test-manager.ts failed",
+    "e2e-logs": "yarn ts-node scripts/e2e-test-manager.ts logs"
   },
   "bugs": {
     "url": "https://github.com/aws-amplify/amplify-codegen/issues"
@@ -126,7 +132,8 @@
     "rimraf": "^3.0.0",
     "ts-jest": "^27.0.0",
     "ts-node": "^8.10.1",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "@aws-sdk/client-cloudwatch-logs": "^3.1080.0"
   },
   "resolutions": {
     "**/@aws-amplify/amplify-codegen-e2e-tests/**/cookie": "^0.7.0",

--- a/scripts/cloud-e2e.sh
+++ b/scripts/cloud-e2e.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+# Triggers the amplify-codegen e2e test suite on the current branch.
+#
+# Usage:
+#   ./scripts/cloud-e2e.sh              # Run e2e on current branch
+#   ./scripts/cloud-e2e.sh pr/1035      # Run e2e on a specific PR
+#
+# Prerequisites:
+#   - scripts/.env must exist with E2E_ACCOUNT_PROD set (see scripts/sample.env)
+#   - mwinit credentials must be active
+
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+source "$scriptDir/.env"
+
+if [ -z "$E2E_ACCOUNT_PROD" ]; then
+  echo "❌ E2E_ACCOUNT_PROD is not set. Please configure scripts/.env (see scripts/sample.env)"
+  exit 1
+fi
+
+REGION=us-east-1
+E2E_ROLE_NAME=CodebuildDeveloper
+E2E_PROFILE_NAME=AmplifyAPIE2EProd
+E2E_PROJECT_NAME=amplify-codegen-e2e-workflow
+
+# Determine source version
+if [ -n "$1" ]; then
+  SOURCE_VERSION="$1"
+else
+  SOURCE_VERSION=$(git branch --show-current)
+fi
+
+echo "🚀 Triggering E2E tests"
+echo "   Project: $E2E_PROJECT_NAME"
+echo "   Source:  $SOURCE_VERSION"
+echo ""
+
+# Authenticate
+echo "🔐 Authenticating..."
+ada cred update --profile="$E2E_PROFILE_NAME" --account="$E2E_ACCOUNT_PROD" --role="$E2E_ROLE_NAME" --provider=isengard --once
+aws configure set region $REGION --profile "$E2E_PROFILE_NAME"
+
+# Trigger the batch build
+RESULT=$(aws codebuild start-build-batch \
+  --profile="$E2E_PROFILE_NAME" \
+  --region "$REGION" \
+  --project-name "$E2E_PROJECT_NAME" \
+  --source-version="$SOURCE_VERSION" \
+  --environment-variables-override name=BRANCH_NAME,value="$SOURCE_VERSION",type=PLAINTEXT \
+  --query 'buildBatch.id' --output text)
+
+echo ""
+echo "✅ Build batch triggered!"
+echo "   Batch ID: $RESULT"
+echo ""
+echo "📋 Monitor with:"
+echo "   yarn e2e-monitor $RESULT"
+echo ""
+echo "🔗 Console URL:"
+echo "   https://$REGION.console.aws.amazon.com/codesuite/codebuild/$E2E_ACCOUNT_PROD/projects/$E2E_PROJECT_NAME/batch/$RESULT?region=$REGION"

--- a/scripts/e2e-test-manager.ts
+++ b/scripts/e2e-test-manager.ts
@@ -1,0 +1,445 @@
+#!/usr/bin/env ts-node
+
+/**
+ * E2E Test Management Script for amplify-codegen
+ *
+ * Usage:
+ *   yarn e2e-status <buildBatchId>         - Show batch status
+ *   yarn e2e-monitor <buildBatchId> [max]  - Monitor batch with auto-retry
+ *   yarn e2e-retry <buildBatchId>          - Retry failed builds
+ *   yarn e2e-list [limit]                  - List recent batches
+ *   yarn e2e-failed <buildBatchId>         - Show failed builds
+ *   yarn e2e-logs <buildId>               - Show build logs
+ *
+ * Prerequisites:
+ *   - scripts/.env must exist with E2E_ACCOUNT_PROD set
+ *   - Authenticate first: yarn authenticate-e2e-profile
+ */
+
+import {
+  CodeBuildClient,
+  BatchGetBuildBatchesCommand,
+  ListBuildBatchesCommand,
+  BatchGetBuildsCommand,
+} from '@aws-sdk/client-codebuild';
+import { CloudWatchLogsClient, GetLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs';
+import { fromIni } from '@aws-sdk/credential-providers';
+import * as process from 'process';
+import { execSync } from 'child_process';
+
+const E2E_PROFILE_NAME = 'AmplifyAPIE2EProd';
+const REGION = 'us-east-1';
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_MAX_RETRIES = 10;
+
+const credentials = fromIni({ profile: E2E_PROFILE_NAME });
+const codeBuild = new CodeBuildClient({ credentials, region: REGION });
+
+type BuildStatus = 'FAILED' | 'FAULT' | 'IN_PROGRESS' | 'STOPPED' | 'SUCCEEDED' | 'TIMED_OUT';
+
+interface BuildSummary {
+  identifier: string;
+  buildStatus: BuildStatus;
+  buildId?: string;
+}
+
+interface BatchStatus {
+  batchId: string;
+  batchStatus: string;
+  builds: BuildSummary[];
+  failedBuilds: BuildSummary[];
+  inProgressBuilds: BuildSummary[];
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const authenticate = () => {
+  try {
+    execSync(
+      'source ./scripts/.env && ada cred update --profile=AmplifyAPIE2EProd --account=$E2E_ACCOUNT_PROD --role=CodebuildDeveloper --provider=isengard --once',
+      { shell: '/bin/bash' },
+    );
+  } catch (error) {
+    console.warn('⚠️  Authentication failed. Make sure you have run mwinit and scripts/.env is configured.');
+  }
+};
+
+const getBatchStatus = async (batchId: string): Promise<BatchStatus> => {
+  const { buildBatches } = await codeBuild.send(new BatchGetBuildBatchesCommand({ ids: [batchId] }));
+
+  if (!buildBatches || buildBatches.length === 0) {
+    throw new Error(`Build batch ${batchId} not found`);
+  }
+
+  const batch = buildBatches[0];
+  const builds: BuildSummary[] = (batch.buildGroups || []).map((group) => ({
+    identifier: group.identifier || 'unknown',
+    buildStatus: (group.currentBuildSummary?.buildStatus as BuildStatus) || 'IN_PROGRESS',
+    buildId: group.currentBuildSummary?.arn?.split('/').pop(),
+  }));
+
+  const failedBuilds = builds.filter((b) => ['FAILED', 'FAULT', 'TIMED_OUT'].includes(b.buildStatus));
+  const inProgressBuilds = builds.filter((b) => b.buildStatus === 'IN_PROGRESS');
+
+  return {
+    batchId,
+    batchStatus: batch.buildBatchStatus || 'UNKNOWN',
+    builds,
+    failedBuilds,
+    inProgressBuilds,
+  };
+};
+
+const printStatus = (status: BatchStatus, compact: boolean = false): void => {
+  console.log(`\n=== Batch Status: ${status.batchId} ===`);
+  console.log(`Overall: ${status.batchStatus}`);
+  console.log(`Total Builds: ${status.builds.length}`);
+  console.log(`Succeeded: ${status.builds.filter((b) => b.buildStatus === 'SUCCEEDED').length}`);
+  console.log(`Failed: ${status.failedBuilds.length}`);
+  console.log(`In Progress: ${status.inProgressBuilds.length}`);
+
+  if (status.failedBuilds.length > 0) {
+    console.log('\n❌ Failed Builds:');
+    status.failedBuilds.forEach((build) => {
+      console.log(`  - ${build.identifier}: ${build.buildStatus}`);
+      if (build.buildId) {
+        console.log(`    Logs: yarn e2e-logs ${build.buildId}`);
+      }
+    });
+  }
+
+  if (status.inProgressBuilds.length > 0) {
+    console.log('\n🏃 In Progress:');
+    const displayCount = compact ? Math.min(5, status.inProgressBuilds.length) : status.inProgressBuilds.length;
+    status.inProgressBuilds.slice(0, displayCount).forEach((build) => {
+      console.log(`  - ${build.identifier}`);
+    });
+    if (compact && status.inProgressBuilds.length > 5) {
+      console.log(`  ... and ${status.inProgressBuilds.length - 5} more`);
+    }
+  }
+};
+
+const retryFailedBuilds = async (batchId: string): Promise<string | undefined> => {
+  const status = await getBatchStatus(batchId);
+  const failedBuildIds = status.failedBuilds.filter((build) => build.buildId).map((build) => build.buildId!);
+
+  if (failedBuildIds.length === 0) {
+    console.log('✅ No failed builds found to retry');
+    return undefined;
+  }
+
+  console.log(`Retrying ${failedBuildIds.length} failed builds...`);
+
+  try {
+    const result = execSync(
+      `aws codebuild retry-build-batch --region=${REGION} --profile=${E2E_PROFILE_NAME} --id="${batchId}"`,
+      { encoding: 'utf8', stdio: 'pipe' },
+    );
+
+    const output = JSON.parse(result);
+    const newBatchId = output.buildBatch?.id;
+
+    if (newBatchId) {
+      console.log(`✅ Retry triggered. Batch ID: ${newBatchId}`);
+      return newBatchId;
+    } else {
+      console.error('❌ Could not extract batch ID from retry response');
+      return undefined;
+    }
+  } catch (error: any) {
+    console.error(`❌ Failed to retry batch:`, error.message);
+    return undefined;
+  }
+};
+
+const listRecentBatches = async (limit: number = 20): Promise<void> => {
+  console.log(`🔍 Fetching ${limit} most recent build batches...`);
+
+  const result = await codeBuild.send(
+    new ListBuildBatchesCommand({
+      maxResults: Math.min(limit * 2, 100),
+      sortOrder: 'DESCENDING',
+    }),
+  );
+
+  if (!result.ids || result.ids.length === 0) {
+    console.log('No build batches found');
+    return;
+  }
+
+  const { buildBatches } = await codeBuild.send(
+    new BatchGetBuildBatchesCommand({ ids: result.ids.slice(0, limit) }),
+  );
+
+  if (!buildBatches || buildBatches.length === 0) {
+    console.log('No build batch details found');
+    return;
+  }
+
+  console.log(`\n=== Recent Build Batches ===`);
+  for (const batch of buildBatches) {
+    const startTime = batch.startTime ? new Date(batch.startTime).toLocaleString() : 'Unknown';
+    const batchStatus = batch.buildBatchStatus || 'Unknown';
+    const buildCount = batch.buildGroups?.length || 0;
+    const branch = batch.sourceVersion || 'Unknown';
+
+    console.log(`${batch.id}`);
+    console.log(`  Branch: ${branch}`);
+    console.log(`  Status: ${batchStatus}`);
+    console.log(`  Started: ${startTime}`);
+    console.log(`  Builds: ${buildCount}`);
+    console.log('');
+  }
+};
+
+const getFailedBuilds = async (batchId: string): Promise<void> => {
+  const status = await getBatchStatus(batchId);
+
+  console.log(`\n=== Failed Builds for Batch: ${batchId} ===`);
+
+  if (status.failedBuilds.length === 0) {
+    console.log('✅ No failed builds found');
+    return;
+  }
+
+  console.log(`❌ Found ${status.failedBuilds.length} failed builds:\n`);
+
+  for (const build of status.failedBuilds) {
+    console.log(`Build: ${build.identifier}`);
+    console.log(`  Status: ${build.buildStatus}`);
+    if (build.buildId) {
+      console.log(`  Build ID: ${build.buildId}`);
+      console.log(`  Logs: yarn e2e-logs ${build.buildId}`);
+    }
+    console.log('');
+  }
+};
+
+const getBuildLogs = async (buildId: string): Promise<void> => {
+  console.log(`📋 Fetching logs for build: ${buildId}`);
+
+  try {
+    const { builds } = await codeBuild.send(new BatchGetBuildsCommand({ ids: [buildId] }));
+
+    if (!builds || builds.length === 0) {
+      console.log('❌ Build not found');
+      return;
+    }
+
+    const build = builds[0];
+    const logGroup = build.logs?.groupName;
+    const logStream = build.logs?.streamName;
+
+    if (!logGroup || !logStream) {
+      console.log('❌ No logs available for this build');
+      return;
+    }
+
+    console.log(`\n=== Build Information ===`);
+    console.log(`Build ID: ${buildId}`);
+    console.log(`Status: ${build.buildStatus}`);
+    console.log(`Project: ${build.projectName}`);
+    console.log(`Log Group: ${logGroup}`);
+    console.log(`Log Stream: ${logStream}`);
+
+    const cloudWatchLogs = new CloudWatchLogsClient({
+      region: REGION,
+      credentials: fromIni({ profile: E2E_PROFILE_NAME }),
+    });
+
+    console.log(`\n=== Log Output ===`);
+
+    try {
+      let allEvents: any[] = [];
+      let nextToken: string | undefined;
+      let pageCount = 0;
+
+      do {
+        pageCount++;
+        const params: any = {
+          logGroupName: logGroup,
+          logStreamName: logStream,
+          startFromHead: true,
+          limit: 10000,
+        };
+
+        if (nextToken) {
+          params.nextToken = nextToken;
+        }
+
+        const response = await cloudWatchLogs.send(new GetLogEventsCommand(params));
+
+        if (response.events && response.events.length > 0) {
+          allEvents = allEvents.concat(response.events);
+        }
+
+        // Prevent infinite loops
+        if (nextToken === response.nextForwardToken) {
+          break;
+        }
+        nextToken = response.nextForwardToken;
+
+        if (pageCount > 100) {
+          console.log(`⚠️  Reached page limit, stopping pagination`);
+          break;
+        }
+      } while (nextToken);
+
+      console.log(`\n📊 Total log events: ${allEvents.length}\n`);
+
+      for (const event of allEvents) {
+        process.stdout.write(event.message || '');
+      }
+    } catch (error: any) {
+      console.log('❌ Could not fetch logs via SDK:', error.message);
+      console.log(`\nFallback command:`);
+      console.log(
+        `aws logs get-log-events --region=${REGION} --profile=${E2E_PROFILE_NAME} --log-group-name="${logGroup}" --log-stream-name="${logStream}" --limit=10000 --query="events[*].message" --output=text`,
+      );
+    }
+  } catch (error: any) {
+    console.error('❌ Error fetching build:', error.message);
+  }
+};
+
+const monitorBatch = async (batchId: string, maxRetries: number = DEFAULT_MAX_RETRIES): Promise<void> => {
+  let retryCount = 0;
+
+  console.log(`🔍 Monitoring batch: ${batchId}`);
+  console.log(`📊 Max retries: ${maxRetries}`);
+  console.log(`⏰ Poll interval: ${POLL_INTERVAL_MS / 1000 / 60} minutes\n`);
+
+  while (retryCount <= maxRetries) {
+    const status = await getBatchStatus(batchId);
+    console.log(`\n🔄 Check (retry ${retryCount}/${maxRetries}) @ ${new Date().toLocaleTimeString()}`);
+    printStatus(status, true);
+
+    // Check if batch is complete
+    if (!['IN_PROGRESS', 'SUBMITTED'].includes(status.batchStatus)) {
+      if (status.failedBuilds.length === 0) {
+        console.log('\n✅ All builds succeeded!');
+        return;
+      }
+
+      // High failure rate means something is fundamentally broken
+      const failureRate = status.failedBuilds.length / status.builds.length;
+      if (failureRate > 0.5) {
+        console.log(
+          `\n🚫 Failure rate too high (${(failureRate * 100).toFixed(1)}% - ${status.failedBuilds.length}/${status.builds.length})`,
+        );
+        console.log('Skipping retries - this likely requires investigation.');
+        process.exit(1);
+      }
+
+      if (retryCount >= maxRetries) {
+        console.log(`\n❌ Max retries (${maxRetries}) reached.`);
+        console.log(`Final failed builds: ${status.failedBuilds.length}`);
+        process.exit(1);
+      }
+
+      // Don't retry build/lint failures
+      const skipRetryJobs = ['build_linux', 'build_windows', 'test', 'lint'];
+      if (status.failedBuilds.length === 1 && skipRetryJobs.includes(status.failedBuilds[0].identifier)) {
+        console.log(`\n🚫 Skipping retry for ${status.failedBuilds[0].identifier} - not a transient failure.`);
+        process.exit(1);
+      }
+
+      console.log(`\n🔄 Retrying ${status.failedBuilds.length} failed builds (attempt ${retryCount + 1}/${maxRetries})`);
+
+      try {
+        await retryFailedBuilds(batchId);
+        retryCount++;
+      } catch (error) {
+        console.error('Failed to retry builds:', error);
+        process.exit(1);
+      }
+    }
+
+    console.log(`\n⏳ Waiting ${POLL_INTERVAL_MS / 1000 / 60} minutes...`);
+    await sleep(POLL_INTERVAL_MS);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const [command, arg1, arg2] = process.argv.slice(2);
+
+  if (!command) {
+    console.error('E2E Test Manager for amplify-codegen\n');
+    console.error('Usage: yarn ts-node scripts/e2e-test-manager.ts <command> [args...]\n');
+    console.error('Commands:');
+    console.error('  status <batchId>            - Show batch status');
+    console.error('  monitor <batchId> [retries] - Monitor with auto-retry (default: 10 retries)');
+    console.error('  retry <batchId>             - Retry failed builds');
+    console.error('  list [limit]                - List recent batches (default: 20)');
+    console.error('  failed <batchId>            - Show failed builds with log commands');
+    console.error('  logs <buildId>              - Show build logs');
+    console.error('\nExamples:');
+    console.error('  yarn e2e-status amplify-codegen-e2e-workflow:abc123');
+    console.error('  yarn e2e-monitor amplify-codegen-e2e-workflow:abc123');
+    console.error('  yarn e2e-monitor amplify-codegen-e2e-workflow:abc123 5');
+    process.exit(1);
+  }
+
+  // Authenticate before running commands
+  authenticate();
+
+  try {
+    switch (command) {
+      case 'status':
+        if (!arg1) {
+          console.error('Error: batchId required');
+          process.exit(1);
+        }
+        printStatus(await getBatchStatus(arg1));
+        break;
+
+      case 'monitor':
+        if (!arg1) {
+          console.error('Error: batchId required');
+          process.exit(1);
+        }
+        await monitorBatch(arg1, arg2 ? parseInt(arg2, 10) : DEFAULT_MAX_RETRIES);
+        break;
+
+      case 'retry':
+        if (!arg1) {
+          console.error('Error: batchId required');
+          process.exit(1);
+        }
+        await retryFailedBuilds(arg1);
+        break;
+
+      case 'list':
+        await listRecentBatches(arg1 ? parseInt(arg1, 10) : 20);
+        break;
+
+      case 'failed':
+        if (!arg1) {
+          console.error('Error: batchId required');
+          process.exit(1);
+        }
+        await getFailedBuilds(arg1);
+        break;
+
+      case 'logs':
+        if (!arg1) {
+          console.error('Error: buildId required');
+          process.exit(1);
+        }
+        await getBuildLogs(arg1);
+        break;
+
+      default:
+        console.error(`Unknown command: ${command}`);
+        process.exit(1);
+    }
+  } catch (error: any) {
+    console.error('Error:', error.message || error);
+    process.exit(1);
+  }
+};
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/scripts/sample.env
+++ b/scripts/sample.env
@@ -1,3 +1,10 @@
+# E2E test configuration for amplify-codegen
+# Copy this file to scripts/.env and fill in the values.
+# scripts/.env is gitignored and must NEVER be committed.
+#
+# Get account IDs from your team lead or internal wiki.
+# Get credentials with: ada cred update --profile=AmplifyAPIE2EProd --account=$E2E_ACCOUNT_PROD --role=CodebuildDeveloper --provider=isengard --once
+
 E2E_ACCOUNT_BETA=
 E2E_ACCOUNT_PROD=
 RELEASE_ACCOUNT_PROD=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,20 @@
     "@aws-sdk/util-utf8-node" "3.6.1"
     tslib "^2.0.0"
 
+"@aws-sdk/client-cloudwatch-logs@^3.1080.0":
+  version "3.1080.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1080.0.tgz#0f194c3ba56bff9375fdd7b34d45da6345d0fcfd"
+  integrity sha512-qH7dSHyMgdxLmDV2bfMGvXHei5x5tSPNZKWqYGlB6DUOKqoSWCO2i40lXR/bZ/3htFRFFKDkxEGabN1PTT2a/A==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/credential-provider-node" "^3.972.63"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/fetch-http-handler" "^5.6.2"
+    "@smithy/node-http-handler" "^4.9.2"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/client-cloudwatch-logs@^3.996.0":
   version "3.1000.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1000.0.tgz#0db7a86a7d264b1a6d711be3d7a4f7316b94fc30"
@@ -3271,6 +3285,20 @@
     "@smithy/util-utf8" "^4.2.1"
     tslib "^2.6.2"
 
+"@aws-sdk/core@^3.974.28":
+  version "3.974.28"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.28.tgz#5fc0140062ef69868bc8e0549f6d0a7e48956823"
+  integrity sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.15"
+    "@aws-sdk/xml-builder" "^3.972.33"
+    "@aws/lambda-invoke-store" "^0.3.0"
+    "@smithy/core" "^3.29.0"
+    "@smithy/signature-v4" "^5.6.1"
+    "@smithy/types" "^4.15.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/crc64-nvme@^3.972.3":
   version "3.972.3"
   resolved "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.3.tgz#cb005d9d4b53e0ad6a9e2f2ddf153d9f1df12da8"
@@ -3360,6 +3388,17 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-env@^3.972.54":
+  version "3.972.54"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.54.tgz#710d272b2c78c2cea68f9c4db707e77450db8eef"
+  integrity sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-http@3.568.0":
   version "3.568.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.568.0.tgz#7f7239bed7c23db7356ebeae5f3b3bda9f751b08"
@@ -3389,6 +3428,19 @@
     "@smithy/smithy-client" "^4.12.0"
     "@smithy/types" "^4.13.0"
     "@smithy/util-stream" "^4.5.15"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.56":
+  version "3.972.56"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.56.tgz#0c6f55c2b83a0fb81385cb9f600d4c953568daa4"
+  integrity sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/fetch-http-handler" "^5.6.2"
+    "@smithy/node-http-handler" "^4.9.2"
+    "@smithy/types" "^4.15.1"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-imds@3.186.0":
@@ -3503,6 +3555,25 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-ini@^3.972.61":
+  version "3.972.61"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.61.tgz#2870286fac970cd963e57513a4aeda995c576800"
+  integrity sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/credential-provider-env" "^3.972.54"
+    "@aws-sdk/credential-provider-http" "^3.972.56"
+    "@aws-sdk/credential-provider-login" "^3.972.60"
+    "@aws-sdk/credential-provider-process" "^3.972.54"
+    "@aws-sdk/credential-provider-sso" "^3.972.60"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.60"
+    "@aws-sdk/nested-clients" "^3.997.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/credential-provider-imds" "^4.4.5"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-login@^3.972.13":
   version "3.972.13"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.13.tgz#75e6541db1977cd1e95a2c4a37593038cfdd583e"
@@ -3515,6 +3586,18 @@
     "@smithy/protocol-http" "^5.3.10"
     "@smithy/shared-ini-file-loader" "^4.4.5"
     "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.60":
+  version "3.972.60"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.60.tgz#8a630e376ada044d61d654f0ac5068930fd315f6"
+  integrity sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/nested-clients" "^3.997.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-node@3.186.0":
@@ -3617,6 +3700,23 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@^3.972.63":
+  version "3.972.63"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.63.tgz#e11257cc890ffebba25c0e6ad4a82b03b452286b"
+  integrity sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.54"
+    "@aws-sdk/credential-provider-http" "^3.972.56"
+    "@aws-sdk/credential-provider-ini" "^3.972.61"
+    "@aws-sdk/credential-provider-process" "^3.972.54"
+    "@aws-sdk/credential-provider-sso" "^3.972.60"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.60"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/credential-provider-imds" "^4.4.5"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.186.0":
   version "3.186.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz#e3be60983261a58c212f5c38b6fb76305bbb8ce7"
@@ -3683,6 +3783,17 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-process@^3.972.54":
+  version "3.972.54"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.54.tgz#d70b569eb4400f1b6dbecfc176f4219fe65d4196"
+  integrity sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-sso@3.186.0":
   version "3.186.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz#e1aa466543b3b0877d45b885a1c11b329232df22"
@@ -3747,6 +3858,19 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@^3.972.60":
+  version "3.972.60"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.60.tgz#d28e2ed1f3d75e25f30b72b7a54363b527f2847e"
+  integrity sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/nested-clients" "^3.997.28"
+    "@aws-sdk/token-providers" "3.1080.0"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@3.186.0":
   version "3.186.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz#db43f37f7827b553490dd865dbaa9a2c45f95494"
@@ -3797,6 +3921,18 @@
     "@smithy/property-provider" "^4.2.10"
     "@smithy/shared-ini-file-loader" "^4.4.5"
     "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.60":
+  version "3.972.60"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.60.tgz#c71d80bb8ec00dfb9b515b0e9bb090fa7e186a3e"
+  integrity sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/nested-clients" "^3.997.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-providers@^3.465.0":
@@ -4743,6 +4879,20 @@
     "@smithy/util-utf8" "^4.2.1"
     tslib "^2.6.2"
 
+"@aws-sdk/nested-clients@^3.997.28":
+  version "3.997.28"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.28.tgz#0da0c2fb2be85bdbd1b2e12a9f69aa0457981278"
+  integrity sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.38"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/fetch-http-handler" "^5.6.2"
+    "@smithy/node-http-handler" "^4.9.2"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/node-config-provider@3.186.0":
   version "3.186.0"
   resolved "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz#64259429d39f2ef5a76663162bf2e8db6032a322"
@@ -4957,6 +5107,16 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/signature-v4-multi-region@^3.996.38":
+  version "3.996.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz#8e603b2a916499f573b537e13860b074950bd29b"
+  integrity sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==
+  dependencies:
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/signature-v4" "^5.6.1"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/signature-v4@3.186.0":
   version "3.186.0"
   resolved "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz#bbd56e71af95548abaeec6307ea1dfe7bd26b4e4"
@@ -4997,6 +5157,18 @@
     "@aws-sdk/middleware-stack" "3.6.1"
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
+
+"@aws-sdk/token-providers@3.1080.0":
+  version "3.1080.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1080.0.tgz#1c1f2b022691c877762bbda63dcec82acb3a46a0"
+  integrity sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.28"
+    "@aws-sdk/nested-clients" "^3.997.28"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
 
 "@aws-sdk/token-providers@3.438.0":
   version "3.438.0"
@@ -5141,6 +5313,14 @@
   version "3.6.1"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz#00686db69e998b521fcd4a5f81ef0960980f80c4"
   integrity sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==
+
+"@aws-sdk/types@^3.973.15":
+  version "3.973.15"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.15.tgz#98a4860bed33c32c7088924d0ab52f9eabbdf7c3"
+  integrity sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
 
 "@aws-sdk/types@^3.973.4":
   version "3.973.4"
@@ -5569,6 +5749,14 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/xml-builder@^3.972.33":
+  version "3.972.33"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz#5cf4c5c74003382ff14928199a6745d4f3201eef"
+  integrity sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@aws-sdk/xml-builder@^3.972.8":
   version "3.972.8"
   resolved "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.8.tgz#b7025b442d9f4d190a94556de6aa62dabd53651c"
@@ -5582,6 +5770,11 @@
   version "0.2.3"
   resolved "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz#f1137f56209ccc69c15f826242cbf37f828617dd"
   integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
+
+"@aws/lambda-invoke-store@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz#708802d987f8e17bdf4af4de1031660ce1cdd65f"
+  integrity sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -8203,6 +8396,14 @@
     "@smithy/uuid" "^1.1.1"
     tslib "^2.6.2"
 
+"@smithy/core@^3.29.0", "@smithy/core@^3.29.1":
+  version "3.29.1"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.29.1.tgz#4f900e19fd80fe9c771ae892b1c84c323845ce21"
+  integrity sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@smithy/credential-provider-imds@^2.0.0", "@smithy/credential-provider-imds@^2.1.4":
   version "2.1.4"
   resolved "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.4.tgz#126adf69eac333f23f8683edbfabdc2b3b2deb15"
@@ -8234,6 +8435,15 @@
     "@smithy/property-provider" "^4.2.10"
     "@smithy/types" "^4.13.0"
     "@smithy/url-parser" "^4.2.10"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.4.5":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz#048ad961282016fc2d46d457f43beac8ca8f0e24"
+  integrity sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==
+  dependencies:
+    "@smithy/core" "^3.29.1"
+    "@smithy/types" "^4.15.1"
     tslib "^2.6.2"
 
 "@smithy/eventstream-codec@^2.0.15":
@@ -8402,6 +8612,15 @@
     "@smithy/querystring-builder" "^4.2.10"
     "@smithy/types" "^4.13.0"
     "@smithy/util-base64" "^4.3.1"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.6.2":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz#7b4aec28f89bd1e3aa00dfae0d0bd30079c58341"
+  integrity sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==
+  dependencies:
+    "@smithy/core" "^3.29.1"
+    "@smithy/types" "^4.15.1"
     tslib "^2.6.2"
 
 "@smithy/hash-blob-browser@^2.0.16":
@@ -8814,6 +9033,15 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@smithy/node-http-handler@^4.9.2":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz#f464b7f4ac242e8d6642dd8a602078bc88b0c53d"
+  integrity sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==
+  dependencies:
+    "@smithy/core" "^3.29.1"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@smithy/property-provider@^2.0.0", "@smithy/property-provider@^2.0.16":
   version "2.0.16"
   resolved "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.16.tgz#0c15ea8a3e8c8e7012bf5877c79ce754f7d2c06e"
@@ -9015,6 +9243,15 @@
     "@smithy/util-utf8" "^4.2.1"
     tslib "^2.6.2"
 
+"@smithy/signature-v4@^5.6.1":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.6.2.tgz#a07e352e0d66149f5e70caf6d3161845ec86062f"
+  integrity sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==
+  dependencies:
+    "@smithy/core" "^3.29.1"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
 "@smithy/smithy-client@^2.1.12", "@smithy/smithy-client@^2.5.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz#0fd2efff09dc65500d260e590f7541f8a387eae3"
@@ -9082,6 +9319,13 @@
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.0.tgz#72fb6fd315f2eff7d4878142db2d1db4ef94f9bc"
   integrity sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/types@^4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.15.1.tgz#cdad0fdf4c5d1f5788dc21a3f1fb6af523d79da0"
+  integrity sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==
   dependencies:
     tslib "^2.6.2"
 
@@ -14757,12 +15001,20 @@ js-yaml@3.14.1, js-yaml@^3.13.1, js-yaml@^3.14.2:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@4.1.0, js-yaml@^3.10.0, js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
+js-yaml@4.1.0, js-yaml@^4.0.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
+
+js-yaml@^3.10.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsdom@^16.6.0:
   version "16.7.0"


### PR DESCRIPTION
## Summary

Adds e2e test management tooling to amplify-codegen, bringing it in line with amplify-cli and amplify-category-api.

## What's Added

### Scripts
- **`scripts/e2e-test-manager.ts`** — TypeScript-based e2e management tool with commands:
  - `status` — Show batch build status
  - `monitor` — Poll with auto-retry of transient failures (5-min intervals)
  - `retry` — Retry failed builds
  - `list` — List recent build batches
  - `failed` — Show failed builds with log commands
  - `logs` — View CloudWatch logs for a specific build

- **`scripts/cloud-e2e.sh`** — Standalone script to trigger e2e batch builds (supports `pr/<number>` argument)

### Yarn Scripts
```
yarn e2e-status <batchId>
yarn e2e-monitor <batchId> [maxRetries]
yarn e2e-retry <batchId>
yarn e2e-list [limit]
yarn e2e-failed <batchId>
yarn e2e-logs <buildId>
```

### Documentation
- **`AGENTS.md`** — Comprehensive guide for running and monitoring e2e tests
- Updated **`scripts/sample.env`** with setup documentation

## Design

Modeled after amplify-cli's `e2e-test-manager.ts` pattern. Uses the existing `@aws-sdk/client-codebuild` dependency and `AmplifyAPIE2EProd` profile convention from `cloud-utils.sh`.

No account IDs or secrets in committed files — all sensitive values come from `scripts/.env` (gitignored).

## Testing

- TypeScript compilation verified (`tsc --noEmit`)
- No secrets or account IDs in committed files (grep verified)